### PR TITLE
Fix typing

### DIFF
--- a/src/ramses_rf/device/base.py
+++ b/src/ramses_rf/device/base.py
@@ -53,7 +53,7 @@ class DeviceBase(Entity):
     """The Device base class - can also be used for unknown device types."""
 
     _SLUG: str = DevType.DEV
-    _STATE_ATTR: str = None  # type: ignore[assignment]
+    _STATE_ATTR: str = None
 
     _bind_context: BindContext | None = None
 
@@ -73,7 +73,7 @@ class DeviceBase(Entity):
         self.addr = dev_addr
         self.type = dev_addr.type  # DEX  # TODO: remove this attr? use SLUG?
 
-        self._scheme: Vendor = None  # type: ignore[assignment]
+        self._scheme: Vendor = None
 
     def __str__(self) -> str:
         if self._STATE_ATTR:
@@ -411,7 +411,7 @@ class HgiGateway(Device):  # HGI (18:)
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
-        self.ctl = None  # type: ignore[assignment]  # FIXME: a mess
+        self.ctl = None  # FIXME: a mess
         self._child_id = "gw"  # TODO
         self.tcs = None
 
@@ -431,7 +431,7 @@ class DeviceHeat(Device):  # Heat domain: Honeywell CH/DHW or compatible
     def __init__(self, gwy: Gateway, dev_addr: Address, **kwargs: Any) -> None:
         super().__init__(gwy, dev_addr, **kwargs)
 
-        self.ctl = None  # type: ignore[assignment]
+        self.ctl = None
         self.tcs = None
         self._child_id = None  # domain_id, or zone_idx
 

--- a/src/ramses_rf/device/heat.py
+++ b/src/ramses_rf/device/heat.py
@@ -421,7 +421,7 @@ class UfhController(Parent, DeviceHeat):  # UFC (02):
             cmd = Command.get_zone_setpoint(self.id, ufc_idx)
             self._add_discovery_cmd(cmd, 60 * 60 * 6)
 
-        for ufc_idx in range(8):  # type: ignore[assignment]
+        for ufc_idx in range(8):
             payload = f"{ufc_idx:02X}{DEV_ROLE_MAP.UFH}"
             cmd = Command.from_attrs(RQ, self.id, Code._000C, payload)
             self._add_discovery_cmd(cmd, 60 * 60 * 24)
@@ -1396,7 +1396,7 @@ class UfhCircuit(Child, Entity):  # FIXME
      - `self.tcs.ctl`: the Evohome controller
     """
 
-    _SLUG: str = None  # type: ignore[assignment]
+    _SLUG: str = None
     _STATE_ATTR = None
 
     def __init__(self, ufc: UfhController, ufh_idx: str) -> None:
@@ -1412,7 +1412,7 @@ class UfhCircuit(Child, Entity):  # FIXME
         self._child_id = ufh_idx
 
         # TODO: _ctl should be: .ufc? .ctl?
-        self._ctl: Controller = None  # type: ignore[assignment]
+        self._ctl: Controller = None
         self._zone: Zone | None = None
 
     # def __str__(self) -> str:

--- a/src/ramses_rf/system/zones.py
+++ b/src/ramses_rf/system/zones.py
@@ -85,10 +85,10 @@ _LOGGER = logging.getLogger(__name__)
 class ZoneBase(Child, Parent, Entity):
     """The Zone/DHW base class."""
 
-    _SLUG: str = None  # type: ignore[assignment]
+    _SLUG: str = None
 
-    _ROLE_ACTUATORS: str = None  # type: ignore[assignment]
-    _ROLE_SENSORS: str = None  # type: ignore[assignment]
+    _ROLE_ACTUATORS: str = None
+    _ROLE_SENSORS: str = None
 
     def __init__(self, tcs: _MultiZoneT | _StoredHwT, zone_idx: str) -> None:
         super().__init__(tcs._gwy)
@@ -97,7 +97,7 @@ class ZoneBase(Child, Parent, Entity):
         self._z_id = tcs.id  # the responsible device is the controller
         self._z_idx: DevIndexT = zone_idx  # the zone idx (ctx), 00-0B (or 0F), HW (FA)
 
-        self.id: str = f"{tcs.id}_{zone_idx}"  # type: ignore[assignment]
+        self.id: str = f"{tcs.id}_{zone_idx}"
 
         self.tcs: Evohome = tcs
         self.ctl: Controller = tcs.ctl
@@ -457,7 +457,7 @@ class DhwZone(ZoneSchedule):  # CS92A
 class Zone(ZoneSchedule):
     """The Zone class for all zone types (but not DHW)."""
 
-    _SLUG: str = None  # type: ignore[assignment]
+    _SLUG: str = None
     _ROLE_ACTUATORS: str = DEV_ROLE_MAP.ACT
 
     def __init__(self, tcs: _MultiZoneT, zone_idx: str) -> None:

--- a/src/ramses_tx/const.py
+++ b/src/ramses_tx/const.py
@@ -158,10 +158,10 @@ class AttrDict(dict):  # type: ignore[type-arg]
     __delitem__ = __readonly
     __setitem__ = __readonly
     clear = __readonly
-    pop = __readonly  # type: ignore[assignment]
+    pop = __readonly
     popitem = __readonly
-    setdefault = __readonly  # type: ignore[assignment]
-    update = __readonly  # type: ignore[assignment]
+    setdefault = __readonly
+    update = __readonly
 
     del __readonly
 

--- a/tests/tests_rf/conftest.py
+++ b/tests/tests_rf/conftest.py
@@ -132,7 +132,7 @@ async def mqtt_evofw3_port() -> PortStrT:
     # We could mock the MQTT client at: patch("ramses_tx.transport.MqttTransport"
     pytest.skip("This test fixture requires an MQTT broker")
 
-    return "mqtt://mqtt_username:mqtt_passw0rd@127.0.0.1"
+    return "mqtt://mqtt_username:mqtt_passw0rd@127.0.0.1"  # type: ignore[unreachable]
 
 
 @pytest.fixture()  # TODO: remove HACK, below

--- a/tests/tests_rf/test_virt_network.py
+++ b/tests/tests_rf/test_virt_network.py
@@ -178,11 +178,11 @@ async def test_virtual_rf_dev_disc() -> None:
 
     try:
         rf.set_gateway(rf.ports[0], "18:000000")
-        gwy_0 = Gateway(rf.ports[0], **GWY_CONFIG)  # type: ignore[arg-type]
+        gwy_0 = Gateway(rf.ports[0], **GWY_CONFIG)
         await assert_devices(gwy_0, [])
 
         rf.set_gateway(rf.ports[1], "18:111111")
-        gwy_1 = Gateway(rf.ports[1], **GWY_CONFIG)  # type: ignore[arg-type]
+        gwy_1 = Gateway(rf.ports[1], **GWY_CONFIG)
         await assert_devices(gwy_1, [])
 
         await _test_virtual_rf_dev_disc(rf, gwy_0, gwy_1)

--- a/tests/tests_rf/virtual_rf/virtual_rf.py
+++ b/tests/tests_rf/virtual_rf/virtual_rf.py
@@ -322,7 +322,7 @@ class VirtualRfBase:
             signal.raise_signal(sig)
 
         _LOGGER.debug("Creating exception handler...")
-        self._loop.set_exception_handler(handle_exception)  # type: ignore[arg-type]
+        self._loop.set_exception_handler(handle_exception)
 
         _LOGGER.debug("Creating signal handlers...")
         if os.name == "posix":  # signal.SIGKILL people?


### PR DESCRIPTION
PR #151 seems to have broken typing in some way (in files untouched by PR).
`mypy v1.15.0` (dev-reqs minimum) as well as `mypy v1.16.0` (the version run on GitHub) show different errors when run locally, but the committed ignores were flagged as "unused" in GH Typing Action.

Copied to a clean branch, replaces PR #193 