### PR TITLE
Fix: Param rounding, Add param `2411` - 4B Bypass

### DIFF
--- a/src/ramses_tx/command.py
+++ b/src/ramses_tx/command.py
@@ -2109,9 +2109,9 @@ class Command(Frame):
             elif (str(data_type) == "00") or (
                 str(data_type) == "10"
             ):  # numeric (minutes, medium(0)/high(1) or days)
-                value_scaled = int(value)
-                min_val_scaled = int(min_val)
-                max_val_scaled = int(max_val)
+                value_scaled = int(float(value))
+                min_val_scaled = int(float(min_val))
+                max_val_scaled = int(float(max_val))
                 precision = 1
                 precision_scaled = int(precision)
                 trailer = (

--- a/src/ramses_tx/ramses.py
+++ b/src/ramses_tx/ramses.py
@@ -1267,7 +1267,7 @@ _22F1_SCHEMES: dict[str, dict[str, str]] = {
 
 # unclear if true for only Orcon/*all* models
 _2411_PARAMS_SCHEMA: dict[str, dict[str, Any]] = {
-    "31": {  # slot 09
+    "31": {  # slot 09 (FANs produced after 2021)
         SZ_DESCRIPTION: "Time to change filter (days)",
         SZ_MIN_VALUE: 0,
         SZ_MAX_VALUE: 1800,
@@ -1338,6 +1338,14 @@ _2411_PARAMS_SCHEMA: dict[str, dict[str, Any]] = {
         SZ_PRECISION: 0.005,
         SZ_DATA_TYPE: "0F",
         SZ_DATA_UNIT: "%",
+    },
+    "4B": {  # slot 09 (FANs produced before 2021) Also check code 22F7
+        SZ_DESCRIPTION: "(Test) Bypass Valve (0=auto, 1=open, 2=closed)",
+        SZ_MIN_VALUE: 0,
+        SZ_MAX_VALUE: 2,
+        SZ_PRECISION: 1,
+        SZ_DATA_TYPE: "00",
+        SZ_DATA_UNIT: "",
     },
     "4E": {  # slot 0A
         SZ_DESCRIPTION: "Moisture scenario position (0=medium, 1=high)",


### PR DESCRIPTION
- Added support for 2411 - 4B (Test) Bypass position.
Works with (Orcon) FAN produced before 2021, but also still for newer models.
In the manual it reads 'test' but you can actually get/set the bypass position.
There are multiple ways to get the actual position, so when relying on the 2411 info, one should run get_fan_param or update_fan_params, or better, check the 22F7 code when available since this is being polled automatically (and 2411 is not).
- fixed rounding issue for '00' data_type