### PR TITLE
bugfix: 31DA not using two's complement for negative temperatures

### DIFF
--- a/ramses_rf/protocol/parsers.py
+++ b/ramses_rf/protocol/parsers.py
@@ -2171,10 +2171,10 @@ def parser_31da(payload, msg) -> dict:
         SZ_CO2_LEVEL: double_from_hex(payload[6:10]),  # ppm, 1298[2:6]
         SZ_INDOOR_HUMIDITY: percent_from_hex(payload[10:12], high_res=False),  # 12A0?
         SZ_OUTDOOR_HUMIDITY: percent_from_hex(payload[12:14], high_res=False),
-        SZ_EXHAUST_TEMPERATURE: double_from_hex(payload[14:18], factor=100),
-        SZ_SUPPLY_TEMPERATURE: double_from_hex(payload[18:22], factor=100),
-        SZ_INDOOR_TEMPERATURE: double_from_hex(payload[22:26], factor=100),
-        SZ_OUTDOOR_TEMPERATURE: double_from_hex(payload[26:30], factor=100),  # 1290?
+        SZ_EXHAUST_TEMPERATURE: temp_from_hex(payload[14:18]),
+        SZ_SUPPLY_TEMPERATURE: temp_from_hex(payload[18:22]),
+        SZ_INDOOR_TEMPERATURE: temp_from_hex(payload[22:26]),
+        SZ_OUTDOOR_TEMPERATURE: temp_from_hex(payload[26:30]),  # 1290?
         SZ_SPEED_CAP: int(payload[30:34], 16),
         SZ_BYPASS_POSITION: percent_from_hex(payload[34:36]),
         SZ_SUPPLY_FAN_SPEED: percent_from_hex(payload[40:42]),


### PR DESCRIPTION
```
2022-11-20T08:32:06.904058 063 RP --- 32:134446 37:171685 --:------ 31DA 030 00EF007FFF2F1B0226069A07EEFFE4F8000038988F0000EFEF1F2420FC00
````

The above payload parses like so: `'outdoor_temperature': 655.08`. However, temperatures such as `FEE4` should be -0.28 °C.

The solution is to use `temp_from_hex('FEE4')` instead of `double_from_hex(...)`.

The Fan is an Orcon HRC 425

[edited by dev]