### PR TITLE
31DA stretch assert range for auto night mode

### DIFF
--- a/ramses_rf/protocol/parsers.py
+++ b/ramses_rf/protocol/parsers.py
@@ -2106,7 +2106,7 @@ def parser_31da(payload, msg) -> dict:
         # assert payload[30:34] in ("0002", "F000", "F800", "F808", "7FFF"), payload[30:34]
         # assert payload[34:36] == "EF", payload[34:36]
         assert (
-            payload[36:38] == "EF" or int(payload[36:38], 16) & 0x1F <= 0x18
+            payload[36:38] == "EF" or int(payload[36:38], 16) & 0x1F <= 0x19
         ), f"invalid _31DA_FAN_INFO: {payload[36:38]}"
         assert int(payload[38:40], 16) <= 200 or payload[38:40] in (
             "EF",

--- a/ramses_rf/protocol/ramses.py
+++ b/ramses_rf/protocol/ramses.py
@@ -1325,7 +1325,7 @@ _31DA_FAN_INFO: dict[int, str] = {
     0x16: "absolute minimum",  # trickle?
     0x17: "absolute maximum",  # boost?
     0x18: "auto",
-    0x19: "auto night",  # autonight?
+    0x19: "auto night",
     0x1A: "-unknown 0x1A-",
     0x1B: "-unknown 0x1B-",
     0x1C: "-unknown 0x1C-",


### PR DESCRIPTION
When HRU is in auto mode (18):
```
2022-08-22 22:54:54.569 WARNING (MainThread) [ramses_rf.protocol.transport] RP --- 18:126620 37:154011 --:------ 31DA 029 00C84002CDEFEF08BF08F0087508A14808C81800FF0000EFEF13A613A6 < There appears to be more than one HGI80-compatible device (active gateway: 18:200467), this is unsupported, configure the known_list/block_list as required
```

When HRU is in night mode (19):
```
2022-08-22 23:05:44.310 WARNING (MainThread) [ramses_rf.protocol.transport]  I --- 18:126620 --:------ 18:126620 31DA 029 00C84002B9EFEF08AB08BF0875089A4808C8193AFF0000EFEF3BBA3BBA < There appears to be more than one HGI80-compatible device (active gateway: 18:200467), this is unsupported, configure the known_list/block_list as required
2022-08-22 23:05:44.314 WARNING (MainThread) [ramses_rf.protocol.parsers]    I --- 18:126620 --:------ 18:126620 31DA 029 00C84002B9EFEF08AB08BF0875089A4808C8193AFF0000EFEF3BBA3BBA < Support the development of ramses_rf by reporting this packet (invalid _31DA_FAN_INFO: 19)
```
I can confirm that _31DA_FAN_INFO: 19 is night mode for my Itho HRU ECO300 system.