### PR TITLE
Convert signed integers

### DIFF
--- a/ramses_rf/protocol/helpers.py
+++ b/ramses_rf/protocol/helpers.py
@@ -104,13 +104,20 @@ def date_from_hex(value: str) -> Optional[str]:  # YY-MM-DD
 
 
 @typechecked
-def double_from_hex(value: str, factor: int = 1) -> Optional[float]:
+def double_from_hex(value: str, factor: int = 1, neg_factor: int = None) -> Optional[float]:
     """Convert a 4-char hex string into a double."""
     if not isinstance(value, str) or len(value) != 4:
         raise ValueError(f"Invalid value: {value}, is not a 4-char hex string")
     if value == "7FFF":
         return None
-    return (-(int(value, 16) & 0x8000) | (int(value, 16) & 0x7fff)) / factor
+    s16 = int(value, 16)
+    if s16 >= 32767:
+        # two's complement negative number
+        if neg_factor is not None:
+            # use different factor for negative numbers
+            factor = neg_factor
+        return ( -(s16 & 0x8000) | (s16 & 0x7fff) ) / factor
+    return s16 / factor
 
 
 @typechecked

--- a/ramses_rf/protocol/helpers.py
+++ b/ramses_rf/protocol/helpers.py
@@ -110,7 +110,7 @@ def double_from_hex(value: str, factor: int = 1) -> Optional[float]:
         raise ValueError(f"Invalid value: {value}, is not a 4-char hex string")
     if value == "7FFF":
         return None
-    return int(value, 16) / factor
+    return (-(int(value, 16) & 0x8000) | (int(value, 16) & 0x7fff)) / factor
 
 
 @typechecked

--- a/ramses_rf/protocol/parsers.py
+++ b/ramses_rf/protocol/parsers.py
@@ -2171,10 +2171,10 @@ def parser_31da(payload, msg) -> dict:
         SZ_CO2_LEVEL: double_from_hex(payload[6:10]),  # ppm, 1298[2:6]
         SZ_INDOOR_HUMIDITY: percent_from_hex(payload[10:12], high_res=False),  # 12A0?
         SZ_OUTDOOR_HUMIDITY: percent_from_hex(payload[12:14], high_res=False),
-        SZ_EXHAUST_TEMPERATURE: double_from_hex(payload[14:18], factor=100),
-        SZ_SUPPLY_TEMPERATURE: double_from_hex(payload[18:22], factor=100),
-        SZ_INDOOR_TEMPERATURE: double_from_hex(payload[22:26], factor=100),
-        SZ_OUTDOOR_TEMPERATURE: double_from_hex(payload[26:30], factor=100),  # 1290?
+        SZ_EXHAUST_TEMPERATURE: double_from_hex(payload[14:18], factor=100, neg_factor=10),
+        SZ_SUPPLY_TEMPERATURE: double_from_hex(payload[18:22], factor=100, neg_factor=10),
+        SZ_INDOOR_TEMPERATURE: double_from_hex(payload[22:26], factor=100, neg_factor=10),
+        SZ_OUTDOOR_TEMPERATURE: double_from_hex(payload[26:30], factor=100, neg_factor=10),  # 1290?
         SZ_SPEED_CAP: int(payload[30:34], 16),
         SZ_BYPASS_POSITION: percent_from_hex(payload[34:36]),
         SZ_SUPPLY_FAN_SPEED: percent_from_hex(payload[40:42]),


### PR DESCRIPTION
Today the outside temperature went below zero:
`2022-11-20T08:32:06.904058 063 RP --- 32:134446 37:171685 --:------ 31DA 030 00EF007FFF2F1B0226069A07EEFFE4F8000038988F0000EFEF1F2420FC00
 `

Temperature `FEE4` should be -2.8 degrees.

two's complement signed integers to negative values

EDIT: DO NOT MERGE. There is a bug (factor 10) this results in -0.28 degrees. Obviously this needs a unit test.