### PR TITLE
3110 mode_demand

### DIFF
--- a/ramses_rf/protocol/parsers.py
+++ b/ramses_rf/protocol/parsers.py
@@ -1993,7 +1993,7 @@ def parser_30c9(payload, msg) -> dict:
     return {SZ_TEMPERATURE: temp_from_hex(payload[2:])}
 
 
-@parser_decorator  # unknown_3110, HVAC
+@parser_decorator  # mode, demand. Itho autotemp / spider
 def parser_3110(payload, msg) -> dict:
     # .I --- 02:250708 --:------ 02:250708 3110 004 0000C820
     # .I --- 21:042656 --:------ 21:042656 3110 004 00000020
@@ -2005,10 +2005,16 @@ def parser_3110(payload, msg) -> dict:
     except AssertionError as exc:
         _LOGGER.warning(f"{msg!r} < {_INFORM_DEV_MSG} ({exc})")
 
+    bitmask = (payload[6:8], 16)
+    mode = {
+        0x00: "disabled",
+        0x10: "heating",
+        0x20: "cooling",
+    }.get(bitmask & 0x30, "unknown")
+
     return {
-        f"_{SZ_UNKNOWN}_1": payload[2:4],
-        "_percent_2": percent_from_hex(payload[4:6]),
-        "_value_3": payload[6:],
+        "mode": mode,
+        "demand": percent_from_hex(payload[4:6]),
     }
 
 

--- a/ramses_rf/protocol/ramses.py
+++ b/ramses_rf/protocol/ramses.py
@@ -520,7 +520,7 @@ CODES_SCHEMA: dict[Code, dict] = {  # rf_unknown
         EXPIRES: td(hours=1),
     },
     Code._3110: {  # unknown_3110 - HVAC
-        SZ_NAME: "message_3110",
+        SZ_NAME: "mode_demand",
         I_: r"^00",
     },
     Code._3120: {  # unknown_3120 - Error Report?


### PR DESCRIPTION
3110 message: Mode (heating/cooling) and (heat_)demand

A full days packet log (last saturday had units heating and cooling):
https://www.dropbox.com/s/e4daw9ql8pje6ed/packet.log.2023-03-19?dl=0
`02:250704` is my master autotemp: it was heating
`02:250708` is my neighbours master autotemp: cooling, then heating
`21:xxxxxx` are spider room thermostats.