### PR TITLE
Fix `blocking call to open(packet.log)` on HA `ramses_cc`

### DIFF
--- a/src/ramses_rf/gateway.py
+++ b/src/ramses_rf/gateway.py
@@ -169,8 +169,6 @@ class Gateway(Engine):
                 if system.dhw:
                     system.dhw._start_discovery_poller()
 
-        # HA issue: next method causes blocking call to open with args ('/config/ramses_esp/packetlog', 'a')
-        # Fix here <<< issue #200 (= ramses_cc issue 217)
         await set_pkt_logging_config(  # type: ignore[arg-type]
             cc_console=self.config.reduce_processing >= DONT_CREATE_MESSAGES,
             **self._packet_log,
@@ -184,7 +182,6 @@ class Gateway(Engine):
         load_schema(self, known_list=self._include, **self._schema)  # create faked too
 
         await super().start()  # TODO: do this *after* restore cache
-        # Fix here <<< issue #200 (= ramses_cc issue 217)
         if cached_packets:
             await self._restore_cached_packets(cached_packets)
 

--- a/src/ramses_rf/gateway.py
+++ b/src/ramses_rf/gateway.py
@@ -169,7 +169,9 @@ class Gateway(Engine):
                 if system.dhw:
                     system.dhw._start_discovery_poller()
 
-        set_pkt_logging_config(  # type: ignore[arg-type]
+        # HA issue: next method causes blocking call to open with args ('/config/ramses_esp/packetlog', 'a')
+        # Fix here <<< issue #200 (= ramses_cc issue 217)
+        await set_pkt_logging_config(  # type: ignore[arg-type]
             cc_console=self.config.reduce_processing >= DONT_CREATE_MESSAGES,
             **self._packet_log,
         )
@@ -182,6 +184,7 @@ class Gateway(Engine):
         load_schema(self, known_list=self._include, **self._schema)  # create faked too
 
         await super().start()  # TODO: do this *after* restore cache
+        # Fix here <<< issue #200 (= ramses_cc issue 217)
         if cached_packets:
             await self._restore_cached_packets(cached_packets)
 

--- a/src/ramses_tx/__init__.py
+++ b/src/ramses_tx/__init__.py
@@ -3,6 +3,9 @@
 
 from __future__ import annotations
 
+import asyncio
+from functools import partial
+
 from typing import TYPE_CHECKING, Any
 
 from .address import (
@@ -133,8 +136,13 @@ if TYPE_CHECKING:
     from logging import Logger
 
 
-def set_pkt_logging_config(**config: Any) -> Logger:
-    set_pkt_logging(PKT_LOGGER, **config)
+# HA issue: method causes blocking call to open with args ('/config/ramses_esp/packetlog', 'a')
+# Fix here <<< issue #200 (= ramses_cc issue 217) >> from .logger import set_pkt_logging
+async def set_pkt_logging_config(**config: Any) -> Logger:
+    # fix? Calling a blocking function
+    loop = asyncio.get_running_loop()
+    await loop.run_in_executor(None, partial(set_pkt_logging, PKT_LOGGER, **config))
+    # set_pkt_logging(PKT_LOGGER, **config)
     return PKT_LOGGER
 
 

--- a/src/ramses_tx/__init__.py
+++ b/src/ramses_tx/__init__.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 
 import asyncio
 from functools import partial
-
 from typing import TYPE_CHECKING, Any
 
 from .address import (
@@ -136,13 +135,16 @@ if TYPE_CHECKING:
     from logging import Logger
 
 
-# HA issue: method causes blocking call to open with args ('/config/ramses_esp/packetlog', 'a')
-# Fix here <<< issue #200 (= ramses_cc issue 217) >> from .logger import set_pkt_logging
 async def set_pkt_logging_config(**config: Any) -> Logger:
-    # fix? Calling a blocking function
+    """
+    Set up ramses packet logging to a file or port.
+    Must runs async in executor to prevent HA blocking call opening packet log file (issue #200)
+
+    :param config: if file_name is included, opens packet_log file
+    :return: a logging.Logger
+    """
     loop = asyncio.get_running_loop()
     await loop.run_in_executor(None, partial(set_pkt_logging, PKT_LOGGER, **config))
-    # set_pkt_logging(PKT_LOGGER, **config)
     return PKT_LOGGER
 
 

--- a/src/ramses_tx/logger.py
+++ b/src/ramses_tx/logger.py
@@ -262,7 +262,6 @@ def set_pkt_logging(
     - backup_count: keep this many copies, and rotate at midnight unless:
     - max_bytes:    rotate log files when log > rotate_size
     """
-
     logger.propagate = False  # log file is distinct from any app/debug logging
     logger.setLevel(logging.DEBUG)  # must be at least .INFO
 
@@ -271,6 +270,8 @@ def set_pkt_logging(
         logger.removeHandler(handler)
 
     if file_name:
+        # HA issue: this method causes blocking call to open with args ('/config/ramses_esp/packetlog', 'a')
+        # Fix here if not working in gateway <<< issue #200 (= ramses_cc issue 217) >> python.logging.FileHandler
         if rotate_bytes:
             rotate_backups = rotate_backups or 2
             handler = logging.handlers.RotatingFileHandler(

--- a/src/ramses_tx/logger.py
+++ b/src/ramses_tx/logger.py
@@ -259,9 +259,11 @@ def set_pkt_logging(
     """Create/configure handlers, formatters, etc.
 
     Parameters:
-    - backup_count: keep this many copies, and rotate at midnight unless:
-    - max_bytes:    rotate log files when log > rotate_size
+    - file_name:      base of file to store packet logs in, from root
+    - rotate_backups: keep this many copies, and rotate at midnight unless:
+    - rotate_bytes:   rotate log files when log > rotate_size
     """
+
     logger.propagate = False  # log file is distinct from any app/debug logging
     logger.setLevel(logging.DEBUG)  # must be at least .INFO
 
@@ -269,9 +271,7 @@ def set_pkt_logging(
     for handler in logger.handlers:  # dont use logger.hasHandlers() as not propagating
         logger.removeHandler(handler)
 
-    if file_name:
-        # HA issue: this method causes blocking call to open with args ('/config/ramses_esp/packetlog', 'a')
-        # Fix here if not working in gateway <<< issue #200 (= ramses_cc issue 217) >> python.logging.FileHandler
+    if file_name:  # note: this opens the packet_log file IO and may block
         if rotate_bytes:
             rotate_backups = rotate_backups or 2
             handler = logging.handlers.RotatingFileHandler(


### PR DESCRIPTION
Run async `set_pkt_logging_config()` in one place.
Fixes issue #200 and [ramses_cc issue 217](https://github.com/zxdavb/ramses_cc/issues/217).
Confirmed on local HA.

Trace:
```
/config/custom_components/ramses_cc/broker.py, line 146: async_setup await self.client.start()
-> /ramses_rf/src/ramses_rf/gateway.py, line 149: async def start()
-> /ramses_rf/src/ramses_rf/gateway.py, line 172: set_pkt_logging_config()
-> /ramses_rf/src/ramses_tx/__init__.py, line 138: def set_pkt_logging_config()  <<<< fix is here
-> /ramses_rf/src/ramses_tx/logger.py, line 252: set_pkt_logging()
-> /usr/local/lib/python3.13/logging/__init__.py, line 1190: new FileHandler
FileHandler will start to emit() once set up, triggering line 1442: _open()
-> /usr/local/lib/python3.13/logging/__init__.py, line 1247: open_func()
blocking as flagged by HA
```