### PR TITLE
Fix `client parse` value_error

### DIFF
--- a/src/ramses_rf/gateway.py
+++ b/src/ramses_rf/gateway.py
@@ -11,7 +11,6 @@ from __future__ import annotations
 
 import asyncio
 import logging
-from io import TextIOWrapper
 from types import SimpleNamespace
 from typing import TYPE_CHECKING, Any
 
@@ -89,7 +88,7 @@ class Gateway(Engine):
     def __init__(
         self,
         port_name: str | None,
-        input_file: TextIOWrapper | None = None,
+        input_file: str | None = None,
         port_config: PortConfigT | None = None,
         packet_log: PktLogConfigT | None = None,
         block_list: DeviceListT | None = None,

--- a/src/ramses_tx/gateway.py
+++ b/src/ramses_tx/gateway.py
@@ -12,7 +12,6 @@ import asyncio
 import logging
 from collections.abc import Callable
 from datetime import datetime as dt
-from io import TextIOWrapper
 from threading import Lock
 from typing import TYPE_CHECKING, Any, Never
 
@@ -74,7 +73,7 @@ class Engine:
     def __init__(
         self,
         port_name: str | None,
-        input_file: TextIOWrapper | None = None,
+        input_file: str | None = None,
         port_config: PortConfigT | None = None,
         packet_log: PktLogConfigT | None = None,
         block_list: DeviceListT | None = None,
@@ -189,7 +188,7 @@ class Engine:
             pkt_source[SZ_PORT_NAME] = self.ser_name
             pkt_source[SZ_PORT_CONFIG] = self._port_config
         else:  # if self._input_file:
-            pkt_source[SZ_PACKET_LOG] = self._input_file  # io.TextIOWrapper
+            pkt_source[SZ_PACKET_LOG] = self._input_file  # filename as string
 
         # incl. await protocol.wait_for_connection_made(timeout=5)
         self._transport = await transport_factory(

--- a/src/ramses_tx/transport.py
+++ b/src/ramses_tx/transport.py
@@ -781,7 +781,7 @@ class FileTransport(_ReadTransport, _FileTransportAbstractor):
                 self._frame_read(dtm_str, pkt_line)
                 # await asyncio.sleep(0)  # NOTE: big performance penalty if delay >0
 
-        elif isinstance(self._pkt_source, str):  # file_name + ...
+        elif isinstance(self._pkt_source, str):  # file_name, used in client parse
             # open file file_name before reading
             try:
                 with fileinput.input(files=self._pkt_source, encoding="utf-8") as file:
@@ -798,7 +798,7 @@ class FileTransport(_ReadTransport, _FileTransportAbstractor):
                         # await asyncio.sleep(0)  # NOTE: big performance penalty if delay >0
             except FileNotFoundError as err:
                 _LOGGER.warning(f"Correct the packet file name; {err}")
-        elif isinstance(self._pkt_source, TextIOWrapper):  # used in tests
+        elif isinstance(self._pkt_source, TextIOWrapper):  # used by client monitor
             for dtm_pkt_line in self._pkt_source:  # should check dtm_str is OK
                 while not self._reading:
                     await asyncio.sleep(0.001)

--- a/src/ramses_tx/typing.py
+++ b/src/ramses_tx/typing.py
@@ -4,7 +4,6 @@
 import asyncio
 from collections.abc import Callable
 from datetime import datetime as dt
-from io import TextIOWrapper
 from typing import Any, Protocol, TypeVar
 
 from serial import Serial  # type: ignore[import-untyped]
@@ -105,7 +104,7 @@ class xRamsesTransportT(Protocol):
     def __init__(  # type: ignore[no-any-unimported]
         self,
         protocol: asyncio.Protocol,
-        pkt_source: Serial | dict[str, str] | TextIOWrapper,
+        pkt_source: Serial | dict[str, str] | str,
         loop: asyncio.AbstractEventLoop | None = None,
         extra: dict[str, Any] | None = None,
         **kwargs: Any,

--- a/tests/deprecated/mocked_devices/transport.py
+++ b/tests/deprecated/mocked_devices/transport.py
@@ -15,7 +15,6 @@ from __future__ import annotations
 import asyncio
 import logging
 from datetime import datetime as dt
-from io import TextIOWrapper
 from queue import Empty, Full, PriorityQueue
 from typing import Callable
 
@@ -222,7 +221,7 @@ def create_pkt_stack(  # to use a mocked Serial port (and a sympathetic Transpor
     protocol_factory: Callable[[], _PacketProtocolT] = None,
     port_name: str = None,
     port_config: dict = None,
-    packet_log: TextIOWrapper = None,
+    packet_log: str = None,  # just the file path, must open
     packet_dict: dict = None,
 ) -> tuple[_PacketProtocolT, _PacketTransportT]:
     """Return a mocked packet stack.

--- a/tests/tests/test_cli_utility.py
+++ b/tests/tests/test_cli_utility.py
@@ -89,14 +89,17 @@ LIB_CONFIG_LISTEN_ = {
 LIB_CONFIG_PARSE__ = {
     "config": {"reduce_processing": 0},
     "input_file": "-",  # will be replaced by sys.stdin by fileinput
-    # was: "input_file": "<_io.TextIOWrapper name='<stdin>' mode='r' encoding='utf-8'>",
 }
 
 BASIC_TESTS = (  # can't use "-z"
     (["client.py", "execute", "/dev/ttyUSB0"], CLI_CONFIG_EXECUTE, LIB_CONFIG_EXECUTE),
     (["client.py", "monitor", "/dev/ttyUSB0"], CLI_CONFIG_MONITOR, LIB_CONFIG_MONITOR),
     (["client.py", "listen", "/dev/ttyUSB0"], CLI_CONFIG_LISTEN_, LIB_CONFIG_LISTEN_),
-    (["client.py", "parse"], CLI_CONFIG_PARSE__, LIB_CONFIG_PARSE__),
+    (
+        ["client.py", "parse", "filename-stand_in"],
+        CLI_CONFIG_PARSE__,
+        LIB_CONFIG_PARSE__,
+    ),
 )
 
 

--- a/tests/tests/test_cli_utility.py
+++ b/tests/tests/test_cli_utility.py
@@ -88,7 +88,7 @@ LIB_CONFIG_LISTEN_ = {
 }
 LIB_CONFIG_PARSE__ = {
     "config": {"reduce_processing": 0},
-    "input_file": "-",  # will be replaced by sys.stdin by fileinput()
+    "input_file": "-",  # will be replaced by sys.stdin by fileinput
     # was: "input_file": "<_io.TextIOWrapper name='<stdin>' mode='r' encoding='utf-8'>",
 }
 

--- a/tests/tests/test_cli_utility.py
+++ b/tests/tests/test_cli_utility.py
@@ -88,7 +88,8 @@ LIB_CONFIG_LISTEN_ = {
 }
 LIB_CONFIG_PARSE__ = {
     "config": {"reduce_processing": 0},
-    "input_file": "<_io.TextIOWrapper name='<stdin>' mode='r' encoding='utf-8'>",
+    "input_file": "-",  # will be replaced by sys.stdin by fileinput()
+    # was: "input_file": "<_io.TextIOWrapper name='<stdin>' mode='r' encoding='utf-8'>",
 }
 
 BASIC_TESTS = (  # can't use "-z"


### PR DESCRIPTION
Fixes #215 
The parse file stream opened by click was closed before arriving at the client (identified by asserts along the way).
By passing the name/path as `str` and only opening (and closing) the read stream in the `client parse` routine, this is prevented.
The `client monitor` option still used TextIOWrapper, so it is still handled in transport.py