### PR TITLE
Add 22F1 and 22F3 to HVAC FAN device class

### DIFF
--- a/ramses_rf/protocol/ramses.py
+++ b/ramses_rf/protocol/ramses.py
@@ -977,7 +977,7 @@ _DEV_KLASSES_HVAC: dict[str, dict] = {
         Code._313F: {I_: {}, RP: {}},
         Code._31D9: {I_: {}, RP: {}},
         Code._31DA: {I_: {}, RP: {}},
-        # Code._31E0: {I_: {}},
+        Code._31E0: {I_: {}},
     },
     DEV_TYPE.CO2: {
         Code._042F: {I_: {}},

--- a/ramses_rf/protocol/ramses.py
+++ b/ramses_rf/protocol/ramses.py
@@ -969,6 +969,8 @@ _DEV_KLASSES_HVAC: dict[str, dict] = {
         Code._1470: {RP: {}},
         Code._1F09: {I_: {}, RP: {}},
         Code._1FC9: {W_: {}},
+        Code._22F1: {I_: {}},
+        Code._22F3: {I_: {}},
         Code._22F7: {I_: {}, RP: {}},
         Code._2411: {I_: {}, RP: {}},
         Code._3120: {I_: {}},


### PR DESCRIPTION
An Orcon RF15 display can send 22F1 and 22F3 commands to HRC Fan unit,
which can relay these commands to a SmartComfort valve.
Hence FAN devices can send 22F1 and 22F3.