### PR TITLE
Refactor protocol/transport

### DIFF
--- a/src/ramses_rf/binding_fsm.py
+++ b/src/ramses_rf/binding_fsm.py
@@ -80,7 +80,7 @@ _RATIFY_WAIT_TIME: Final[float] = (
 BINDING_QOS = QosParams(
     max_retries=SENDING_RETRY_LIMIT,
     timeout=WAITING_TIMEOUT_SECS * 2,
-    wait_for_reply=True,
+    wait_for_reply=False,
 )
 
 
@@ -274,7 +274,7 @@ class BindContextRespondent(BindContextBase):
         """Resp sends an Accept on the basis of a rcvd Offer & returns the Confirm."""
 
         cmd = Command.put_bind(W_, self._dev.id, codes, dst_id=tender.src.id, idx=idx)
-        if DEV_MODE:
+        if DEV_MODE:  # TODO: should be in test suite
             assert Message._from_cmd(cmd).payload["phase"] == BindPhase.ACCEPT
 
         pkt: Packet = await self._dev._async_send_cmd(  # Tx accept/accept
@@ -356,7 +356,7 @@ class BindContextSupplicant(BindContextBase):
         cmd = Command.put_bind(
             I_, self._dev.id, codes, dst_id=self._dev.id, oem_code=oem_code
         )
-        if DEV_MODE:
+        if DEV_MODE:  # TODO: should be in test suite
             assert Message._from_cmd(cmd).payload["phase"] == BindPhase.TENDER
 
         pkt: Packet = await self._dev._async_send_cmd(  # Tx tender/offer
@@ -382,7 +382,7 @@ class BindContextSupplicant(BindContextBase):
         cmd = Command.put_bind(
             I_, self._dev.id, confirm_code, dst_id=accept.src.id, idx=idx
         )
-        if DEV_MODE:
+        if DEV_MODE:  # TODO: should be in test suite
             assert Message._from_cmd(cmd).payload["phase"] == BindPhase.AFFIRM
 
         pkt: Packet = await self._dev._async_send_cmd(  # Tx affirm/confirm

--- a/src/ramses_rf/gateway.py
+++ b/src/ramses_rf/gateway.py
@@ -278,14 +278,17 @@ class Gateway(Engine):
         if _clear_state:  # only intended for test suite use
             clear_state()
 
-        tmp_protocol = protocol_factory(self._msg_handler, disable_sending=True)
+        tmp_protocol = protocol_factory(
+            self._msg_handler,
+            disable_sending=True,
+            enforce_include_list=self._enforce_known_list,
+            exclude_list=self._exclude,
+            include_list=self._include,
+        )
 
         tmp_transport = await transport_factory(
             tmp_protocol,
             packet_dict=packets,
-            enforce_include_list=self._enforce_known_list,
-            exclude_list=self._exclude,
-            include_list=self._include,
         )
 
         await tmp_transport.get_extra_info(tmp_transport.READER_TASK)

--- a/src/ramses_rf/gateway.py
+++ b/src/ramses_rf/gateway.py
@@ -37,7 +37,7 @@ from ramses_tx.const import (
     DEFAULT_GAP_DURATION,
     DEFAULT_MAX_RETRIES,
     DEFAULT_NUM_REPEATS,
-    DEFAULT_TIMEOUT,
+    DEFAULT_SEND_TIMEOUT,
     SZ_ACTIVE_HGI,
 )
 from ramses_tx.schemas import (
@@ -552,7 +552,7 @@ class Gateway(Engine):
         max_retries: int = DEFAULT_MAX_RETRIES,
         num_repeats: int = DEFAULT_NUM_REPEATS,
         priority: Priority = Priority.DEFAULT,
-        timeout: float = DEFAULT_TIMEOUT,
+        timeout: float = DEFAULT_SEND_TIMEOUT,
         wait_for_reply: bool | None = None,
         **kwargs: Any,
     ) -> Packet | None:

--- a/src/ramses_rf/version.py
+++ b/src/ramses_rf/version.py
@@ -1,4 +1,4 @@
 """RAMSES RF - a RAMSES-II protocol decoder & analyser (application layer)."""
 
-__version__ = "0.31.13"
+__version__ = "0.31.14"
 VERSION = __version__

--- a/src/ramses_rf/version.py
+++ b/src/ramses_rf/version.py
@@ -1,4 +1,4 @@
 """RAMSES RF - a RAMSES-II protocol decoder & analyser (application layer)."""
 
-__version__ = "0.31.12"
+__version__ = "0.31.13"
 VERSION = __version__

--- a/src/ramses_rf/version.py
+++ b/src/ramses_rf/version.py
@@ -1,4 +1,4 @@
 """RAMSES RF - a RAMSES-II protocol decoder & analyser (application layer)."""
 
-__version__ = "0.31.11"
+__version__ = "0.31.12"
 VERSION = __version__

--- a/src/ramses_tx/__init__.py
+++ b/src/ramses_tx/__init__.py
@@ -24,7 +24,6 @@ from .message import Message  # noqa: F401
 from .packet import PKT_LOGGER, Packet  # noqa: F401
 from .protocol import (  # noqa: F401, pylint: disable=unused-import
     PortProtocol,
-    QosProtocol,
     ReadProtocol,
     protocol_factory,
 )

--- a/src/ramses_tx/const.py
+++ b/src/ramses_tx/const.py
@@ -13,18 +13,20 @@ from typing import Final, Literal
 __dev_mode__ = False  # NOTE: this is const.py
 DEV_MODE = __dev_mode__
 
-# used by transport...
-SZ_ACTIVE_HGI: Final = "active_gwy"
-SZ_SIGNATURE: Final = "signature"
-SZ_IS_EVOFW3: Final = "is_evofw3"
+# used by protocol QoS FSM (echo tout is 0.50 for MQTT)...
+DEFAULT_ECHO_TIMEOUT: Final[float] = 0.504  # waiting for echo pkt after cmd sent
+DEFAULT_RPLY_TIMEOUT: Final[float] = 0.20  # waiting for reply pkt after echo pkt rcvd
+DEFAULT_BUFFER_SIZE: Final[int] = 32
 
-# used by protocol QoS...
-MINIMUM_GAP_DURATION: Final[float] = 0.02  # seconds
+DEFAULT_SEND_TIMEOUT: Final[float] = 30.0  # total waiting for successful send: FIXME
+MAX_SEND_TIMEOUT: Final[float] = 30.0  # for a command to be sent, incl. queuing time
 
-DEFAULT_GAP_DURATION: Final[float] = MINIMUM_GAP_DURATION
+MAX_RETRY_LIMIT: Final[int] = 3  # for a command to be re-sent (not incl. 1st send)
+
+MINIMUM_WRITE_GAP: Final[float] = 0.02  # seconds
+DEFAULT_GAP_DURATION: Final[float] = MINIMUM_WRITE_GAP
 DEFAULT_MAX_RETRIES: Final[int] = 3
 DEFAULT_NUM_REPEATS: Final[int] = 1
-DEFAULT_TIMEOUT: Final[float] = 30.0  # total waiting for successful send: FIXME
 
 SZ_QOS: Final = "qos"
 
@@ -34,6 +36,15 @@ SZ_MAX_RETRIES: Final = "max_retries"
 SZ_NUM_REPEATS: Final = "num_repeats"
 SZ_PRIORITY: Final = "priority"
 SZ_TIMEOUT: Final = "timeout"
+
+
+# used by transport...
+SZ_ACTIVE_HGI: Final = "active_gwy"
+SZ_SIGNATURE: Final = "signature"
+SZ_IS_EVOFW3: Final = "is_evofw3"
+
+MAX_DUTY_CYCLE_RATE = 0.01  # % bandwidth used per cycle (default 60 secs)
+DUTY_CYCLE_DURATION = 60  # # seconds
 
 
 # used by schedule.py...

--- a/src/ramses_tx/const.py
+++ b/src/ramses_tx/const.py
@@ -16,7 +16,6 @@ DEV_MODE = __dev_mode__
 # used by transport...
 SZ_ACTIVE_HGI: Final = "active_gwy"
 SZ_SIGNATURE: Final = "signature"
-SZ_KNOWN_HGI: Final = "known_hgi"
 SZ_IS_EVOFW3: Final = "is_evofw3"
 
 # used by protocol QoS...

--- a/src/ramses_tx/const.py
+++ b/src/ramses_tx/const.py
@@ -14,7 +14,7 @@ __dev_mode__ = False  # NOTE: this is const.py
 DEV_MODE = __dev_mode__
 
 # used by protocol QoS FSM (echo tout is 0.50 for MQTT)...
-DEFAULT_ECHO_TIMEOUT: Final[float] = 0.504  # waiting for echo pkt after cmd sent
+DEFAULT_ECHO_TIMEOUT: Final[float] = 0.50  # waiting for echo pkt after cmd sent
 DEFAULT_RPLY_TIMEOUT: Final[float] = 0.20  # waiting for reply pkt after echo pkt rcvd
 DEFAULT_BUFFER_SIZE: Final[int] = 32
 

--- a/src/ramses_tx/const.py
+++ b/src/ramses_tx/const.py
@@ -22,12 +22,9 @@ SZ_IS_EVOFW3: Final = "is_evofw3"
 MINIMUM_GAP_DURATION: Final[float] = 0.02  # seconds
 
 DEFAULT_GAP_DURATION: Final[float] = MINIMUM_GAP_DURATION
+DEFAULT_MAX_RETRIES: Final[int] = 3
 DEFAULT_NUM_REPEATS: Final[int] = 1
 DEFAULT_TIMEOUT: Final[float] = 30.0  # total waiting for successful send: FIXME
-
-DEFAULT_MAX_RETRIES: Final[int] = 3
-DEFAULT_ECHO_TIMEOUT: Final[float] = 0.04  # waiting for echo pkt after cmd sent
-DEFAULT_RPLY_TIMEOUT: Final[float] = 0.20  # waiting for reply pkt after echo pkt rcvd
 
 SZ_QOS: Final = "qos"
 

--- a/src/ramses_tx/frame.py
+++ b/src/ramses_tx/frame.py
@@ -166,6 +166,11 @@ class Frame:
         except AttributeError as err:
             return f"{self!r} < {err}"
 
+    def __eq__(self, other) -> bool:
+        if not hasattr(other, "_frame"):
+            return NotImplemented
+        return self._frame[4:] == other._frame[4:]  # type: ignore[no-any-return]
+
     @property
     def _has_array(self) -> None | bool:  # TODO: a mess - has false negatives
         """Return the True if the payload is an array, False otherwise.

--- a/src/ramses_tx/gateway.py
+++ b/src/ramses_tx/gateway.py
@@ -154,6 +154,7 @@ class Engine:
             enforce_include_list=self._enforce_known_list,
             exclude_list=self._exclude,
             include_list=self._include,
+            **self._kwargs,  # HACK: odd/misc params
         )
 
     def add_msg_handler(
@@ -195,7 +196,7 @@ class Engine:
             disable_sending=self._disable_sending,
             loop=self._loop,
             **pkt_source,
-            **self._kwargs,  # HACK: only accept disable_qos, extra & one other
+            **self._kwargs,  # HACK: odd/misc params
         )
 
         self._kwargs = {}  # HACK

--- a/src/ramses_tx/gateway.py
+++ b/src/ramses_tx/gateway.py
@@ -151,6 +151,9 @@ class Engine:
             msg_handler,
             disable_sending=self._disable_sending,
             disable_qos=self._kwargs.get(SZ_DISABLE_QOS, False),
+            enforce_include_list=self._enforce_known_list,
+            exclude_list=self._exclude,
+            include_list=self._include,
         )
 
     def add_msg_handler(
@@ -190,9 +193,9 @@ class Engine:
         self._transport = await transport_factory(
             self._protocol,
             disable_sending=self._disable_sending,
-            enforce_include_list=self._enforce_known_list,
-            exclude_list=self._exclude,
-            include_list=self._include,
+            enforce_include_list=self._enforce_known_list,  # FIXME: remove
+            exclude_list=self._exclude,  # FIXME: remove
+            include_list=self._include,  # FIXME: remove
             loop=self._loop,
             **pkt_source,
             **self._kwargs,  # HACK: only accept disable_qos, extra & one other

--- a/src/ramses_tx/gateway.py
+++ b/src/ramses_tx/gateway.py
@@ -195,7 +195,7 @@ class Engine:
             disable_sending=self._disable_sending,
             loop=self._loop,
             **pkt_source,
-            **self._kwargs,  # HACK: only accept disable_qos, extra & one other
+            **self._kwargs,  # HACK: odd/misc params
         )
 
         self._kwargs = {}  # HACK

--- a/src/ramses_tx/gateway.py
+++ b/src/ramses_tx/gateway.py
@@ -27,7 +27,7 @@ from .const import (
     DEFAULT_GAP_DURATION,
     DEFAULT_MAX_RETRIES,
     DEFAULT_NUM_REPEATS,
-    DEFAULT_TIMEOUT,
+    DEFAULT_SEND_TIMEOUT,
     Priority,
 )
 from .message import Message
@@ -307,7 +307,7 @@ class Engine:
         max_retries: int = DEFAULT_MAX_RETRIES,
         num_repeats: int = DEFAULT_NUM_REPEATS,
         priority: Priority = Priority.DEFAULT,
-        timeout: float = DEFAULT_TIMEOUT,
+        timeout: float = DEFAULT_SEND_TIMEOUT,
         wait_for_reply: bool | None = None,
     ) -> Packet | None:
         """Send a Command and, if QoS is enabled, return the corresponding Packet.

--- a/src/ramses_tx/gateway.py
+++ b/src/ramses_tx/gateway.py
@@ -193,9 +193,6 @@ class Engine:
         self._transport = await transport_factory(
             self._protocol,
             disable_sending=self._disable_sending,
-            enforce_include_list=self._enforce_known_list,  # FIXME: remove
-            exclude_list=self._exclude,  # FIXME: remove
-            include_list=self._include,  # FIXME: remove
             loop=self._loop,
             **pkt_source,
             **self._kwargs,  # HACK: only accept disable_qos, extra & one other

--- a/src/ramses_tx/gateway.py
+++ b/src/ramses_tx/gateway.py
@@ -154,7 +154,7 @@ class Engine:
             enforce_include_list=self._enforce_known_list,
             exclude_list=self._exclude,
             include_list=self._include,
-            **self._kwargs,  # HACK: odd/misc params
+            # **self._kwargs,  # HACK: odd/misc params
         )
 
     def add_msg_handler(

--- a/src/ramses_tx/packet.py
+++ b/src/ramses_tx/packet.py
@@ -113,11 +113,6 @@ class Packet(Frame):
     def dtm(self) -> dt:
         return self._dtm
 
-    def __eq__(self, other) -> bool:
-        if not hasattr(other, "_frame"):
-            return NotImplemented
-        return self._frame[4:] == other._frame[4:]  # type: ignore[no-any-return]
-
     @staticmethod
     def _partition(pkt_line: str) -> tuple[str, str, str]:  # map[str]
         """Partition a packet line into its three parts.

--- a/src/ramses_tx/protocol.py
+++ b/src/ramses_tx/protocol.py
@@ -309,7 +309,7 @@ class _BaseProtocol(asyncio.Protocol):
 
     async def _send_frame(self, frame: str) -> None:  # _send_frame() -> transport
         """Write some bytes to the transport."""
-        self._transport.write_frame(frame)
+        await self._transport.write_frame(frame)
 
     def pkt_received(self, pkt: Packet) -> None:
         """A wrapper for self._pkt_received(pkt)."""

--- a/src/ramses_tx/protocol.py
+++ b/src/ramses_tx/protocol.py
@@ -17,6 +17,7 @@ from .command import Command
 from .const import (
     DEFAULT_GAP_DURATION,
     DEFAULT_NUM_REPEATS,
+    DEV_TYPE_MAP,
     SZ_ACTIVE_HGI,
     SZ_IS_EVOFW3,
     DevType,
@@ -332,58 +333,58 @@ class _DeviceIdFilterMixin(_BaseProtocol):
 
         return known_hgis[0]
 
-    # def _is_wanted_addrs(
-    #     self, src_id: DeviceIdT, dst_id: DeviceIdT, sending: bool = False
-    # ) -> bool:
-    #     """Return True if the packet is not to be filtered out.
+    def _is_wanted_addrs(
+        self, src_id: DeviceIdT, dst_id: DeviceIdT, sending: bool = False
+    ) -> bool:
+        """Return True if the packet is not to be filtered out.
 
-    #     In any one packet, an excluded device_id 'trumps' an included device_id.
+        In any one packet, an excluded device_id 'trumps' an included device_id.
 
-    #     There are two ways to set the Active Gateway (HGI80/evofw3):
-    #     - by signature (evofw3 only), when frame -> packet
-    #     - by known_list (HGI80/evofw3), when filtering packets
-    #     """
+        There are two ways to set the Active Gateway (HGI80/evofw3):
+        - by signature (evofw3 only), when frame -> packet
+        - by known_list (HGI80/evofw3), when filtering packets
+        """
 
-    #     def warn_foreign_hgi(dev_id: DeviceIdT) -> None:
-    #         current_date = dt.now().date()
+        def warn_foreign_hgi(dev_id: DeviceIdT) -> None:
+            current_date = dt.now().date()
 
-    #         if self._foreign_last_run != current_date:
-    #             self._foreign_last_run = current_date
-    #             self._foreign_gwys_lst = []  # reset the list every 24h
+            if self._foreign_last_run != current_date:
+                self._foreign_last_run = current_date
+                self._foreign_gwys_lst = []  # reset the list every 24h
 
-    #         if dev_id in self._foreign_gwys_lst:
-    #             return
+            if dev_id in self._foreign_gwys_lst:
+                return
 
-    #         _LOGGER.warning(
-    #             f"Device {dev_id} is potentially a Foreign gateway, "
-    #             f"the Active gateway is {self._active_hgi}, "
-    #             f"alternatively, is it a HVAC device?{TIP}"
-    #         )
-    #         self._foreign_gwys_lst.append(dev_id)
+            _LOGGER.warning(
+                f"Device {dev_id} is potentially a Foreign gateway, "
+                f"the Active gateway is {self._active_hgi}, "
+                f"alternatively, is it a HVAC device?{TIP}"
+            )
+            self._foreign_gwys_lst.append(dev_id)
 
-    #     for dev_id in dict.fromkeys((src_id, dst_id)):  # removes duplicates
-    #         if dev_id in self._exclude:  # problems if incl. active gateway
-    #             return False
+        for dev_id in dict.fromkeys((src_id, dst_id)):  # removes duplicates
+            if dev_id in self._exclude:  # problems if incl. active gateway
+                return False
 
-    #         if dev_id == self._active_hgi:  # is active gwy
-    #             continue  # consider: return True
+            if dev_id == self._active_hgi:  # is active gwy
+                continue  # consider: return True
 
-    #         if dev_id in self._include:  # incl. 63:262142 & --:------
-    #             continue
+            if dev_id in self._include:  # incl. 63:262142 & --:------
+                continue
 
-    #         if sending and dev_id == HGI_DEV_ADDR.id:
-    #             continue
+            if sending and dev_id == HGI_DEV_ADDR.id:
+                continue
 
-    #         if self.enforce_include:
-    #             return False
+            if self.enforce_include:
+                return False
 
-    #         if dev_id[:2] != DEV_TYPE_MAP.HGI:
-    #             continue
+            if dev_id[:2] != DEV_TYPE_MAP.HGI:
+                continue
 
-    #         if self._active_hgi:  # this 18: is not in known_list
-    #             warn_foreign_hgi(dev_id)
+            if self._active_hgi:  # this 18: is not in known_list
+                warn_foreign_hgi(dev_id)
 
-    #     return True
+        return True
 
     def pkt_received(self, pkt: Packet) -> None:
         #     if not self._is_wanted_addrs(pkt.src.id, pkt.dst.id):

--- a/src/ramses_tx/protocol.py
+++ b/src/ramses_tx/protocol.py
@@ -708,6 +708,7 @@ def protocol_factory(
     enforce_include_list: bool = False,
     exclude_list: dict[DeviceIdT, dict] | None = None,
     include_list: dict[DeviceIdT, dict] | None = None,
+    **kwargs,  # HACK: odd/misc params
 ) -> RamsesProtocolT:
     """Create and return a Ramses-specific async packet Protocol."""
 

--- a/src/ramses_tx/protocol.py
+++ b/src/ramses_tx/protocol.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 import asyncio
 import logging
 from collections.abc import Callable
-from datetime import datetime as dt
+from datetime import datetime as dt, timedelta as td
 from typing import TYPE_CHECKING, Final
 
 from . import exceptions as exc
@@ -28,7 +28,7 @@ from .message import Message
 from .packet import Packet
 from .protocol_fsm import ProtocolContext
 from .schemas import SZ_BLOCK_LIST, SZ_CLASS, SZ_KNOWN_LIST, SZ_PORT_NAME
-from .transport import transport_factory
+from .transport import MqttTransport, transport_factory
 from .typing import ExceptionT, MsgFilterT, MsgHandlerT, QosParams
 
 from .const import (  # noqa: F401, isort: skip, pylint: disable=unused-import
@@ -573,6 +573,9 @@ class QosProtocol(PortProtocol):
 
         if not ramses:
             return
+
+        if isinstance(transport, MqttTransport):  # HACK: need to move FSM to transport
+            self._context.echo_timeout = td(seconds=0.5)
 
         super().connection_made(transport, ramses=ramses)
         self._context.connection_made(transport)

--- a/src/ramses_tx/protocol.py
+++ b/src/ramses_tx/protocol.py
@@ -412,7 +412,7 @@ class _DeviceIdFilterMixin(_BaseProtocol):
 
     def pkt_received(self, pkt: Packet) -> None:
         if not self._is_wanted_addrs(pkt.src.id, pkt.dst.id):
-            raise exc.ProtocolError(f"Packet excluded by device_id filter: {pkt}")
+            _LOGGER.debug("%s < Packet excluded by device_id filter", pkt)
         super().pkt_received(pkt)
 
     async def send_cmd(self, cmd: Command, *args, **kwargs) -> Packet | None:

--- a/src/ramses_tx/protocol.py
+++ b/src/ramses_tx/protocol.py
@@ -54,7 +54,6 @@ _DBG_DISABLE_QOS: Final[bool] = False
 _DBG_FORCE_LOG_PACKETS: Final[bool] = False
 
 
-# send_cmd(), _send_cmd(), _send_frame()
 class _BaseProtocol(asyncio.Protocol):
     """Base class for RAMSES II protocols."""
 

--- a/src/ramses_tx/protocol.py
+++ b/src/ramses_tx/protocol.py
@@ -9,7 +9,7 @@ import asyncio
 import logging
 from collections.abc import Callable
 from datetime import datetime as dt
-from typing import TYPE_CHECKING, Final
+from typing import TYPE_CHECKING, Final, TypeAlias
 
 from . import exceptions as exc
 from .address import ALL_DEV_ADDR, HGI_DEV_ADDR, NON_DEV_ADDR
@@ -655,7 +655,7 @@ class PortProtocol(_DeviceIdFilterMixin, _BaseProtocol):
         )
 
 
-RamsesProtocolT = PortProtocol | ReadProtocol
+RamsesProtocolT: TypeAlias = PortProtocol | ReadProtocol
 
 
 def protocol_factory(

--- a/src/ramses_tx/protocol.py
+++ b/src/ramses_tx/protocol.py
@@ -333,6 +333,31 @@ class _DeviceIdFilterMixin(_BaseProtocol):
 
         return known_hgis[0]
 
+    def _set_active_hgi(self, dev_id: DeviceIdT, by_signature: bool = False) -> None:
+        """Set the Active Gateway (HGI) device_if.
+
+        Send a warning if the include list is configured incorrectly.
+        """
+
+        assert self._active_hgi is None  # should only be called once
+
+        msg = f"The active gateway {dev_id}: {{ class: HGI }} "
+        msg += "(by signature)" if by_signature else "(by filter)"
+
+        if dev_id not in self._exclude:
+            self._active_hgi = dev_id
+            # else: setting self._active_hgi will not help
+
+        if dev_id in self._exclude:
+            _LOGGER.error(f"{msg} MUST NOT be in the {SZ_BLOCK_LIST}{TIP}")
+        elif dev_id in self._include:
+            pass
+        elif self.enforce_include:
+            _LOGGER.warning(f"{msg} SHOULD be in the (enforced) {SZ_KNOWN_LIST}")
+            # self._include.append(dev_id)  # a good idea?
+        else:
+            _LOGGER.warning(f"{msg} SHOULD be in the {SZ_KNOWN_LIST}")
+
     def _is_wanted_addrs(
         self, src_id: DeviceIdT, dst_id: DeviceIdT, sending: bool = False
     ) -> bool:

--- a/src/ramses_tx/protocol.py
+++ b/src/ramses_tx/protocol.py
@@ -252,8 +252,6 @@ class _BaseProtocol(asyncio.Protocol):
 class _DeviceIdFilterMixin(_BaseProtocol):
     """Filter out any unwanted (but otherwise valid) packets via device ids."""
 
-    pass
-
     def __init__(
         self,
         msg_handler: MsgHandlerT,

--- a/src/ramses_tx/protocol.py
+++ b/src/ramses_tx/protocol.py
@@ -630,7 +630,7 @@ class QosProtocol(PortProtocol):
             """
 
             await self._send_frame(
-                str(cmd), num_repeats=num_repeats, gap_duration=gap_duration
+                str(kmd), num_repeats=num_repeats, gap_duration=gap_duration
             )
 
         # if cmd.code == Code._PUZZ:  # NOTE: not as simple as this

--- a/src/ramses_tx/protocol.py
+++ b/src/ramses_tx/protocol.py
@@ -309,7 +309,7 @@ class _BaseProtocol(asyncio.Protocol):
 
     async def _send_frame(self, frame: str) -> None:  # _send_frame() -> transport
         """Write some bytes to the transport."""
-        self._transport.send_frame(frame)
+        self._transport.write_frame(frame)
 
     def pkt_received(self, pkt: Packet) -> None:
         """A wrapper for self._pkt_received(pkt)."""

--- a/src/ramses_tx/protocol.py
+++ b/src/ramses_tx/protocol.py
@@ -412,13 +412,13 @@ class _DeviceIdFilterMixin(_BaseProtocol):
         return True
 
     def pkt_received(self, pkt: Packet) -> None:
-        #     if not self._is_wanted_addrs(pkt.src.id, pkt.dst.id):
-        #         raise exc.TransportError(f"Packet excluded by device_id filter: {pkt}")
+        if not self._is_wanted_addrs(pkt.src.id, pkt.dst.id):
+            raise exc.ProtocolError(f"Packet excluded by device_id filter: {pkt}")
         super().pkt_received(pkt)
 
     async def send_cmd(self, cmd: Command, *args, **kwargs) -> Packet | None:
-        # if not self._is_wanted_addrs(cmd.src.id, cmd.dst.id, sending=True):
-        #     raise exc.TransportError(f"Command excluded by device_id filter: {cmd}")
+        if not self._is_wanted_addrs(cmd.src.id, cmd.dst.id, sending=True):
+            raise exc.ProtocolError(f"Command excluded by device_id filter: {cmd}")
         return await super().send_cmd(cmd, *args, **kwargs)
 
 

--- a/src/ramses_tx/protocol.py
+++ b/src/ramses_tx/protocol.py
@@ -391,7 +391,7 @@ class _DeviceIdFilterMixin(_BaseProtocol):
                 return False
 
             if dev_id == self._active_hgi:  # is active gwy
-                continue  # consider: return True
+                continue  # consider: return True (but what if corrupted dst.id?)
 
             if dev_id in self._include:  # incl. 63:262142 & --:------
                 continue
@@ -413,6 +413,7 @@ class _DeviceIdFilterMixin(_BaseProtocol):
     def pkt_received(self, pkt: Packet) -> None:
         if not self._is_wanted_addrs(pkt.src.id, pkt.dst.id):
             _LOGGER.debug("%s < Packet excluded by device_id filter", pkt)
+            return
         super().pkt_received(pkt)
 
     async def send_cmd(self, cmd: Command, *args, **kwargs) -> Packet | None:

--- a/src/ramses_tx/protocol.py
+++ b/src/ramses_tx/protocol.py
@@ -270,7 +270,7 @@ class _DeviceIdFilterMixin(_BaseProtocol):
         self._include = list(include_list.keys())
         self._include += [ALL_DEV_ADDR.id, NON_DEV_ADDR.id]
 
-        self._active_hgi = None  # FIXME
+        self._active_hgi: DeviceIdT | None = None
         self._known_hgi = self._extract_known_hgi(include_list)
 
         self._foreign_gwys_lst: list[DeviceIdT] = []

--- a/src/ramses_tx/protocol.py
+++ b/src/ramses_tx/protocol.py
@@ -629,8 +629,6 @@ class QosProtocol(PortProtocol):
             Repeats are distinct from retries (a QoS feature): you wouldn't have both.
             """
 
-            assert kmd and kmd is cmd, kmd  # maybe the FSM is confused
-
             await self._send_frame(
                 str(cmd), num_repeats=num_repeats, gap_duration=gap_duration
             )

--- a/src/ramses_tx/protocol.py
+++ b/src/ramses_tx/protocol.py
@@ -334,7 +334,7 @@ class _DeviceIdFilterMixin(_BaseProtocol):
         return known_hgis[0]
 
     def _set_active_hgi(self, dev_id: DeviceIdT, by_signature: bool = False) -> None:
-        """Set the Active Gateway (HGI) device_if.
+        """Set the Active Gateway (HGI) device_id.
 
         Send a warning if the include list is configured incorrectly.
         """
@@ -485,6 +485,7 @@ class PortProtocol(_DeviceIdFilterMixin, _BaseProtocol):
         super().connection_made(transport)
         # TODO: needed? self.resume_writing()
 
+        self._set_active_hgi(self._transport.get_extra_info(SZ_ACTIVE_HGI))
         self._is_evofw3 = self._transport.get_extra_info(SZ_IS_EVOFW3)
 
     def connection_lost(self, err: ExceptionT | None) -> None:  # type: ignore[override]

--- a/src/ramses_tx/protocol_fsm.py
+++ b/src/ramses_tx/protocol_fsm.py
@@ -14,7 +14,16 @@ from typing import TYPE_CHECKING, Any, Final, TypeAlias
 from . import exceptions as exc
 from .address import HGI_DEVICE_ID
 from .command import Command
-from .const import MINIMUM_GAP_DURATION, Code, Priority
+from .const import (
+    DEFAULT_BUFFER_SIZE,
+    DEFAULT_ECHO_TIMEOUT,
+    DEFAULT_RPLY_TIMEOUT,
+    MAX_RETRY_LIMIT,
+    MAX_SEND_TIMEOUT,
+    MINIMUM_WRITE_GAP,
+    Code,
+    Priority,
+)
 from .packet import Packet
 from .typing import ExceptionT, QosParams
 
@@ -29,18 +38,6 @@ _LOGGER = logging.getLogger(__name__)
 _DBG_MAINTAIN_STATE_CHAIN: Final[bool] = False  # maintain Context._prev_state
 _DBG_USE_STRICT_TRANSITIONS: Final[bool] = False
 
-# echo timeout:
-#  - 0.50 for MQTT
-#  - 0.04 for serial (too low?)
-
-DEFAULT_ECHO_TIMEOUT: Final[float] = 0.04  # waiting for echo pkt after cmd sent
-DEFAULT_RPLY_TIMEOUT: Final[float] = 0.20  # waiting for reply pkt after echo pkt rcvd
-MAX_BUFFER_SIZE: Final[int] = 32
-
-MAX_SEND_TIMEOUT: Final[float] = 30.0  # for a command to be sent, incl. queuing time
-MAX_RETRY_LIMIT: Final[int] = 3  # for a command to be re-sent (not incl. 1st send)
-
-
 #######################################################################################
 
 
@@ -52,16 +49,16 @@ class ProtocolContext:
         *,
         echo_timeout: float = DEFAULT_ECHO_TIMEOUT,
         reply_timeout: float = DEFAULT_RPLY_TIMEOUT,
-        min_gap_duration: float = MINIMUM_GAP_DURATION,
+        min_gap_duration: float = MINIMUM_WRITE_GAP,
         max_retry_limit: int = MAX_RETRY_LIMIT,
-        max_buffer_size: int = MAX_BUFFER_SIZE,
+        max_buffer_size: int = DEFAULT_BUFFER_SIZE,
     ) -> None:
         self._protocol = protocol
         self.echo_timeout = echo_timeout
         self.reply_timeout = reply_timeout
         self.min_gap_duration = td(seconds=min_gap_duration)
         self.max_retry_limit = min(max_retry_limit, MAX_RETRY_LIMIT)
-        self.max_buffer_size = min(max_buffer_size, MAX_BUFFER_SIZE)
+        self.max_buffer_size = min(max_buffer_size, DEFAULT_BUFFER_SIZE)
 
         self._loop = protocol._loop
         self._fut: asyncio.Future | None = None

--- a/src/ramses_tx/protocol_fsm.py
+++ b/src/ramses_tx/protocol_fsm.py
@@ -503,6 +503,7 @@ class WantRply(ProtocolStateBase):
 
 
 _ProtocolStateT: TypeAlias = Inactive | IsInIdle | WantEcho | WantRply
+
 _ProtocolStateClassT: TypeAlias = (
     type[Inactive] | type[IsInIdle] | type[WantEcho] | type[WantRply]
 )

--- a/src/ramses_tx/protocol_fsm.py
+++ b/src/ramses_tx/protocol_fsm.py
@@ -37,7 +37,7 @@ DEFAULT_ECHO_TIMEOUT: Final[float] = 0.04  # waiting for echo pkt after cmd sent
 DEFAULT_RPLY_TIMEOUT: Final[float] = 0.20  # waiting for reply pkt after echo pkt rcvd
 MAX_BUFFER_SIZE: Final[int] = 32
 
-MAX_SEND_TIMEOUT: Final[float] = 30.0  # for a command to be sent, incl. retries, etc.
+MAX_SEND_TIMEOUT: Final[float] = 30.0  # for a command to be sent, incl. queuing time
 MAX_RETRY_LIMIT: Final[int] = 3  # for a command to be re-sent (not incl. 1st send)
 
 
@@ -230,7 +230,7 @@ class ProtocolContext:
         if isinstance(self._state, IsInIdle):
             self._loop.call_soon_threadsafe(self._check_buffer_for_cmd)
 
-        timeout = min(qos.timeout, MAX_SEND_TIMEOUT)
+        timeout = min(qos.timeout, MAX_SEND_TIMEOUT)  # incl. time queued in buffer
         try:
             await asyncio.wait_for(fut, timeout=timeout)
         except TimeoutError as err:  # incl. fut.cancel()

--- a/src/ramses_tx/protocol_fsm.py
+++ b/src/ramses_tx/protocol_fsm.py
@@ -1,9 +1,5 @@
 #!/usr/bin/env python3
-# -*- coding: utf-8 -*-
 #
-
-# TODO: set dt_sent after self._que.get, not before self._que.put?
-
 """RAMSES RF - RAMSES-II compatible packet protocol finite state machine."""
 
 from __future__ import annotations
@@ -13,39 +9,36 @@ import logging
 from collections.abc import Callable, Coroutine
 from datetime import datetime as dt, timedelta as td
 from queue import Empty, Full, PriorityQueue
-from threading import Lock
-from typing import TYPE_CHECKING, Any, Final
+from typing import TYPE_CHECKING, Any, Final, TypeAlias, TypeVar
 
 from . import exceptions as exc
-from .address import HGI_DEV_ADDR
 from .command import Command
-from .const import MINIMUM_GAP_DURATION, SZ_ACTIVE_HGI, Priority
+from .const import MINIMUM_GAP_DURATION, Code, Priority
 from .packet import Packet
 from .typing import ExceptionT, QosParams
 
-from .const import (  # noqa: F401, isort: skip, pylint: disable=unused-import
-    I_,
-    RP,
-    RQ,
-    W_,
-    Code,
-)
-
 if TYPE_CHECKING:
+    # these would be circular imports
     from .protocol import RamsesProtocolT
     from .transport import RamsesTransportT
+
+ProtocolStateBase = TypeVar("ProtocolStateBase")
 
 _LOGGER = logging.getLogger(__name__)
 
 # All debug flags should be False for end-users
-_DBG_MAINTAIN_STATE_CHAIN = False  # maintain Context._prev_state
+_DBG_MAINTAIN_STATE_CHAIN: Final[bool] = False  # maintain Context._prev_state
+_DBG_USE_STRICT_TRANSITIONS: Final[bool] = False
 
-
-DEFAULT_MAX_BUFFER_SIZE: Final[int] = 32
+MAX_BUFFER_SIZE: Final[int] = 32
 DEFAULT_ECHO_TIMEOUT: Final[float] = 0.04  # waiting for echo pkt after cmd sent
 DEFAULT_RPLY_TIMEOUT: Final[float] = 0.20  # waiting for reply pkt after echo pkt rcvd
 
-_POLLING_INTERVAL: Final[float] = 0.0005
+MAX_SEND_TIMEOUT: Final[float] = 3.0  # for a command to be sent, incl. retries, etc.
+MAX_RETRY_LIMIT: Final[int] = 3  # for a command to be re-sent (not incl. 1st send)
+
+
+#######################################################################################
 
 
 class _ProtocolWaitFailed(exc.ProtocolSendFailed):
@@ -60,226 +53,167 @@ class _ProtocolRplyFailed(exc.ProtocolSendFailed):
     """The Command received an echo OK, but failed to elicit the expected reply."""
 
 
+#######################################################################################
+
+
 class ProtocolContext:
-    """To add state to a Protocol."""
-
-    _proc_queue_task: None | asyncio.Task = None  # None when not connected to Protocol
-    _state: _ProtocolStateT = None  # type: ignore[assignment]
-
     def __init__(
         self,
         protocol: RamsesProtocolT,
         /,
         *,
-        max_buffer_size: int = DEFAULT_MAX_BUFFER_SIZE,
         echo_timeout: float = DEFAULT_ECHO_TIMEOUT,
         reply_timeout: float = DEFAULT_RPLY_TIMEOUT,
         min_gap_duration: float = MINIMUM_GAP_DURATION,
-        max_retry_limit: int = 3,
+        max_retry_limit: int = MAX_RETRY_LIMIT,
+        max_buffer_size: int = MAX_BUFFER_SIZE,
     ) -> None:
-        # super().__init__(*args, **kwargs)
         self._protocol = protocol
-        self.max_buffer_size = max_buffer_size
         self.echo_timeout = td(seconds=echo_timeout)
         self.reply_timeout = td(seconds=reply_timeout)
         self.min_gap_duration = td(seconds=min_gap_duration)
-        self.max_retry_limit = max_retry_limit
+        self.max_retry_limit = min(max_retry_limit, MAX_RETRY_LIMIT)
+        self.max_buffer_size = min(max_buffer_size, MAX_BUFFER_SIZE)
 
-        self._loop = asyncio.get_running_loop()
+        self._loop = protocol._loop
+        self._fut: asyncio.Future | None = None
         self._que: PriorityQueue = PriorityQueue(maxsize=self.max_buffer_size)
-        self._mutex = Lock()
 
-        self.set_state(Inactive)  # set initiate state, pre connection_made
+        self._expiry_timer: asyncio.Task = None  # type: ignore[assignment]
+        self._state: ProtocolStateBase = None  # type: ignore[assignment]
 
-    def __repr__(self) -> str:
-        cls = self.state.__class__.__name__
-        return (
-            f"Context({cls}, len(Queue)="
-            f"{self._que.unfinished_tasks}/{self._que._qsize()})"
-        )
+        # TODO: pass this over as an instance paramater
+        self._send_fnc: Callable[[Command], Coroutine[Any, Any, None]] = None  # type: ignore[assignment]
 
-    def set_state(self, state: type[_ProtocolStateT]) -> None:
-        """Set the State of the Protocol (context)."""
+        self._cmd: Command = None  # type: ignore[assignment]
+        self._qos: QosParams = None  # type: ignore[assignment]
+        self._cmd_tx_count: int = 0
+        self._cmd_tx_limit: int = 0
 
-        prev_state = self._state
+        self.set_state(Inactive)
 
-        # assert prev_state and prev_state._next_state is None  # FSM error
+    def set_state(
+        self,
+        state: ProtocolStateBase,
+        expired: bool = False,
+        timed_out: bool = False,
+        exception: Exception | None = None,
+        result: Packet | None = None,
+    ) -> None:
+        async def expire_state_on_timeout() -> None:
+            if isinstance(self._state, WantEcho):
+                await asyncio.sleep(self.echo_timeout)
+            else:
+                await asyncio.sleep(self.reply_timeout)
 
-        if state in (Inactive, IsPaused, IsInIdle):
-            self._state = state(self)
+            # Timer has expired, can we retry?
+            if self._cmd_tx_count < self._cmd_tx_limit:
+                self.set_state(WantEcho, timed_out=True)
+            else:
+                self.set_state(IsInIdle, expired=True)
 
-        else:  # if state in (WantEcho, WantRply, IsFailed):
-            self._state = state(
-                self,
-                active_cmd=self._state.active_cmd,
-                num_sends=self._state.num_sends,
-                echo_frame=self._state._echo_frame,
-                echo_pkt=self._state._echo_pkt,
-            )
+        if self._expiry_timer is not None:
+            self._expiry_timer.cancel()
+            self._expiry_timer = None
 
-        # TODO: aquire lock
-        if prev_state:
-            prev_state._next_state = self._state  # used to detect transitions
-        if _DBG_MAINTAIN_STATE_CHAIN:  # HACK for debugging
-            setattr(self._state, "_prev_state", prev_state)  # noqa: B010
-        # TODO: release lock
+        self._state = state(self)
 
-        if isinstance(self._state, IsInIdle | IsFailed):
-            self._ensure_queue_processor()  # because just became Idle
+        if result:
+            self._fut.set_result(result)
+        elif exception:
+            self._fut.set_exception(exception)
+        elif expired:
+            self._fut.set_exception(exc.ProtocolSendFailed("Exceeded maximum retries"))
+        elif timed_out:
+            self._send_cmd(is_retry=True)
+
+        if isinstance(self._state, IsInIdle):
+            self._check_buffer_for_cmd()
+
+        elif isinstance(self._state, WantRply) and not self._qos.wait_for_reply:
+            self.set_state(IsInIdle, result=self._state._echo_pkt)
+
+        elif isinstance(self._state, WantEcho | WantRply):
+            self._expiry_timer = self._loop.create_task(expire_state_on_timeout())
 
     @property
     def state(self) -> _ProtocolStateT:
         return self._state
 
     def connection_made(self, transport: RamsesTransportT) -> None:
-        self._proc_queue_task = self._loop.create_task(self._process_queued_cmds())
-        self.state.made_connection(transport)  # TODO: needs to be after prev. line?
+        # may want to set some instance variables, according to type of transport
+        self._state.connection_made()
 
     def connection_lost(self, err: ExceptionT | None) -> None:
-        fut: asyncio.Future
+        self._state.connection_lost()
 
-        self.state.lost_connection(err)
-
-        if self._proc_queue_task:
-            self._proc_queue_task.cancel()
-            self._proc_queue_task = None  # FIXME
-
-        # with self._que.mutex.acquire():
-        while True:
-            try:
-                *_, fut = self._que.get_nowait()
-            except Empty:
-                break
-            fut.cancel()
+    def pkt_received(self, pkt: Packet) -> Any:
+        self._state.pkt_rcvd(pkt)
 
     def pause_writing(self) -> None:
-        self.state.writing_paused()
+        self._state.writing_paused()
 
     def resume_writing(self) -> None:
-        self.state.writing_resumed()
-
-    def pkt_received(self, pkt: Packet) -> None:
-        # if isinstance(self.state, (WantEcho, WantRply)):  # not needed
-        self.state.rcvd_pkt(pkt)
+        self._state.writing_resumed()
 
     async def send_cmd(
         self,
-        send_fnc: Callable[[Command], Coroutine[Any, Any, None]],
+        send_fnc: Callable[[Command], Coroutine[Any, Any, None]],  # TODO: remove
         cmd: Command,
         priority: Priority,
         qos: QosParams,
     ) -> Packet:
-        """Send the Command (with retries) and wait for the expected Packet.
+        self._send_fnc = send_fnc  # TODO: REMOVE: make per Context, not per Command
 
-        if wait_for_reply is True, wait for the RP/I corresponding to the RQ/W,
-        otherwise simply return the echo Packet.
-
-        Raises a ProtocolSendFailed if either max_retires or timeout is exceeded before
-        receiving the expected packet.
-        """
-
-        def is_future_done(item: tuple) -> bool:
-            """Return True if the item's Future is done (condition)."""
-            fut: asyncio.Future  # mypy
-            *_, fut = item
-            return fut.done()  # usu. because expired?
-
-        def remove_unwanted_items(queue: PriorityQueue, condition: Callable):
-            """Removes all entries from the queue that satisfy the condition.."""
-            # HACK: I have no idea if this is kosher (it does appear thread-safe)
-            if queue.mutex.acquire():
-                queue_copy = queue.queue[:]  # the queue attr is a list
-                for entry in queue_copy:
-                    if condition(entry):
-                        queue.queue.remove(entry)
-                queue.mutex.release()
-
-        max_retries = qos.max_retries
-        timeout = qos.timeout
-        wait_for_reply = qos.wait_for_reply
-
-        # if self.state.is_active_cmd(cmd):  # no need to queue?
-
-        dt_sent = dt.now()  # TODO: put this after self._que.get?
-        dt_expires = dt_sent + td(seconds=timeout)
         fut = self._loop.create_future()
-        params = send_fnc, cmd, max_retries, wait_for_reply
+        await self._push_cmd_to_buffer(cmd, priority, qos, fut)
 
-        remove_unwanted_items(self._que, is_future_done)
-        try:
-            self._que.put_nowait(  # priority / dt_sent is the priority
-                (priority, dt_sent, dt_expires, params, fut)
-            )
-        except Full:
-            fut.set_exception(exc.ProtocolFsmError("Send queue full, cmd discarded"))
-
-        self._ensure_queue_processor()  # because just added job to send queue
+        if isinstance(self._state, IsInIdle):
+            self._loop.call_soon_threadsafe(self._check_buffer_for_cmd)
 
         try:
-            pkt: Packet = await asyncio.wait_for(
-                fut, timeout
-            )  # TODO: return message instead?
+            await asyncio.wait_for(fut, timeout=min(qos.timeout, MAX_SEND_TIMEOUT))
         except TimeoutError as err:
-            self.set_state(IsFailed)
-            raise exc.ProtocolSendFailed(
-                f"{cmd._hdr}: Timeout (outer) has expired"
-            ) from err
-        except exc.ProtocolError as err:
-            self.set_state(IsFailed)
-            raise exc.ProtocolSendFailed(f"{cmd._hdr}: Other error") from err
+            self.set_state(IsInIdle)
+            raise exc.ProtocolSendFailed("Send timeout has expired") from err
+        return fut.result()  # may raise ProtocolFsmError
 
-        self._ensure_queue_processor()  # because just completed job
-        return pkt
+    async def _push_cmd_to_buffer(
+        self,
+        cmd: Command,
+        priority: Priority,
+        qos: QosParams,
+        fut: asyncio.Future,
+    ):
+        try:
+            self._que.put_nowait((priority, dt.now(), cmd, qos, fut))
+        except Full:
+            fut.set_exception(_ProtocolWaitFailed("Send buffer full, cmd discarded"))
 
-    def _ensure_queue_processor(self) -> None:
-        """Ensure the queue processor is running (called when a cmd is added)."""
-
-        if self._mutex.acquire(timeout=0.005):
-            if self._proc_queue_task is None:  # pkts sent before connection_made()?
-                pass
-            elif self._proc_queue_task.done():
-                self._proc_queue_task = self._loop.create_task(
-                    self._process_queued_cmds()
-                )
-            self._mutex.release()
-
-    async def _process_queued_cmds(self) -> None:
-        """Walk through the queue and send only the next valid Commands."""
-
-        fut: asyncio.Future
+    def _check_buffer_for_cmd(self):
+        if not isinstance(self._state, IsInIdle):  # TODO: make assert? or remove?
+            raise exc.ProtocolFsmError("Incorrect state to check the buffer")
 
         while True:
             try:
-                *_, dt_expires, params, fut = self._que.get_nowait()
+                *_, self._cmd, self._qos, self._fut = self._que.get_nowait()
             except Empty:
+                self._cmd = self._qos = self._fut = None
                 return
 
-            if fut.done():
+            assert isinstance(self._fut, asyncio.Future)  # mypy hint
+            if self._fut.done():  # e.g. TimeoutError
                 self._que.task_done()
                 continue
 
-            if dt_expires <= dt.now():  # ?needed
-                fut.set_exception(_ProtocolWaitFailed("Timeout (inner) has expired"))
-                self._que.task_done()
-                continue
-
-            try:
-                result = await self._send_cmd(*params)
-            except exc.ProtocolSendFailed as err:
-                fut.set_exception(err)
-            else:
-                fut.set_result(result)
-            finally:
-                self._que.task_done()
             break
 
-    async def _send_cmd(  # actual Tx is in here
-        self,
-        send_fnc: Callable,
-        cmd: Command,
-        max_retries: int,
-        wait_for_reply: bool | None,
-    ) -> Packet:
+        try:
+            self._send_cmd()
+        finally:
+            self._que.task_done()
+
+    def _send_cmd(self, is_retry: bool = False) -> Packet:
         """Wrapper to send a command with retries, until success or exception.
 
         Supported Exceptions are limited to:
@@ -288,281 +222,153 @@ class ProtocolContext:
          - _ProtocolRplyFailed - issue receiving expected reply pPacket
         """
 
-        if isinstance(self.state, IsFailed):  # is OK to send when last send failed
-            self.set_state(IsInIdle)
+        async def send_fnc_wrapper(cmd: Command) -> None:
+            if self._cmd is None:
+                pass
 
-        num_retries = -1
-        while num_retries < max_retries:  # resend until RetryLimitExceeded
-            num_retries += 1
+            try:  # the wrapped function (actual Tx.write)
+                await self._send_fnc(cmd)
+            except exc.TransportError as err:
+                self.set_state(IsInIdle, exception=err)
 
-            try:  # send the cmd
-                # the order of these two calls appears irrelevent, but dev/tested as is
-                self.state.sent_cmd(cmd)
-                await send_fnc(cmd)  # the wrapped function (actual Tx.write)
-                assert isinstance(self.state, WantEcho), f"{self}: Expects WantEcho"
-
-            except (AssertionError, exc.ProtocolFsmError) as err:  # FIXME
-                msg = f"{self}: Failed to Tx echo {cmd.tx_header}"
-                if num_retries == max_retries:
-                    raise _ProtocolWaitFailed(f"{msg}: {err}") from err
-                _LOGGER.debug(f"{msg} (will retry): {err}")
-                continue
-
-            try:  # receive the echo pkt
-                # assert isinstance(self.state, WantEcho)  # This won't work here
-                prev_state, next_state = await self._wait_for_transition(
-                    self.state,  # NOTE: is self.state, not next_state
-                    self.echo_timeout + num_retries * self.min_gap_duration,
-                )
-                assert prev_state._echo_pkt, f"{self}: Missing echo packet"
-
-                if not cmd.rx_header:  # no reply to wait for
-                    # self.set_state(IsInIdle)  # FSM will do this
-                    assert isinstance(next_state, IsInIdle), f"{self}: Expects IsInIdle"
-                    return prev_state._echo_pkt
-
-                if (
-                    wait_for_reply is False
-                    or (wait_for_reply is None and cmd.verb != RQ)
-                    or cmd.code == Code._1FC9  # otherwise issues with binding FSM
-                ):
-                    # binding FSM is implemented at higher layer
-                    self.set_state(IsInIdle)  # some will have been set to WantRply
-                    assert isinstance(self.state, IsInIdle), f"{self}: Expects IsInIdle"
-                    return prev_state._echo_pkt
-
-                assert isinstance(next_state, WantRply), f"{self}: Expects WantRply"
-
-            except (AssertionError, exc.ProtocolFsmError) as err:
-                msg = f"{self}: Failed to Rx echo {cmd.tx_header}"
-                if num_retries == max_retries:
-                    raise _ProtocolEchoFailed(f"{msg}: {err}") from err
-                _LOGGER.debug(f"{msg} (will retry): {err}")
-                continue
-
-            try:  # receive the reply pkt (if any)
-                prev_state, next_state = await self._wait_for_transition(
-                    next_state,  # NOTE: is next_state, not self.state
-                    self.reply_timeout + num_retries * self.min_gap_duration,
-                )
-                assert isinstance(next_state, IsInIdle), f"{self}: Expects IsInIdle"
-                assert prev_state._rply_pkt, f"{self}: Missing rply packet"
-
-            except (AssertionError, exc.ProtocolFsmError) as err:
-                msg = f"{self}: Failed to Rx reply {cmd.rx_header}"
-                if num_retries == max_retries:
-                    raise _ProtocolRplyFailed(f"{msg}: {err}") from err
-                _LOGGER.debug(f"{msg} (will retry): {err}")
-                continue
-
-            return prev_state._rply_pkt
-
-        # It would never be expected to reach this code, so a safety-net
-        raise exc.ProtocolFsmError(f"{self}: Unexpected error {cmd.tx_header}")
-
-    async def _wait_for_transition(
-        self, this_state: _ProtocolStateT, timeout: td
-    ) -> tuple[_ProtocolStateT, _ProtocolStateT]:
-        until = dt.now() + timeout
-        while until > dt.now():
-            if this_state._next_state:
-                break
-            await asyncio.sleep(_POLLING_INTERVAL)
+        if is_retry:
+            self._cmd_tx_count += 1
         else:
-            raise exc.ProtocolFsmError(f"Failed to leave {this_state} in time")
+            # TODO: check what happens when exception here - why does it hang?
+            self._cmd_tx_limit = min(self._qos.max_retries, self.max_retry_limit) + 1
+            self._cmd_tx_count = 0
 
-        return this_state, this_state._next_state
+        try:  # the wrapped function (actual Tx.write)
+            self._state.cmd_sent(self._cmd)
+        except exc.ProtocolError as err:
+            self.set_state(IsInIdle, exception=err)
+            return
+
+        self._loop.create_task(send_fnc_wrapper(self._cmd))
 
 
-class _ProtocolStateBase:
-    """Protocol may Tx / can Rx according to it's internal state."""
+#######################################################################################
 
-    # state attrs
-    active_cmd: None | Command
-    num_sends: int
 
-    _echo_frame: None | str = None
-    _echo_pkt: None | Packet = None
-    _rply_pkt: None | Packet = None
+class ProtocolStateBase:
+    def __init__(self, context: ProtocolContext) -> None:
+        self._context = context
 
-    _next_state: None | _ProtocolStateT = None  # used to detect transition
+        self._sent_cmd: Command | None = None
+        self._echo_pkt: Packet | None = None
+        self._rply_pkt: Packet | None = None
 
-    _cant_send_cmd_error: None | str = "Not Implemented"
-
-    def __init__(
-        self,
-        context: ProtocolContext,
-        /,
-        *,
-        active_cmd: None | Command = None,
-        num_sends: int = 0,
-        echo_frame: None | str = None,
-        echo_pkt: None | Packet = None,
-    ) -> None:
-        self._context = context  # a Protocol
-
-        self.active_cmd = active_cmd  # #  the cmd as sent (the active cmd)
-        self.num_sends = num_sends  # #    the number of times the active cmd was sent
-        self._echo_frame = echo_frame  # # the expected echo Frame for the active cmd
-        self._echo_pkt = echo_pkt  # #     the received echo Packet
-
-    def __repr__(self) -> str:
-        cls = self.__class__.__name__
-
-        if isinstance(self, WantRply):
-            assert self.active_cmd is not None
-            return f"{cls}(rx_hdr={self.active_cmd.rx_header}, sends={self.num_sends})"
-
-        if isinstance(self, WantEcho | IsFailed):
-            assert self.active_cmd is not None
-            return f"{cls}(tx_hdr={self.active_cmd.tx_header}, sends={self.num_sends})"
-
-        assert self.active_cmd is None  # Inactive | IsPaused | IsInIdle
-        assert self.num_sends == 0, f"{self}: num_sends != 0"
-        return f"{cls}()"
-
-    def is_active_cmd(self, cmd: Command) -> bool:
-        """Return True if this cmd is the active cmd."""
-        return bool(cmd and cmd is self.active_cmd)
-
-    def made_connection(self, transport: RamsesTransportT) -> None:
-        """Set the Context to IsInIdle (can Tx/Rx) or IsPaused."""
-
-        if self._context._protocol._pause_writing:
-            self._context.set_state(IsPaused)
-        else:
-            self._context.set_state(IsInIdle)
-
-    def lost_connection(self, err: ExceptionT | None) -> None:
-        """Set the Context to Inactive (can't Tx, will not Rx)."""
-        self._context.set_state(Inactive)
-
-    def writing_paused(self) -> None:
-        """Set the Context to IsPaused (shouldn't Tx, might Rx)."""
-        self._context.set_state(IsPaused)
-
-    def writing_resumed(self) -> None:
-        """Set the Context to IsInIdle (can Tx/Rx)."""
-        self._context.set_state(IsInIdle)
-
-    def rcvd_pkt(self, pkt: Packet) -> None:
-        """Receive a Packet without complaint (most times this is OK)."""
+    def connection_made(self) -> None:  # Same for all states except Inactive
+        """Do nothing, as (except for InActive) we're already connected."""
         pass
 
-    def sent_cmd(self, cmd: Command) -> None:  # raises exception
-        """Send a packet if in the correct state."""
-        # if self._cant_send_cmd_error:
-        raise exc.ProtocolFsmError(
-            f"{self}: Can't send {cmd._hdr}: {self._cant_send_cmd_error}"
-        )
+    def connection_lost(self) -> None:  # Same for all states (not needed if Inactive)
+        """Transition to Inactive, regardless of current state."""
+        self._context.set_state(Inactive)
 
+    def pkt_rcvd(self, pkt: Packet) -> None:  # Different for each state
+        """Raise a NotImplementedError."""
+        raise NotImplementedError  # this method should never be called
 
-class Inactive(_ProtocolStateBase):
-    """Protocol cannot Tx at all, and wont Rx (no active connection to a Transport)."""
+    def writing_paused(self) -> None:  # Currently same for all states (TBD)
+        """Do nothing."""
+        pass
 
-    _cant_send_cmd_error = "Protocol has no connected Transport"
+    def writing_resumed(self) -> None:  # Currently same for all states (TBD)
+        """Do nothing."""
+        pass
 
+    def cmd_sent(self, cmd: Command) -> None:  # Same for all states except IsInIdle
+        raise exc.ProtocolFsmError("In the wrong state to send a command")
 
-class IsPaused(_ProtocolStateBase):
-    """Protocol cannot Tx at all, but may Rx (Transport has no capacity to Tx)."""
-
-    _cant_send_cmd_error = "Protocol is paused"
-
-
-class IsInIdle(_ProtocolStateBase):
-    """Protocol can Tx next Command, may Rx (has no current Command)."""
-
-    _cant_send_cmd_error = None
-
-    # NOTE: unfortunately, the cmd's src / echo's src can be different:
-    # RQ --- 18:000730 10:052644 --:------ 3220 005 0000050000  # RQ|10:048122|3220|05
-    # RQ --- 18:198151 10:052644 --:------ 3220 005 0000050000  # RQ|10:048122|3220|05
-
-    def sent_cmd(self, cmd: Command) -> None:
-        """The Transport has possibly sent a Command."""
-
-        assert self.active_cmd is None
-        self.active_cmd = cmd
-
-        # FIXME: the following requires the active GWY's device_id to be known...
-        if self.active_cmd._frame[7:16] != HGI_DEV_ADDR.id:  # applies only for addr0
-            self._echo_frame = self.active_cmd._frame
-
-        elif src_id := self._context._protocol._transport.get_extra_info(SZ_ACTIVE_HGI):
-            self._echo_frame = (
-                self.active_cmd._frame[:7] + src_id + self.active_cmd._frame[16:]
-            )
-
+    def _warn_or_raise(self, error: str) -> None:
+        if _DBG_USE_STRICT_TRANSITIONS:
+            err = exc.ProtocolFsmError(error)
+            self._context.set_state(self.__class__, exception=err)
         else:
-            self._echo_frame = self.active_cmd._frame
+            _LOGGER.warning(error)
 
-        self.num_sends = 1
+
+class Inactive(ProtocolStateBase):
+    def connection_made(self) -> None:
+        """Transition to IsInIdle."""
+        self._context.set_state(IsInIdle)
+
+    def pkt_rcvd(self, pkt: Packet) -> None:  # raise ProtocolFsmError
+        """Raise an exception, as a packet is not expected in this state."""
+        if pkt.code != Code._PUZZ:
+            self._warn_or_raise("Not expecting to receive a packet")
+
+
+class IsInIdle(ProtocolStateBase):
+    def pkt_rcvd(self, pkt: Packet) -> None:  # Do nothing
+        """Do nothing as we're not expecting an echo, nor a reply."""
+        pass
+
+    def cmd_sent(self, cmd: Command) -> None:  # Will expect an Echo
+        """Transition to WantEcho."""
+        self._sent_cmd = cmd
         self._context.set_state(WantEcho)
 
 
-class _WantPkt(_ProtocolStateBase):
-    _cant_send_cmd_error = None
+class WantEcho(ProtocolStateBase):
+    def __init__(self, context: ProtocolContext) -> None:
+        super().__init__(context)
 
-    def sent_cmd(self, cmd: Command) -> None:
-        """The Transport has likely re-sent a Command."""
+        self._sent_cmd = context._state._sent_cmd
 
-        if not self.is_active_cmd(cmd):
-            raise exc.ProtocolFsmError(
-                f"{self}: Can't send {cmd._hdr}: not active Command"
-            )
+    def pkt_rcvd(self, pkt: Packet) -> None:  # Check if pkt is expected Echo
+        """If the pkt is the expected Echo, transition to IsInIdle, or WantRply."""
 
-        self._context.set_state(WantEcho)
+        # RQ --- 18:002563 01:078710 --:------ 2349 002 0200                # 2349|RQ|01:078710|02
+        # RP --- 01:078710 18:002563 --:------ 2349 007 0201F400FFFFFF      # 2349|RP|01:078710|02
+        #  W --- 30:257306 01:096339 --:------ 313F 009 0060002916050B07E7  # 313F| W|01:096339
+        #  I --- 01:096339 30:257306 --:------ 313F 009 00FC0029D6050B07E7  # 313F| I|01:096339
 
+        if (
+            self._sent_cmd.rx_header
+            and pkt._hdr == self._sent_cmd.rx_header
+            and pkt.dst.id == self._sent_cmd.src.id
+        ):  # TODO: just skip to idle?
+            self._warn_or_raise("Expecting an echo, but received the reply")
+            return
 
-class WantEcho(_WantPkt):
-    """Protocol can re-Tx this Command, wanting a Rx (has an outstanding Command)."""
-
-    def rcvd_pkt(self, pkt: Packet) -> None:
-        """The Transport has possibly received the expected echo Packet."""
-
-        assert isinstance(self.active_cmd, Command)  # mypy
-
-        if pkt._frame != self._echo_frame:
+        if pkt._hdr != self._sent_cmd.tx_header:
             return
 
         self._echo_pkt = pkt
-        if self.active_cmd.rx_header:  # and wait_for_reply is True:
+        if self._sent_cmd.rx_header:
             self._context.set_state(WantRply)
         else:
-            self._context.set_state(IsInIdle)
+            self._context.set_state(IsInIdle, result=pkt)
 
 
-class WantRply(_WantPkt):
-    """Protocol can re-Tx this Command, wanting a Rx (has received echo)."""
+class WantRply(ProtocolStateBase):
+    def __init__(self, context: ProtocolContext) -> None:
+        super().__init__(context)
 
-    # NOTE: is possible get a false rply (same rx_header), e.g.:
-    # RP --- 10:048122 18:198151 --:------ 3220 005 00C0050000  # 3220|RP|10:048122|05
-    # RP --- 10:048122 01:145038 --:------ 3220 005 00C0050000  # 3220|RP|10:048122|05
+        self._sent_cmd = context._state._sent_cmd
+        self._echo_pkt = context._state._echo_pkt
 
-    # NOTE: unfortunately, the cmd's src / rply's dst can still be different:
-    # RQ --- 18:000730 10:052644 --:------ 3220 005 0000050000  # 3220|RQ|10:048122|05
-    # RP --- 10:048122 18:198151 --:------ 3220 005 00C0050000  # 3220|RP|10:048122|05
+    def pkt_rcvd(self, pkt: Packet) -> None:  # Check if pkt is expected Reply
+        """If the pkt is the expected reply, transition to IsInIdle."""
 
-    def rcvd_pkt(self, pkt: Packet) -> None:
-        """The Transport has possibly received the expected response Packet."""
+        if pkt == self._sent_cmd:  # pkt._hdr == self._sent_cmd.tx_header and ...
+            self._warn_or_raise("Expecting a reply, but received the echo")
+            return
 
-        assert isinstance(self.active_cmd, Command)  # mypy hint
-        assert isinstance(self._echo_pkt, Packet)  # mypy hint
-
-        # NOTE: use: pkt.dst.id !=     self._echo_pkt.src.id
-        # and not:   pkt.dst    is not self._echo_pkt.src
-        # because Addr may become Device from one packet to the next
-        if pkt._hdr != self.active_cmd.rx_header or pkt.dst.id != self._echo_pkt.src.id:
+        if pkt._hdr != self._sent_cmd.rx_header:
             return
 
         self._rply_pkt = pkt
-        self._context.set_state(IsInIdle)
+        self._context.set_state(IsInIdle, result=pkt)
 
 
-class IsFailed(_ProtocolStateBase):
-    """Protocol can't (yet) Tx next Command, but may Rx (last Command has failed)."""
-
-    _cant_send_cmd_error = "Protocol FSM is in a failed state"
+class IsFailed(ProtocolStateBase):  # TODO: remove?
+    pass
 
 
-_ProtocolStateT = Inactive | IsPaused | IsInIdle | WantEcho | WantRply | IsFailed
+#######################################################################################
+
+
+_ProtocolStateT: TypeAlias = Inactive | IsInIdle | WantEcho | WantRply

--- a/src/ramses_tx/schemas.py
+++ b/src/ramses_tx/schemas.py
@@ -13,7 +13,15 @@ from typing import TYPE_CHECKING, Final
 
 import voluptuous as vol
 
-from .const import DEV_TYPE_MAP, DEVICE_ID_REGEX, DevType
+from .const import (
+    DEFAULT_ECHO_TIMEOUT,
+    DEFAULT_RPLY_TIMEOUT,
+    DEV_TYPE_MAP,
+    DEVICE_ID_REGEX,
+    MAX_DUTY_CYCLE_RATE,
+    MINIMUM_WRITE_GAP,
+    DevType,
+)
 
 if TYPE_CHECKING:
     from .frame import DeviceIdT
@@ -24,12 +32,38 @@ _LOGGER = logging.getLogger(__name__)
 
 #
 # 0/5: Packet source configuration
+SZ_COMMS_PARAMS: Final = "comms_params"
+SZ_DUTY_CYCLE_LIMIT: Final = "duty_cycle_limit"
+SZ_GAP_BETWEEN_WRITES: Final = "gap_between_writes"
+SZ_ECHO_TIMEOUT: Final = "echo_timeout"
+SZ_RPLY_TIMEOUT: Final = "reply_timeout"
+
+SCH_COMMS_PARAMS = vol.Schema(
+    {
+        vol.Required(SZ_DUTY_CYCLE_LIMIT, default=MAX_DUTY_CYCLE_RATE): vol.All(
+            float, vol.Range(min=0.005, max=0.2)
+        ),
+        vol.Required(SZ_GAP_BETWEEN_WRITES, default=MINIMUM_WRITE_GAP): vol.All(
+            float, vol.Range(min=0.05, max=1.0)
+        ),
+        vol.Required(SZ_ECHO_TIMEOUT, default=DEFAULT_ECHO_TIMEOUT): vol.All(
+            float, vol.Range(min=0.01, max=1.0)
+        ),
+        vol.Required(SZ_RPLY_TIMEOUT, default=DEFAULT_RPLY_TIMEOUT): vol.All(
+            float, vol.Range(min=0.01, max=1.0)
+        ),
+    },
+    extra=vol.PREVENT_EXTRA,
+)
+
+#
+# 1/5: Packet source configuration
 SZ_INPUT_FILE: Final = "input_file"
 SZ_PACKET_SOURCE: Final = "packet_source"
 
 
 #
-# 1/5: Packet log configuration
+# 2/5: Packet log configuration
 SZ_FILE_NAME: Final = "file_name"
 SZ_PACKET_LOG: Final = "packet_log"
 SZ_ROTATE_BACKUPS: Final = "rotate_backups"
@@ -85,7 +119,7 @@ def sch_packet_log_dict_factory(default_backups=0) -> dict[vol.Required, vol.Any
 
 
 #
-# 2/5: Serial port configuration
+# 3/5: Serial port configuration
 SZ_PORT_CONFIG: Final = "port_config"
 SZ_PORT_NAME: Final = "port_name"
 SZ_SERIAL_PORT: Final = "serial_port"
@@ -152,7 +186,7 @@ def extract_serial_port(ser_port_dict: dict) -> tuple[str, dict[str, bool | int]
 
 
 #
-# 3/5: Traits (of devices) configuraion (basic)
+# 4/5: Traits (of devices) configuraion (basic)
 def ConvertNullToDict():
     def convert_null_to_dict(node_value) -> dict:
         if node_value is None:
@@ -343,7 +377,7 @@ def select_device_filter_mode(
 
 
 #
-# 4/5: Gateway (engine) configuration
+# 5/5: Gateway (engine) configuration
 SZ_DISABLE_SENDING: Final = "disable_sending"
 SZ_DISABLE_QOS: Final = "disable_qos"
 SZ_ENFORCE_KNOWN_LIST: Final[str] = f"enforce_{SZ_KNOWN_LIST}"
@@ -360,6 +394,7 @@ SCH_ENGINE_DICT = {
     vol.Optional(SZ_EVOFW_FLAG): vol.Any(None, str),
     # vol.Optional(SZ_PORT_CONFIG): SCH_SERIAL_PORT_CONFIG,
     vol.Optional(SZ_USE_REGEX): dict,  # vol.All(ConvertNullToDict(), dict),
+    vol.Optional(SZ_COMMS_PARAMS): SCH_COMMS_PARAMS,
 }
 SCH_ENGINE_CONFIG = vol.Schema(SCH_ENGINE_DICT, extra=vol.REMOVE_EXTRA)
 

--- a/src/ramses_tx/schemas.py
+++ b/src/ramses_tx/schemas.py
@@ -299,8 +299,10 @@ def select_device_filter_mode(
     ]
     if len(hgi_list) != 1:
         _LOGGER.warning(
-            f"Best practice is exactly one gateway (HGI) in the {SZ_KNOWN_LIST}: %s",
+            f"Best practice is exactly one gateway (HGI) in the {SZ_KNOWN_LIST}: "
+            "but, len(%s) = %s",
             hgi_list,
+            len(hgi_list),
         )
 
     if enforce_known_list and not known_list:

--- a/src/ramses_tx/transport.py
+++ b/src/ramses_tx/transport.py
@@ -67,13 +67,7 @@ from serial import (  # type: ignore[import-untyped]
 from . import exceptions as exc
 from .address import ALL_DEV_ADDR, NON_DEV_ADDR
 from .command import Command
-from .const import (
-    MINIMUM_GAP_DURATION,
-    SZ_ACTIVE_HGI,
-    SZ_IS_EVOFW3,
-    SZ_KNOWN_HGI,
-    SZ_SIGNATURE,
-)
+from .const import MINIMUM_GAP_DURATION, SZ_ACTIVE_HGI, SZ_IS_EVOFW3, SZ_SIGNATURE
 from .helpers import dt_now
 from .packet import Packet
 from .schemas import (
@@ -498,7 +492,7 @@ class _BaseTransport:  # NOTE: active gwy detection in here
         self._foreign_gwys_lst: list[DeviceIdT] = []
         self._foreign_last_run = dt.now().date()
 
-        for key in (SZ_ACTIVE_HGI, SZ_SIGNATURE, SZ_KNOWN_HGI):
+        for key in (SZ_ACTIVE_HGI, SZ_SIGNATURE):
             self._extra[key] = None
 
     def __repr__(self) -> str:
@@ -798,9 +792,6 @@ class _PortTransport(serial_asyncio.SerialTransport):  # type: ignore[misc]
         ):
             self._set_active_hgi(pkt.src.id, by_signature=True)
             self._init_fut.set_result(pkt)
-
-        elif not self._extra[SZ_ACTIVE_HGI] and pkt.src.id == self._extra[SZ_KNOWN_HGI]:
-            self._set_active_hgi(pkt.src.id)
 
         self._pkt_read(pkt)  # TODO: remove raw_line attr from Packet()
 

--- a/src/ramses_tx/transport.py
+++ b/src/ramses_tx/transport.py
@@ -727,6 +727,9 @@ class _PortTransport(serial_asyncio.SerialTransport):  # type: ignore[misc]
     def _frame_read(self, dtm: dt, frame: str) -> None:
         """Make a Packet from the Frame and process it."""
 
+        if not frame:
+            return
+
         try:
             pkt = Packet.from_port(dtm, frame)
         except (exc.PacketInvalid, ValueError) as err:  # VE from dt.fromisoformat()

--- a/src/ramses_tx/transport.py
+++ b/src/ramses_tx/transport.py
@@ -1002,7 +1002,8 @@ class MqttTransport(_BaseTransport, asyncio.Transport):
 
         # TODO: determine active gateway
 
-        self._pkt_read(pkt)  # TODO: remove raw_line attr from Packet()
+        # TODO: remove raw_line attr from Packet()
+        self.loop.call_soon_threadsafe(self._pkt_read, pkt)
 
     def _publish(self, message: str) -> None:
         info: mqtt.MQTTMessageInfo = self.client.publish(

--- a/src/ramses_tx/transport.py
+++ b/src/ramses_tx/transport.py
@@ -46,10 +46,12 @@ import logging
 import os
 import re
 import sys
-from collections.abc import Iterable
+from collections.abc import Awaitable, Callable, Iterable
 from datetime import datetime as dt
+from functools import wraps
 from io import TextIOWrapper
 from string import printable
+from time import perf_counter
 from typing import TYPE_CHECKING, Any, Final, TypeAlias
 from urllib.parse import parse_qs, unquote, urlparse
 
@@ -111,9 +113,15 @@ _LOGGER = logging.getLogger(__name__)
 if DEV_MODE:
     _LOGGER.setLevel(logging.DEBUG)
 
-# All debug flags (used for dev/test) should be False for end-users
+# All debug flags (used for dev/test) should be False for published code
+_DBG_DISABLE_DUTY_CYCLE_LIMIT: Final[bool] = False
 _DBG_DISABLE_REGEX_WARNINGS = False
 _DBG_FORCE_LOG_FRAMES = False
+
+# other constants
+_MAX_DUTY_CYCLE = 0.01  # % bandwidth used per cycle (default 60 secs)
+_MAX_TOKENS = 45  # number of Tx per cycle (default 60 secs)
+_CYCLE_DURATION = 60  # seconds
 
 
 # For linux, use a modified version of comports() to include /dev/serial/by-id/* links
@@ -268,6 +276,110 @@ def _str(value: bytes) -> str:
         _LOGGER.warning("%s < Cant decode bytestream (ignoring)", value)
         return ""
     return result
+
+
+def limit_duty_cycle(max_duty_cycle: float, time_window: int = _CYCLE_DURATION):
+    """Limit the Tx rate to the RF duty cycle regulations (e.g. 1% per hour).
+
+    max_duty_cycle: bandwidth available per observation window (%)
+    time_window: duration of the sliding observation window (default 60 seconds)
+    """
+
+    TX_RATE_AVAIL: int = 38400  # bits per second (deemed)
+    FILL_RATE: float = TX_RATE_AVAIL * max_duty_cycle  # bits per second
+    BUCKET_CAPACITY: float = FILL_RATE * time_window
+
+    def decorator(fnc: Callable[..., Awaitable]):
+        # start with a full bit bucket
+        bits_in_bucket: float = BUCKET_CAPACITY
+        last_time_bit_added = perf_counter()
+
+        @wraps(fnc)
+        async def wrapper(self, frame: str, *args, **kwargs) -> None:
+            nonlocal bits_in_bucket
+            nonlocal last_time_bit_added
+
+            rf_frame_size = 330 + len(frame[46:]) * 10
+
+            # top-up the bit bucket
+            elapsed_time = perf_counter() - last_time_bit_added
+            bits_in_bucket = min(
+                bits_in_bucket + elapsed_time * FILL_RATE, BUCKET_CAPACITY
+            )
+            last_time_bit_added = perf_counter()
+
+            if _DBG_DISABLE_DUTY_CYCLE_LIMIT:
+                bits_in_bucket = BUCKET_CAPACITY
+
+            # if required, wait for the bit bucket to refill (not for SETs/PUTs)
+            if bits_in_bucket < rf_frame_size:
+                await asyncio.sleep((rf_frame_size - bits_in_bucket) / FILL_RATE)
+
+            # consume the bits from the bit bucket
+            try:
+                await fnc(self, frame, *args, **kwargs)
+            finally:
+                bits_in_bucket -= rf_frame_size
+
+        @wraps(fnc)
+        async def null_wrapper(self, frame: str, *args, **kwargs) -> None:
+            await fnc(self, frame, *args, **kwargs)
+
+        if 0 < max_duty_cycle <= 1:
+            return wrapper
+
+        return null_wrapper
+
+    return decorator
+
+
+def limit_transmit_rate(max_tokens: float, time_window: int = _CYCLE_DURATION):
+    """Limit the Tx rate as # packets per period of time.
+
+    Rate-limits the decorated function locally, for one process (Token Bucket).
+
+    max_tokens: maximum number of calls of function in time_window
+    time_window: duration of the sliding observation window (default 60 seconds)
+    """
+    # thanks, kudos to: Thomas Meschede, license: MIT
+    # see: https://gist.github.com/yeus/dff02dce88c6da9073425b5309f524dd
+
+    token_fill_rate: float = max_tokens / time_window
+
+    def decorator(fnc: Callable):
+        token_bucket: float = max_tokens  # initialize with max tokens
+        last_time_token_added = perf_counter()
+
+        @wraps(fnc)
+        async def wrapper(*args, **kwargs):
+            nonlocal token_bucket
+            nonlocal last_time_token_added
+
+            # top-up the bit bucket
+            elapsed = perf_counter() - last_time_token_added
+            token_bucket = min(token_bucket + elapsed * token_fill_rate, max_tokens)
+            last_time_token_added = perf_counter()
+
+            # if required, wait for a token (not for SETs/PUTs)
+            if token_bucket < 1.0:
+                await asyncio.sleep((1 - token_bucket) / token_fill_rate)
+
+            # consume one token for every call
+            try:
+                await fnc(*args, **kwargs)
+            finally:
+                token_bucket -= 1.0
+
+        return wrapper
+
+        @wraps(fnc)  # type: ignore[unreachable]
+        async def null_wrapper(*args, **kwargs) -> Any:
+            return await fnc(*args, **kwargs)
+
+        if max_tokens <= 0:
+            return null_wrapper
+
+    return decorator
 
 
 class _DeviceIdFilterMixin:  # NOTE: active gwy detection in here

--- a/src/ramses_tx/transport.py
+++ b/src/ramses_tx/transport.py
@@ -483,8 +483,10 @@ class _BaseTransport:  # NOTE: active gwy detection in here
         # NOTE: Thus, excepts need checking
         try:  # below could be a call_soon?
             self._protocol.pkt_received(pkt)
-        except (AssertionError, exc.ProtocolError) as err:  # protect from upper layers
+        except AssertionError as err:  # protect from upper layers
             _LOGGER.exception("%s < exception from msg layer: %s", pkt, err)
+        except exc.ProtocolError as err:  # protect from upper layers
+            _LOGGER.error("%s < exception from msg layer: %s", pkt, err)
 
 
 class _RegHackMixin:

--- a/src/ramses_tx/transport.py
+++ b/src/ramses_tx/transport.py
@@ -1057,7 +1057,7 @@ async def transport_factory(
     disable_sending: bool | None = False,
     extra: dict | None = None,
     loop: asyncio.AbstractEventLoop | None = None,
-    **kwargs,
+    **kwargs,  # HACK: odd/misc params
 ) -> RamsesTransportT:
     """Create and return a Ramses-specific async packet Transport."""
 

--- a/src/ramses_tx/transport.py
+++ b/src/ramses_tx/transport.py
@@ -489,9 +489,6 @@ class _BaseTransport:  # NOTE: active gwy detection in here
         self._exclude = list(exclude_list.keys())
         self._include = list(include_list.keys()) + [ALL_DEV_ADDR.id, NON_DEV_ADDR.id]
 
-        self._foreign_gwys_lst: list[DeviceIdT] = []
-        self._foreign_last_run = dt.now().date()
-
         for key in (SZ_ACTIVE_HGI, SZ_SIGNATURE):
             self._extra[key] = None
 

--- a/src/ramses_tx/transport.py
+++ b/src/ramses_tx/transport.py
@@ -483,7 +483,7 @@ class _BaseTransport:  # NOTE: active gwy detection in here
         # NOTE: Thus, excepts need checking
         try:  # below could be a call_soon?
             self._protocol.pkt_received(pkt)
-        except AssertionError as err:  # protect from upper-layer callbacks
+        except (AssertionError, exc.ProtocolError) as err:  # protect from upper layers
             _LOGGER.exception("%s < exception from msg layer: %s", pkt, err)
 
 

--- a/src/ramses_tx/transport.py
+++ b/src/ramses_tx/transport.py
@@ -451,7 +451,7 @@ def track_system_syncs(fnc: Callable[[Any, Packet], None]):
     return wrapper
 
 
-class _BaseTransport:  # NOTE: active gwy detection in here
+class _BaseTransport:
     """Filter out any unwanted (but otherwise valid) packets via device ids."""
 
     _protocol: RamsesProtocolT
@@ -981,6 +981,9 @@ class MqttTransport(_BaseTransport, asyncio.Transport):
     def _on_message(
         self, client: mqtt.Client, userdata: Any | None, msg: mqtt.MQTTMessage
     ):
+        if self._closing:
+            return
+
         if _DBG_FORCE_LOG_FRAMES:
             _LOGGER.warning("Rx: %s", msg.payload)
         elif _LOGGER.getEffectiveLevel() == logging.INFO:  # log for INFO not DEBUG
@@ -994,7 +997,7 @@ class MqttTransport(_BaseTransport, asyncio.Transport):
             _LOGGER.warning("%s < PacketInvalid(%s)", _normalise(payload["msg"]), err)
             return
 
-        # TODO: dtermine active gateway
+        # TODO: determine active gateway
 
         self._pkt_read(pkt)  # TODO: remove raw_line attr from Packet()
 

--- a/src/ramses_tx/transport.py
+++ b/src/ramses_tx/transport.py
@@ -577,7 +577,7 @@ class _FileTransport(asyncio.ReadTransport):
         self._reading = True
         try:
             await self._reader()
-        except KeyboardInterrupt as err:
+        except Exception as err:
             self._protocol.connection_lost(err)  # type: ignore[arg-type]
         else:
             self._protocol.connection_lost(None)

--- a/src/ramses_tx/transport.py
+++ b/src/ramses_tx/transport.py
@@ -820,7 +820,7 @@ class _PortTransport(serial_asyncio.SerialTransport):  # type: ignore[misc]
     ) -> None:  # Protocol usu. calls this, not write()
         await self._write_frame(frame)
 
-    # @limit_duty_cycle(_MAX_DUTY_CYCLE)  # type: ignore[misc]  # @limit_transmit_rate(_MAX_TOKENS)
+    @limit_duty_cycle(_MAX_DUTY_CYCLE)  # type: ignore[misc]  # @limit_transmit_rate(_MAX_TOKENS)
     async def _write_frame(self, frame: str) -> None:
         self.write(bytes(frame, "ascii") + b"\r\n")
 

--- a/src/ramses_tx/typing.py
+++ b/src/ramses_tx/typing.py
@@ -16,7 +16,7 @@ from .const import (
     DEFAULT_GAP_DURATION,
     DEFAULT_MAX_RETRIES,
     DEFAULT_NUM_REPEATS,
-    DEFAULT_TIMEOUT,
+    DEFAULT_SEND_TIMEOUT,
     Priority,
 )
 from .message import Message
@@ -35,13 +35,13 @@ class QosParams:
         self,
         *,
         max_retries: int | None = DEFAULT_MAX_RETRIES,
-        timeout: float | None = DEFAULT_TIMEOUT,
+        timeout: float | None = DEFAULT_SEND_TIMEOUT,
         wait_for_reply: bool | None = None,
     ) -> None:
         """Create a QosParams instance."""
 
         self._max_retries = DEFAULT_MAX_RETRIES if max_retries is None else max_retries
-        self._timeout = timeout or DEFAULT_TIMEOUT
+        self._timeout = timeout or DEFAULT_SEND_TIMEOUT
         self._wait_for_reply = wait_for_reply  # False / None have different meanings
 
         self._echo_pkt: Packet | None = None

--- a/src/ramses_tx/version.py
+++ b/src/ramses_tx/version.py
@@ -1,4 +1,4 @@
 """RAMSES RF - a RAMSES-II protocol decoder & analyser (transport layer)."""
 
-__version__ = "0.31.11"
+__version__ = "0.31.12"
 VERSION = __version__

--- a/src/ramses_tx/version.py
+++ b/src/ramses_tx/version.py
@@ -1,4 +1,4 @@
 """RAMSES RF - a RAMSES-II protocol decoder & analyser (transport layer)."""
 
-__version__ = "0.31.13"
+__version__ = "0.31.14"
 VERSION = __version__

--- a/src/ramses_tx/version.py
+++ b/src/ramses_tx/version.py
@@ -1,4 +1,4 @@
 """RAMSES RF - a RAMSES-II protocol decoder & analyser (transport layer)."""
 
-__version__ = "0.31.12"
+__version__ = "0.31.13"
 VERSION = __version__

--- a/tests/deprecated/_test_mock_schedule.py
+++ b/tests/deprecated/_test_mock_schedule.py
@@ -43,7 +43,7 @@ def pytest_generate_tests(metafunc):
 _global_flow_marker: int = None  # type: ignore[assignment]
 
 
-_GAP_BETWEEN_WRITES = 0  # patch ramses_tx.transport
+MINIMUM_WRITE_GAP = 0  # patch ramses_tx.transport
 WAITING_TIMEOUT_SECS = 0  # #      patch ramses_rf.binding_fsm
 
 
@@ -304,7 +304,7 @@ async def test_rq_0006_ver(test_port):
 
 
 @abort_if_rf_test_fails
-@patch("ramses_tx.transport._GAP_BETWEEN_WRITES", _GAP_BETWEEN_WRITES)
+@patch("ramses_tx.transport.MINIMUM_WRITE_GAP", MINIMUM_WRITE_GAP)
 async def test_rq_0404_dhw(test_port):
     """Test the dhw.get_schedule() method."""
 
@@ -325,7 +325,7 @@ async def test_rq_0404_dhw(test_port):
 
 
 @abort_if_rf_test_fails
-@patch("ramses_tx.transport._GAP_BETWEEN_WRITES", _GAP_BETWEEN_WRITES)
+@patch("ramses_tx.transport.MINIMUM_WRITE_GAP", MINIMUM_WRITE_GAP)
 async def test_rq_0404_zon(test_port):
     """Test the zone.get_schedule() method."""
 
@@ -346,7 +346,7 @@ async def test_rq_0404_zon(test_port):
 
 
 @abort_if_rf_test_fails
-@patch("ramses_tx.transport._GAP_BETWEEN_WRITES", _GAP_BETWEEN_WRITES)
+@patch("ramses_tx.transport.MINIMUM_WRITE_GAP", MINIMUM_WRITE_GAP)
 async def test_ww_0404_dhw(test_port):
     """Test the dhw.set_schedule() method (uses get_schedule)."""
 
@@ -367,7 +367,7 @@ async def test_ww_0404_dhw(test_port):
 
 
 @abort_if_rf_test_fails
-@patch("ramses_tx.transport._GAP_BETWEEN_WRITES", _GAP_BETWEEN_WRITES)
+@patch("ramses_tx.transport.MINIMUM_WRITE_GAP", MINIMUM_WRITE_GAP)
 async def test_ww_0404_zon(test_port):
     """Test the zone.set_schedule() method (uses get_schedule)."""
 

--- a/tests/tests_rf/conftest.py
+++ b/tests/tests_rf/conftest.py
@@ -1,0 +1,10 @@
+"""Fixtures for testing."""
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def patches_for_tests(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setattr("ramses_tx.protocol._DBG_DISABLE_IMPERSONATION_ALERTS", True)
+    monkeypatch.setattr("ramses_tx.transport._DBG_DISABLE_DUTY_CYCLE_LIMIT", True)
+    monkeypatch.setattr("ramses_tx.transport._GAP_BETWEEN_WRITES", 0)

--- a/tests/tests_rf/conftest.py
+++ b/tests/tests_rf/conftest.py
@@ -7,4 +7,4 @@ import pytest
 def patches_for_tests(monkeypatch: pytest.MonkeyPatch):
     monkeypatch.setattr("ramses_tx.protocol._DBG_DISABLE_IMPERSONATION_ALERTS", True)
     monkeypatch.setattr("ramses_tx.transport._DBG_DISABLE_DUTY_CYCLE_LIMIT", True)
-    monkeypatch.setattr("ramses_tx.transport._GAP_BETWEEN_WRITES", 0)
+    monkeypatch.setattr("ramses_tx.transport.MINIMUM_WRITE_GAP", 0)

--- a/tests/tests_rf/test_binding_fsm.py
+++ b/tests/tests_rf/test_binding_fsm.py
@@ -31,7 +31,6 @@ from .virtual_rf.helpers import ensure_fakeable
 
 # patched constants
 DEFAULT_MAX_RETRIES = 0  # #                ramses_tx.protocol
-DEFAULT_TIMEOUT = 0.005  # #                ramses_tx.protocol_fsm
 MAINTAIN_STATE_CHAIN = False  # #           ramses_tx.protocol_fsm
 
 # other constants

--- a/tests/tests_rf/test_binding_fsm.py
+++ b/tests/tests_rf/test_binding_fsm.py
@@ -30,6 +30,7 @@ from .virtual_rf import rf_factory
 from .virtual_rf.helpers import ensure_fakeable
 
 # patched constants
+_DBG_DISABLE_DUTY_CYCLE_LIMIT = True  # #   ramses_tx.transport
 _DBG_DISABLE_IMPERSONATION_ALERTS = True  # ramses_tx.protocol
 _DBG_DISABLE_QOS = False  # #               ramses_tx.protocol
 DEFAULT_MAX_RETRIES = 0  # #                ramses_tx.protocol
@@ -171,6 +172,10 @@ def patches_for_tests(monkeypatch: pytest.MonkeyPatch):
         _DBG_DISABLE_IMPERSONATION_ALERTS,
     )
     monkeypatch.setattr("ramses_tx.protocol._GAP_BETWEEN_WRITES", _GAP_BETWEEN_WRITES)
+    monkeypatch.setattr(
+        "ramses_tx.transport._DBG_DISABLE_DUTY_CYCLE_LIMIT",
+        _DBG_DISABLE_DUTY_CYCLE_LIMIT,
+    )
 
 
 def pytest_generate_tests(metafunc: pytest.Metafunc):

--- a/tests/tests_rf/test_binding_fsm.py
+++ b/tests/tests_rf/test_binding_fsm.py
@@ -227,6 +227,7 @@ async def _test_flow_10x(
 
     pkt = await supplicant._bind_context._make_offer(codes)
     await assert_context_state(supplicant, _BindStates.NEEDING_ACCEPT)
+    assert pkt is not None
 
     await resp_task
     await assert_context_state(respondent, _BindStates.NEEDING_AFFIRM)
@@ -246,6 +247,7 @@ async def _test_flow_10x(
 
     pkt = await respondent._bind_context._accept_offer(tender, codes)
     await assert_context_state(respondent, _BindStates.NEEDING_AFFIRM)
+    assert pkt is not None
 
     await supp_task
     await assert_context_state(supplicant, _BindStates.TO_SEND_AFFIRM)
@@ -262,6 +264,7 @@ async def _test_flow_10x(
 
     pkt = await supplicant._bind_context._confirm_accept(accept, confirm_code=codes)
     await assert_context_state(supplicant, _BindStates.HAS_BOUND_SUPP)
+    assert pkt is not None
 
     if len(pkt_flow_expected) > _RATIFY:  # FIXME
         supplicant._bind_context.set_state(
@@ -299,6 +302,7 @@ async def _test_flow_10x(
     # # TODO: need to finish this
     # pkt = await supplicant._context._cast_addenda()
     # await assert_context_state(supplicant, _BindStates.HAS_BOUND_SUPP)
+    # assert pkt is not None
 
     # await assert_context_state(respondent, _BindStates.HAS_BOUND_RESP)
     # await resp_task

--- a/tests/tests_rf/test_binding_fsm.py
+++ b/tests/tests_rf/test_binding_fsm.py
@@ -30,13 +30,9 @@ from .virtual_rf import rf_factory
 from .virtual_rf.helpers import ensure_fakeable
 
 # patched constants
-_DBG_DISABLE_DUTY_CYCLE_LIMIT = True  # #   ramses_tx.transport
-_DBG_DISABLE_IMPERSONATION_ALERTS = True  # ramses_tx.protocol
-_DBG_DISABLE_QOS = False  # #               ramses_tx.protocol
 DEFAULT_MAX_RETRIES = 0  # #                ramses_tx.protocol
 DEFAULT_TIMEOUT = 0.005  # #                ramses_tx.protocol_fsm
 MAINTAIN_STATE_CHAIN = False  # #           ramses_tx.protocol_fsm
-_GAP_BETWEEN_WRITES = 0  # #                ramses_tx.protocol
 
 # other constants
 ASSERT_CYCLE_TIME = 0.0005  # max_cycles_per_assert = max_sleep / ASSERT_CYCLE_TIME
@@ -163,19 +159,6 @@ TEST_SUITE_300 = [
 # TEST_SUITE_300 = [TEST_SUITE_300[-2]]
 
 # ### FIXTURES #########################################################################
-
-
-@pytest.fixture(autouse=True)
-def patches_for_tests(monkeypatch: pytest.MonkeyPatch):
-    monkeypatch.setattr(
-        "ramses_tx.protocol._DBG_DISABLE_IMPERSONATION_ALERTS",
-        _DBG_DISABLE_IMPERSONATION_ALERTS,
-    )
-    monkeypatch.setattr("ramses_tx.protocol._GAP_BETWEEN_WRITES", _GAP_BETWEEN_WRITES)
-    monkeypatch.setattr(
-        "ramses_tx.transport._DBG_DISABLE_DUTY_CYCLE_LIMIT",
-        _DBG_DISABLE_DUTY_CYCLE_LIMIT,
-    )
 
 
 def pytest_generate_tests(metafunc: pytest.Metafunc):

--- a/tests/tests_rf/test_binding_fsm.py
+++ b/tests/tests_rf/test_binding_fsm.py
@@ -24,7 +24,7 @@ from ramses_rf.binding_fsm import (
     _BindStates,
 )
 from ramses_rf.device import Fakeable
-from ramses_tx.protocol import QosProtocol
+from ramses_tx.protocol import PortProtocol
 
 from .virtual_rf import rf_factory
 from .virtual_rf.helpers import ensure_fakeable
@@ -232,7 +232,7 @@ async def _test_flow_10x(
     await resp_task
     await assert_context_state(respondent, _BindStates.NEEDING_AFFIRM)
 
-    if not isinstance(gwy_r._protocol, QosProtocol):
+    if not isinstance(gwy_r._protocol, PortProtocol) or not gwy_r._protocol._context:
         assert False, "QoS protocol not enabled"  # use assert, not skip
 
     tender = resp_task.result()

--- a/tests/tests_rf/test_create_stack.py
+++ b/tests/tests_rf/test_create_stack.py
@@ -1,0 +1,229 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+#
+
+# TODO: replace protocol_decorator with a factory or fixture
+
+"""RAMSES RF - Test the binding protocol with a virtual RF
+
+NB: This test will likely fail with pytest -n x, because of the protocol's throttle
+limits.
+"""
+
+import asyncio
+from collections.abc import Callable
+
+import pytest
+import serial
+
+from ramses_rf import Message
+from ramses_tx.address import DeviceIdT
+from ramses_tx.const import SZ_ACTIVE_HGI, SZ_IS_EVOFW3, Code
+from ramses_tx.protocol import RamsesProtocolT, create_stack, protocol_factory
+from ramses_tx.transport import RamsesTransportT, transport_factory
+
+from .virtual_rf import HgiFwTypes, VirtualRf
+
+# ######################################################################################
+
+
+async def assert_stack_state(
+    protocol: RamsesProtocolT, transport: RamsesTransportT
+) -> None:
+    assert transport._this_pkt.code == Code._PUZZ
+    assert transport._this_pkt.src.id == GWY_ID
+    assert transport._prev_pkt is None
+
+    assert transport.get_extra_info(SZ_ACTIVE_HGI) == GWY_ID
+    assert transport.get_extra_info(SZ_IS_EVOFW3) is True
+
+    assert protocol._active_hgi == GWY_ID
+    assert protocol._is_evofw3 is True
+
+
+def _msg_handler(msg: Message) -> None:
+    pass
+
+
+# ### TESTS ############################################################################
+
+
+async def _test_create_stack(
+    rf: VirtualRf,
+    /,
+    *,
+    protocol_factory_: Callable | None = None,
+    transport_factory_: Callable | None = None,
+    disable_qos: bool | None = False,
+    disable_sending: bool | None = False,
+    enforce_include_list: bool = False,
+    exclude_list: dict[DeviceIdT, dict] | None = None,
+    include_list: dict[DeviceIdT, dict] | None = None,
+    **kwargs,  # TODO: these are for the transport_factory
+) -> None:
+    protocol: RamsesProtocolT
+    transport: RamsesTransportT
+
+    protocol, transport = await create_stack(
+        _msg_handler,
+        disable_qos=disable_qos,
+        disable_sending=disable_sending,
+        enforce_include_list=enforce_include_list,
+        exclude_list=exclude_list,
+        include_list=include_list,
+        **kwargs,
+    )
+
+    try:
+        await assert_stack_state(protocol, transport)
+    except serial.SerialException as err:
+        transport._close(err=err)
+        raise
+    except (AssertionError, asyncio.InvalidStateError, TimeoutError):
+        transport.close()
+        raise
+    else:
+        transport.close()
+
+
+async def _test_factories(
+    rf: VirtualRf,
+    /,
+    *,
+    protocol_factory_: Callable | None = None,
+    transport_factory_: Callable | None = None,
+    disable_qos: bool | None = False,
+    disable_sending: bool | None = False,
+    enforce_include_list: bool = False,
+    exclude_list: dict[DeviceIdT, dict] | None = None,
+    include_list: dict[DeviceIdT, dict] | None = None,
+    **kwargs,  # TODO: these are for the transport_factory
+) -> None:
+    protocol: RamsesProtocolT = protocol_factory(
+        _msg_handler,
+        disable_qos=disable_qos,
+        disable_sending=disable_sending,
+        enforce_include_list=enforce_include_list,
+        exclude_list=exclude_list,
+        include_list=include_list,
+    )
+    transport: RamsesTransportT = await transport_factory(
+        protocol,
+        disable_sending=disable_sending,
+        **kwargs,
+    )
+
+    try:
+        await assert_stack_state(protocol, transport)
+    except serial.SerialException as err:
+        transport._close(err=err)
+        raise
+    except (AssertionError, asyncio.InvalidStateError, TimeoutError):
+        transport.close()
+        raise
+    else:
+        transport.close()
+
+
+# ######################################################################################
+
+
+GWY_ID = "18:111111"
+OTH_ID = "18:123456"
+
+TEST_SUITE_GOOD = {
+    "00": {
+        "include_list": {},
+    },
+    "01": {
+        "enforce_include_list": True,
+        "include_list": {GWY_ID: {"class": "HGI"}},
+    },
+    "02": {
+        "enforce_include_list": True,
+        "include_list": {GWY_ID: {"class": "HGI"}, OTH_ID: {"class": "HGI"}},
+    },
+    "03": {
+        "enforce_include_list": True,
+        "include_list": {OTH_ID: {"class": "HGI"}, GWY_ID: {"class": "HGI"}},
+    },
+    "04": {
+        "enforce_include_list": True,
+        "include_list": {OTH_ID: {"class": "HGI"}},
+    },
+}
+TEST_SUITE_FAIL = {  # fails because exclude_list is checked before active_hgi
+    "10": {
+        "exclude_list": {GWY_ID: {"class": "HGI"}},
+    },
+    "11": {
+        "enforce_include_list": True,
+        "exclude_list": {GWY_ID: {"class": "HGI"}},
+        "include_list": {GWY_ID: {"class": "HGI"}},
+    },
+}
+
+
+@pytest.mark.xdist_group(name="virt_serial")
+@pytest.mark.parametrize("idx", TEST_SUITE_GOOD)
+async def test_create_stack(idx: str) -> None:
+    """Check that Transport calls Protocol.connection_made() correctly."""
+
+    rf = VirtualRf(2, start=True)
+    rf.set_gateway(rf.ports[0], GWY_ID, fw_type=HgiFwTypes.EVOFW3)
+
+    kwargs = {
+        "port_name": rf.ports[0],
+        "port_config": {},
+        "extra": {"virtual_rf": rf},
+    }
+
+    try:
+        await _test_create_stack(rf, **TEST_SUITE_GOOD[idx], **kwargs)
+    finally:
+        await rf.stop()
+
+
+@pytest.mark.xdist_group(name="virt_serial")
+@pytest.mark.parametrize("idx", TEST_SUITE_GOOD)
+async def test_create_s_alt(idx: str) -> None:
+    """Check that Transport calls Protocol.connection_made() correctly."""
+
+    rf = VirtualRf(2, start=True)
+    rf.set_gateway(rf.ports[0], GWY_ID, fw_type=HgiFwTypes.EVOFW3)
+
+    kwargs = {
+        "port_name": rf.ports[0],
+        "port_config": {},
+        "protocol_factory_": protocol_factory,
+        "transport_factory_": transport_factory,
+        "extra": {"virtual_rf": rf},
+    }
+
+    try:
+        await _test_create_stack(rf, **TEST_SUITE_GOOD[idx], **kwargs)
+    finally:
+        await rf.stop()
+
+
+@pytest.mark.xdist_group(name="virt_serial")
+@pytest.mark.parametrize("idx", TEST_SUITE_GOOD)
+async def test_factories_01(idx: str) -> None:
+    """Check that Transport calls Protocol.connection_made() correctly.
+
+    This is the method used by ramses_tf.gateway.py.
+    """
+
+    rf = VirtualRf(2, start=True)
+    rf.set_gateway(rf.ports[0], GWY_ID, fw_type=HgiFwTypes.EVOFW3)
+
+    kwargs = {
+        "port_name": rf.ports[0],
+        "port_config": {},
+        "extra": {"virtual_rf": rf},
+    }
+
+    try:
+        await _test_factories(rf, **TEST_SUITE_GOOD[idx], **kwargs)
+    finally:
+        await rf.stop()

--- a/tests/tests_rf/test_hgi_behaviors.py
+++ b/tests/tests_rf/test_hgi_behaviors.py
@@ -71,7 +71,7 @@ pytestmark = pytest.mark.asyncio(scope="module")
 @pytest.fixture(autouse=True)
 def patches_for_tests(monkeypatch: pytest.MonkeyPatch):
     monkeypatch.setattr(
-        "ramses_tx.protocol._DBG_DISABLE_DUTY_CYCLE_LIMIT",
+        "ramses_tx.transport._DBG_DISABLE_DUTY_CYCLE_LIMIT",
         _DBG_DISABLE_DUTY_CYCLE_LIMIT,
     )
     monkeypatch.setattr(

--- a/tests/tests_rf/test_hgi_behaviors.py
+++ b/tests/tests_rf/test_hgi_behaviors.py
@@ -21,10 +21,7 @@ from ramses_tx.typing import QosParams
 from tests_rf.virtual_rf import HgiFwTypes, VirtualRf
 
 # patched constants
-_DBG_DISABLE_DUTY_CYCLE_LIMIT = True  # #   ramses_tx.protocol
-_DBG_DISABLE_IMPERSONATION_ALERTS = True  # ramses_tx.protocol
 _DBG_DISABLE_STRICT_CHECKING = True  # #    ramses_tx.address
-_GAP_BETWEEN_WRITES = 0  # #          ramses_tx.transport
 
 # other constants
 ASSERT_CYCLE_TIME = 0.001  # max_cycles_per_assert = max_sleep / ASSERT_CYCLE_TIME
@@ -66,19 +63,6 @@ _global_failed_ports: list[str] = []
 # ### FIXTURES #########################################################################
 
 pytestmark = pytest.mark.asyncio(scope="module")
-
-
-@pytest.fixture(autouse=True)
-def patches_for_tests(monkeypatch: pytest.MonkeyPatch):
-    monkeypatch.setattr(
-        "ramses_tx.transport._DBG_DISABLE_DUTY_CYCLE_LIMIT",
-        _DBG_DISABLE_DUTY_CYCLE_LIMIT,
-    )
-    monkeypatch.setattr(
-        "ramses_tx.protocol._DBG_DISABLE_IMPERSONATION_ALERTS",
-        _DBG_DISABLE_IMPERSONATION_ALERTS,
-    )
-    monkeypatch.setattr("ramses_tx.protocol._GAP_BETWEEN_WRITES", _GAP_BETWEEN_WRITES)
 
 
 def pytest_generate_tests(metafunc: pytest.Metafunc):

--- a/tests/tests_rf/test_hgi_behaviors.py
+++ b/tests/tests_rf/test_hgi_behaviors.py
@@ -16,6 +16,7 @@ from serial.tools.list_ports import comports
 from ramses_rf import Command, Gateway
 from ramses_rf.device import HgiGateway
 from ramses_tx import exceptions as exc
+from ramses_tx.address import HGI_DEVICE_ID
 from ramses_tx.protocol import QosProtocol
 from ramses_tx.typing import QosParams
 from tests_rf.virtual_rf import HgiFwTypes, VirtualRf
@@ -27,7 +28,7 @@ _DBG_DISABLE_STRICT_CHECKING = True  # #    ramses_tx.address
 ASSERT_CYCLE_TIME = 0.001  # max_cycles_per_assert = max_sleep / ASSERT_CYCLE_TIME
 DEFAULT_MAX_SLEEP = 0.05  # 0.01/0.05 minimum for mocked (virtual RF)/actual
 
-HGI_ID_ = "18:000730"  # the sentinel value
+HGI_ID_ = HGI_DEVICE_ID  # the sentinel value
 TST_ID_ = "18:222222"  # a specific ID
 
 GWY_CONFIG = {
@@ -182,7 +183,7 @@ async def _test_gwy_device(gwy: Gateway, test_idx: str):
         # using gwy._protocol.send_cmd() instead of gwy.async_send_cmd() as the
         # latter may swallow the exception we wish to capture (ProtocolSendFailed)
         pkt = await gwy._protocol.send_cmd(
-            cmd, qos=QosParams(max_retries=0, wait_for_reply=False)
+            cmd, qos=QosParams(max_retries=0, wait_for_reply=False, timeout=0.5)
         )  # for this test, we only need the cmd echo
     except exc.ProtocolSendFailed:
         if is_hgi80 and cmd_str[7:16] != HGI_ID_:

--- a/tests/tests_rf/test_protocol_fsm.py
+++ b/tests/tests_rf/test_protocol_fsm.py
@@ -23,7 +23,6 @@ from ramses_tx import exceptions as exc
 from ramses_tx.protocol import QosProtocol, protocol_factory
 from ramses_tx.protocol_fsm import (
     Inactive,
-    IsFailed,
     IsInIdle,
     WantEcho,
     WantRply,
@@ -102,7 +101,7 @@ def prot_factory(disable_qos: bool | None = False):
             try:
                 await assert_protocol_state(protocol, IsInIdle, max_sleep=0)
                 await fnc(rf, protocol, *args, **kwargs)
-                await assert_protocol_state(protocol, (IsInIdle, IsFailed))
+                await assert_protocol_state(protocol, IsInIdle)
             except serial.SerialException as err:
                 transport._close(err=err)
                 raise

--- a/tests/tests_rf/test_protocol_fsm.py
+++ b/tests/tests_rf/test_protocol_fsm.py
@@ -337,6 +337,10 @@ async def _test_flow_401(
 
     assert await asyncio.gather(*tasks.values())
 
+    for i in numbers:
+        pkt = tasks[i].result()
+        assert pkt == Command.put_sensor_temp("03:123456", i)
+
 
 @prot_factory()
 async def _test_flow_402(

--- a/tests/tests_rf/test_protocol_fsm.py
+++ b/tests/tests_rf/test_protocol_fsm.py
@@ -35,7 +35,6 @@ from .virtual_rf import VirtualRf
 
 # patched constants
 DEFAULT_MAX_RETRIES = 0  # #                ramses_tx.protocol
-DEFAULT_TIMEOUT = 0.05  # #                 ramses_tx.protocol_fsm
 MAX_DUTY_CYCLE = 1.0  # #                   ramses_tx.protocol
 
 # other constants

--- a/tests/tests_rf/test_protocol_fsm.py
+++ b/tests/tests_rf/test_protocol_fsm.py
@@ -276,7 +276,7 @@ async def _test_flow_30x(
     # STEP 0: Setup...
     ser = serial.Serial(rf.ports[1])
 
-    qos = QosParams()
+    qos = QosParams(wait_for_reply=True)
 
     # STEP 1: Send an I cmd (no reply)...
     task = protocol._loop.create_task(

--- a/tests/tests_rf/test_protocol_fsm.py
+++ b/tests/tests_rf/test_protocol_fsm.py
@@ -21,7 +21,7 @@ import serial
 
 from ramses_rf import Command, Message, Packet
 from ramses_tx import exceptions as exc
-from ramses_tx.protocol import QosProtocol, protocol_factory
+from ramses_tx.protocol import PortProtocol, protocol_factory
 from ramses_tx.protocol_fsm import (
     Inactive,
     IsInIdle,
@@ -125,7 +125,7 @@ def prot_factory(disable_qos: bool | None = False):
 
 
 async def assert_protocol_state(
-    protocol: QosProtocol,
+    protocol: PortProtocol,
     expected_state: _ProtocolStateT,
     max_sleep: int = DEFAULT_MAX_SLEEP,
 ) -> None:
@@ -137,7 +137,7 @@ async def assert_protocol_state(
 
 
 def assert_protocol_state_detail(
-    protocol: QosProtocol, cmd: Command, num_sends: int
+    protocol: PortProtocol, cmd: Command, num_sends: int
 ) -> None:
     assert protocol._context.state.is_active_cmd(cmd)
     assert protocol._context.state.num_sends == num_sends
@@ -145,7 +145,7 @@ def assert_protocol_state_detail(
 
 
 async def async_pkt_received(
-    protocol: QosProtocol,
+    protocol: PortProtocol,
     pkt: Packet,
     method: int = 0,
     ser: None | serial.Serial = None,
@@ -179,7 +179,7 @@ async def async_pkt_received(
 @prot_factory()
 async def _test_flow_10x(
     rf: VirtualRf,
-    protocol: QosProtocol,
+    protocol: PortProtocol,
     rcvd_method: int = 0,
     min_sleeps: bool = None,
 ) -> None:
@@ -269,10 +269,7 @@ async def _test_flow_10x(
 
 
 @prot_factory()
-async def _test_flow_30x(
-    rf: VirtualRf,
-    protocol: QosProtocol,
-) -> None:
+async def _test_flow_30x(rf: VirtualRf, protocol: PortProtocol) -> None:
     # STEP 0: Setup...
     ser = serial.Serial(rf.ports[1])
 
@@ -322,10 +319,7 @@ async def _test_flow_30x(
 
 
 @prot_factory()
-async def _test_flow_401(
-    rf: VirtualRf,
-    protocol: QosProtocol,
-) -> None:
+async def _test_flow_401(rf: VirtualRf, protocol: PortProtocol) -> None:
     qos = QosParams(wait_for_reply=False)
 
     numbers = list(range(24))
@@ -343,10 +337,7 @@ async def _test_flow_401(
 
 
 @prot_factory()
-async def _test_flow_402(
-    rf: VirtualRf,
-    protocol: QosProtocol,
-) -> None:
+async def _test_flow_402(rf: VirtualRf, protocol: PortProtocol) -> None:
     qos = QosParams(wait_for_reply=False)
 
     numbers = list(range(24))
@@ -364,7 +355,7 @@ async def _test_flow_402(
 
 
 @prot_factory(disable_qos=False)
-async def _test_flow_qos(rf: VirtualRf, protocol: QosProtocol) -> None:
+async def _test_flow_qos(rf: VirtualRf, protocol: PortProtocol) -> None:
     #
     # ### Simple test for an I (does not expect any reply)...
 
@@ -433,7 +424,7 @@ async def _test_flow_qos(rf: VirtualRf, protocol: QosProtocol) -> None:
 
 
 @prot_factory()
-async def _test_flow_60x(rf: VirtualRf, protocol: QosProtocol, num_cmds=1) -> None:
+async def _test_flow_60x(rf: VirtualRf, protocol: PortProtocol, num_cmds=1) -> None:
     #
     # Setup...
     tasks = []

--- a/tests/tests_rf/test_protocol_fsm.py
+++ b/tests/tests_rf/test_protocol_fsm.py
@@ -35,12 +35,9 @@ from ramses_tx.typing import QosParams
 from .virtual_rf import VirtualRf
 
 # patched constants
-_DBG_DISABLE_IMPERSONATION_ALERTS = True  # ramses_tx.protocol
-_DBG_MAINTAIN_STATE_CHAIN = False  # #      ramses_tx.protocol_fsm
 DEFAULT_MAX_RETRIES = 0  # #                ramses_tx.protocol
 DEFAULT_TIMEOUT = 0.05  # #                 ramses_tx.protocol_fsm
 MAX_DUTY_CYCLE = 1.0  # #                   ramses_tx.protocol
-_GAP_BETWEEN_WRITES = 0  # #                ramses_tx.protocol
 
 # other constants
 CALL_LATER_DELAY = 0.001  # FIXME: this is hardware-specific
@@ -74,19 +71,6 @@ RP_PKT_1 = Packet(dt.now(), f"... {RP_CMD_STR_1}")
 
 
 # ### FIXTURES #########################################################################
-
-
-@pytest.fixture(autouse=True)
-def patches_for_tests(monkeypatch: pytest.MonkeyPatch):
-    monkeypatch.setattr(
-        "ramses_tx.protocol._DBG_DISABLE_IMPERSONATION_ALERTS",
-        _DBG_DISABLE_IMPERSONATION_ALERTS,
-    )
-    monkeypatch.setattr("ramses_tx.protocol._GAP_BETWEEN_WRITES", _GAP_BETWEEN_WRITES)
-    monkeypatch.setattr(
-        "ramses_tx.protocol_fsm._DBG_MAINTAIN_STATE_CHAIN",
-        _DBG_MAINTAIN_STATE_CHAIN,
-    )
 
 
 def prot_factory(disable_qos: bool | None = False):

--- a/tests/tests_rf/test_use_regex_wip.py
+++ b/tests/tests_rf/test_use_regex_wip.py
@@ -73,10 +73,11 @@ GWY_CONFIG = {
 def patches_for_tests(monkeypatch: pytest.MonkeyPatch):
     monkeypatch.setattr("ramses_tx.protocol._DBG_DISABLE_IMPERSONATION_ALERTS", True)
     monkeypatch.setattr("ramses_tx.transport._GAP_BETWEEN_WRITES", 0)
-    monkeypatch.setattr("ramses_tx.protocol_fsm.DEFAULT_TIMEOUT", 0.005)
 
 
-async def assert_this_pkt(gwy, expected: Command, max_sleep: int = DEFAULT_MAX_SLEEP):
+async def assert_this_pkt(
+    gwy: Gateway, expected: Command, max_sleep: int = DEFAULT_MAX_SLEEP
+):
     """Check, at the gateway layer, that the current packet is as expected."""
     for _ in range(int(max_sleep / ASSERT_CYCLE_TIME)):
         await asyncio.sleep(ASSERT_CYCLE_TIME)

--- a/tests/tests_rf/test_use_regex_wip.py
+++ b/tests/tests_rf/test_use_regex_wip.py
@@ -21,12 +21,6 @@ from ramses_tx.schemas import SZ_INBOUND, SZ_OUTBOUND, SZ_USE_REGEX
 from ramses_tx.transport import _str
 from tests_rf.virtual_rf import VirtualRf
 
-# patched constants
-_DBG_DISABLE_IMPERSONATION_ALERTS = True  # ramses_tx.protocol
-_DBG_DISABLE_QOS = True  # #                ramses_tx.protocol
-DEFAULT_TIMEOUT = 0.005  # #                  ramses_tx.protocol_fsm
-_GAP_BETWEEN_WRITES = 0  # #          ramses_tx.protocol
-
 # other constants
 ASSERT_CYCLE_TIME = 0.0005  # max_cycles_per_assert = max_sleep / ASSERT_CYCLE_TIME
 DEFAULT_MAX_SLEEP = 0.1
@@ -77,12 +71,9 @@ GWY_CONFIG = {
 
 @pytest.fixture(autouse=True)
 def patches_for_tests(monkeypatch: pytest.MonkeyPatch):
-    monkeypatch.setattr(
-        "ramses_tx.protocol._DBG_DISABLE_IMPERSONATION_ALERTS",
-        _DBG_DISABLE_IMPERSONATION_ALERTS,
-    )
-    monkeypatch.setattr("ramses_tx.protocol._GAP_BETWEEN_WRITES", _GAP_BETWEEN_WRITES)
-    monkeypatch.setattr("ramses_tx.protocol_fsm.DEFAULT_TIMEOUT", DEFAULT_TIMEOUT)
+    monkeypatch.setattr("ramses_tx.protocol._DBG_DISABLE_IMPERSONATION_ALERTS", True)
+    monkeypatch.setattr("ramses_tx.transport._GAP_BETWEEN_WRITES", 0)
+    monkeypatch.setattr("ramses_tx.protocol_fsm.DEFAULT_TIMEOUT", 0.005)
 
 
 async def assert_this_pkt(gwy, expected: Command, max_sleep: int = DEFAULT_MAX_SLEEP):

--- a/tests/tests_rf/test_use_regex_wip.py
+++ b/tests/tests_rf/test_use_regex_wip.py
@@ -16,7 +16,7 @@ import pytest
 import serial
 
 from ramses_rf import Command, Gateway, Packet
-from ramses_tx.protocol import QosProtocol
+from ramses_tx.protocol import PortProtocol
 from ramses_tx.schemas import SZ_INBOUND, SZ_OUTBOUND, SZ_USE_REGEX
 from ramses_tx.transport import _str
 from tests_rf.virtual_rf import VirtualRf
@@ -165,7 +165,7 @@ async def test_regex_with_qos():
     gwy_0 = Gateway(rf.ports[0], **config)
     ser_1 = serial.Serial(rf.ports[1])
 
-    if not isinstance(gwy_0._protocol, QosProtocol):
+    if not isinstance(gwy_0._protocol, PortProtocol) or not gwy_0._protocol._context:
         await rf.stop()
         pytest.skip("QoS protocol not enabled")
 

--- a/tests/tests_rf/test_use_regex_wip.py
+++ b/tests/tests_rf/test_use_regex_wip.py
@@ -72,7 +72,7 @@ GWY_CONFIG = {
 @pytest.fixture(autouse=True)
 def patches_for_tests(monkeypatch: pytest.MonkeyPatch):
     monkeypatch.setattr("ramses_tx.protocol._DBG_DISABLE_IMPERSONATION_ALERTS", True)
-    monkeypatch.setattr("ramses_tx.transport._GAP_BETWEEN_WRITES", 0)
+    monkeypatch.setattr("ramses_tx.transport.MINIMUM_WRITE_GAP", 0)
 
 
 async def assert_this_pkt(

--- a/tests/tests_rf/test_virt_network.py
+++ b/tests/tests_rf/test_virt_network.py
@@ -118,21 +118,21 @@ async def test_virtual_rf_dev_disc():
     await assert_devices(gwy_1, ["18:111111"])
 
     # TEST 1: Tx to all from GWY /dev/pty/0 (NB: no RSSI)
-    cmd = Command("RP --- 01:010000 --:------ 01:010000 1F09 003 0004B5")
+    cmd = Command(" I --- 01:010000 --:------ 01:010000 1F09 003 0004B5")
     gwy_0.send_cmd(cmd)
 
     await assert_devices(gwy_0, ["01:010000", "18:000000", "18:111111"])
     await assert_devices(gwy_1, ["01:010000", "18:111111"])
 
     # TEST 2: Tx to all from non-GWY /dev/pty/2 (NB: no RSSI)
-    cmd = Command("RP --- 01:011111 --:------ 01:011111 1F09 003 0004B5")
+    cmd = Command(" I --- 01:011111 --:------ 01:011111 1F09 003 0004B5")
     ser_2.write(bytes(f"{cmd}\r\n".encode("ascii")))
 
     await assert_devices(gwy_0, ["01:010000", "01:011111", "18:000000", "18:111111"])
     await assert_devices(gwy_1, ["01:010000", "01:011111", "18:111111"])
 
     # TEST 3: Rx only by *only one* GWY (NB: needs RSSI)
-    cmd = Command("RP --- 01:022222 --:------ 01:022222 1F09 003 0004B5")
+    cmd = Command(" I --- 01:022222 --:------ 01:022222 1F09 003 0004B5")
     list(rf._port_to_object.values())[1].write(bytes(f"000 {cmd}\r\n".encode("ascii")))
 
     await assert_devices(gwy_0, ["01:010000", "01:011111", "18:000000", "18:111111"])
@@ -164,7 +164,7 @@ async def test_virtual_rf_pkt_flow():
         gwy_0, "01:022222", Code._1F09, max_sleep=0, test_not=True
     )  # device wont exist
 
-    cmd = Command("RP --- 01:022222 --:------ 01:022222 1F09 003 0004B5")
+    cmd = Command(" I --- 01:022222 --:------ 01:022222 1F09 003 0004B5")
     gwy_0.send_cmd(cmd, num_repeats=1)
 
     await assert_devices(gwy_0, ["01:022222", "18:000000", "18:111111", "40:000000"])

--- a/tests/tests_rf/test_virt_network.py
+++ b/tests/tests_rf/test_virt_network.py
@@ -52,7 +52,7 @@ SCHEMA_1 = {
 @pytest.fixture(autouse=True)
 def patches_for_tests(monkeypatch: pytest.MonkeyPatch):
     monkeypatch.setattr(
-        "ramses_tx.protocol._DBG_DISABLE_DUTY_CYCLE_LIMIT",
+        "ramses_tx.transport._DBG_DISABLE_DUTY_CYCLE_LIMIT",
         _DBG_DISABLE_DUTY_CYCLE_LIMIT,
     )
     monkeypatch.setattr(

--- a/tests/tests_rf/test_virt_network.py
+++ b/tests/tests_rf/test_virt_network.py
@@ -17,11 +17,6 @@ import serial
 from ramses_rf import Code, Command, Device, Gateway
 from tests_rf.virtual_rf import VirtualRf, rf_factory
 
-# patched constants
-_DBG_DISABLE_DUTY_CYCLE_LIMIT = True  # #   ramses_tx.protocol
-_DBG_DISABLE_IMPERSONATION_ALERTS = True  # ramses_tx.protocol
-_GAP_BETWEEN_WRITES = 0  # #          ramses_tx.protocol
-
 # other constants
 ASSERT_CYCLE_TIME = 0.001  # max_cycles_per_assert = max_sleep / ASSERT_CYCLE_TIME
 DEFAULT_MAX_SLEEP = 1
@@ -44,25 +39,6 @@ SCHEMA_1 = {
     "orphans_hvac": ["41:111111"],
     "known_list": {"41:111111": {"class": "FAN"}},
 }
-
-
-# ### FIXTURES #########################################################################
-
-
-@pytest.fixture(autouse=True)
-def patches_for_tests(monkeypatch: pytest.MonkeyPatch):
-    monkeypatch.setattr(
-        "ramses_tx.transport._DBG_DISABLE_DUTY_CYCLE_LIMIT",
-        _DBG_DISABLE_DUTY_CYCLE_LIMIT,
-    )
-    monkeypatch.setattr(
-        "ramses_tx.protocol._DBG_DISABLE_IMPERSONATION_ALERTS",
-        _DBG_DISABLE_IMPERSONATION_ALERTS,
-    )
-    monkeypatch.setattr(
-        "ramses_tx.protocol._GAP_BETWEEN_WRITES",
-        _GAP_BETWEEN_WRITES,
-    )
 
 
 # ######################################################################################

--- a/tests/tests_rf/virtual_rf/__init__.py
+++ b/tests/tests_rf/virtual_rf/__init__.py
@@ -65,7 +65,7 @@ def _get_hgi_id_for_schema(schema: dict, port_idx: int) -> tuple[str, HgiFwTypes
     return hgi_id, fw_type
 
 
-@patch("ramses_tx.protocol._GAP_BETWEEN_WRITES", _GAP_BETWEEN_WRITES)
+@patch("ramses_tx.transport._GAP_BETWEEN_WRITES", _GAP_BETWEEN_WRITES)
 async def rf_factory(
     schemas: list[dict | None], start_gwys: bool = True
 ) -> tuple[VirtualRf, list[Gateway]]:

--- a/tests/tests_rf/virtual_rf/__init__.py
+++ b/tests/tests_rf/virtual_rf/__init__.py
@@ -16,7 +16,7 @@ from .virtual_rf import (
 # patched constants
 # _DBG_DISABLE_IMPERSONATION_ALERTS = True  # # ramses_tx.protocol
 # _DBG_DISABLE_QOS = False  # #                 ramses_tx.protocol
-_GAP_BETWEEN_WRITES = 0  # #              ramses_tx.protocol
+MINIMUM_WRITE_GAP = 0  # #              ramses_tx.protocol
 
 # other constants
 GWY_ID_0 = "18:000000"
@@ -65,7 +65,7 @@ def _get_hgi_id_for_schema(schema: dict, port_idx: int) -> tuple[str, HgiFwTypes
     return hgi_id, fw_type
 
 
-@patch("ramses_tx.transport._GAP_BETWEEN_WRITES", _GAP_BETWEEN_WRITES)
+@patch("ramses_tx.transport.MINIMUM_WRITE_GAP", MINIMUM_WRITE_GAP)
 async def rf_factory(
     schemas: list[dict | None], start_gwys: bool = True
 ) -> tuple[VirtualRf, list[Gateway]]:


### PR DESCRIPTION
Move elements of protocol and transport to more appropriate layers, for example:
 - duty cycle / min write gap moved down to transport layer
 - device id filtering moved up to protocol layer
 - Qos is now enabled by default (**QosProtocol** and **PortProtocol** merged)

Related changes:
 - tweak timers for above
 - refactor protocol FSM to be clearer / more robust
 - can now compare packets (as Rx'd) with commands (as Tx'd)

Add / refactor / bugfix tests for above.