### PR TITLE
GH workflow publish hatch

### DIFF
--- a/.github/workflows/publish-hatch.yml
+++ b/.github/workflows/publish-hatch.yml
@@ -31,12 +31,11 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements.txt
+          python -m pip install build
 
       - name: Build package
         run:
-          python -m pip install build
           python -m build
-      # must install build to run
 
       - name: Publish package
         uses: pypa/gh-action-pypi-publish@76f52bc884231f62b9a034ebfe128415bbaabdfc

--- a/.github/workflows/publish-hatch.yml
+++ b/.github/workflows/publish-hatch.yml
@@ -30,17 +30,17 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -r requirements.txt
+          python -m pip install -r requirements.txt
           python -m pip install build
 
       - name: Build package
         run:
           python -m build
 
-      - name: Publish package
-        uses: pypa/gh-action-pypi-publish@76f52bc884231f62b9a034ebfe128415bbaabdfc
-        with:
-          user: __token__
-          password: ${{ secrets.PYPI_API_TOKEN }}
+      # - name: Publish package
+        # uses: pypa/gh-action-pypi-publish@76f52bc884231f62b9a034ebfe128415bbaabdfc
+        # with:
+        #   user: __token__
+        #   password: ${{ secrets.PYPI_API_TOKEN }}
 
       - run: echo "🍏 This job's status is ${{ job.status }}."

--- a/.github/workflows/publish-hatch.yml
+++ b/.github/workflows/publish-hatch.yml
@@ -1,6 +1,6 @@
-# This workflow will upload a Python Package using Twine when a release is created
+# This workflow will upload a Python Package using Hatch when a release is created
 # For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-python#publishing-to-package-registries
-
+# and: https://github.com/pypa/hatch/issues/669
 name: Publish via Hatch
 
 on:
@@ -14,31 +14,20 @@ jobs:
   build-and-deploy:
     runs-on: ubuntu-latest
 
-    strategy:
-      fail-fast: false
-      matrix:
-        python-version: ["3.13"]
-
     steps:
       - uses: actions/checkout@v4
 
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
-        with:
-          python-version: ${{ matrix.python-version }}
+      - name: Install hatch
+        run: pipx install hatch
 
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          python -m pip install -r requirements.txt
-          python -m pip install build
+      - name: Run tests
+        run: hatch run test:test
 
-      - name: Build package
-        run:
-          python -m build
+      - name: Build dist
+        run: hatch build
 
-      # - name: Publish package
-        # uses: pypa/gh-action-pypi-publish@76f52bc884231f62b9a034ebfe128415bbaabdfc
+      # - name: Publish on PyPi
+        # run: hatch publish
         # with:
         #   user: __token__
         #   password: ${{ secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/publish-hatch.yml
+++ b/.github/workflows/publish-hatch.yml
@@ -1,6 +1,7 @@
 # This workflow will upload a Python Package using Hatch when a release is created
 # For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-python#publishing-to-package-registries
 # and: https://github.com/pypa/hatch/issues/669
+
 name: Publish via Hatch
 
 on:

--- a/.github/workflows/publish-hatch.yml
+++ b/.github/workflows/publish-hatch.yml
@@ -8,6 +8,9 @@ on:
   release:
     types: [published]
 
+  workflow_dispatch:
+  # for testing hatch
+
 permissions:
   contents: read
 

--- a/src/ramses_rf/version.py
+++ b/src/ramses_rf/version.py
@@ -1,4 +1,4 @@
 """RAMSES RF - a RAMSES-II protocol decoder & analyser (application layer)."""
 
-__version__ = "0.51.0"
+__version__ = "0.51.1"
 VERSION = __version__

--- a/src/ramses_rf/version.py
+++ b/src/ramses_rf/version.py
@@ -1,4 +1,4 @@
 """RAMSES RF - a RAMSES-II protocol decoder & analyser (application layer)."""
 
-__version__ = "0.50.2"
+__version__ = "0.51.0"
 VERSION = __version__

--- a/src/ramses_tx/version.py
+++ b/src/ramses_tx/version.py
@@ -1,4 +1,4 @@
 """RAMSES RF - a RAMSES-II protocol decoder & analyser (transport layer)."""
 
-__version__ = "0.51.0"
+__version__ = "0.51.1"
 VERSION = __version__

--- a/src/ramses_tx/version.py
+++ b/src/ramses_tx/version.py
@@ -1,4 +1,4 @@
 """RAMSES RF - a RAMSES-II protocol decoder & analyser (transport layer)."""
 
-__version__ = "0.50.2"
+__version__ = "0.51.0"
 VERSION = __version__


### PR DESCRIPTION
Set up workflow step to publish a new release to use `hatch`, not `python build`.
Actual Publish step commented out until Hatch step is working.