### PR TITLE
Feature/refactor 2411 params storage

### DIFF
--- a/src/ramses_rf/device/hvac.py
+++ b/src/ramses_rf/device/hvac.py
@@ -627,6 +627,8 @@ class HvacVentilator(FilterChange):  # FAN: RP/31DA, I/31D[9A], 2411
         # Normalize the value if needed
         if param_id == "75" and isinstance(param_value, (int, float)):
             param_value = round(float(param_value), 1)
+        elif param_id in ("52", "95"):  # Percentage parameters
+            param_value = round(float(param_value), 3)  # Keep precision for percentages
 
         # Store in params
         old_value = self.get_2411_param(param_id)
@@ -640,10 +642,6 @@ class HvacVentilator(FilterChange):  # FAN: RP/31DA, I/31D[9A], 2411
             old_value,
             self.id,
         )
-
-        # Round parameter 75 values to 1 decimal place
-        if param_id == "75" and isinstance(param_value, int | float):
-            param_value = round(float(param_value), 1)
 
         # call the 2411 parameter update callback
         self._handle_param_update(param_id, param_value)

--- a/tests/test_hvac_ventilator.py
+++ b/tests/test_hvac_ventilator.py
@@ -115,7 +115,7 @@ class TestHvacVentilator:
         msg.payload = {"parameter": TEST_PARAM_ID, "value": TEST_PARAM_VALUE}
 
         # Set up the message store
-        hvac_ventilator._msgs_ = {}
+        hvac_ventilator._params_2411 = {}
 
         # Set up the param update callback
         mock_callback = MagicMock()
@@ -128,8 +128,8 @@ class TestHvacVentilator:
         assert hvac_ventilator._supports_2411 is True
 
         # Check that the message was stored correctly
-        assert Code._2411 in hvac_ventilator._msgs
-        assert f"{Code._2411}_{TEST_PARAM_ID}" in hvac_ventilator._msgs
+        assert TEST_PARAM_ID in hvac_ventilator._params_2411
+        assert hvac_ventilator._params_2411[TEST_PARAM_ID] == TEST_PARAM_VALUE
 
         # Check that the callback was called with the correct parameters
         mock_callback.assert_called_once_with(TEST_PARAM_ID, TEST_PARAM_VALUE)
@@ -285,14 +285,8 @@ class TestHvacVentilator:
 
     def test_get_fan_param_supported(self, hvac_ventilator: HvacVentilator) -> None:
         """Test getting a supported fan parameter."""
-        # Set up a mock message in the device's message store
-        msg = MagicMock()
-        msg.code = Code._2411
-        msg.payload = {"parameter": TEST_PARAM_ID, "value": TEST_PARAM_VALUE}
-
-        # Use the message store properly
-        hvac_ventilator._msgs[Code._2411] = msg
-        hvac_ventilator._msgs[f"{Code._2411}_{TEST_PARAM_ID}"] = msg  # type: ignore[index]
+        # Set up the parameter in the device's parameter store
+        hvac_ventilator._params_2411[TEST_PARAM_ID] = TEST_PARAM_VALUE
 
         # Mark as supporting 2411
         hvac_ventilator._supports_2411 = True
@@ -315,14 +309,9 @@ class TestHvacVentilator:
 
     def test_get_fan_param_normalization(self, hvac_ventilator: HvacVentilator) -> None:
         """Test parameter ID normalization."""
-        # Set up a mock message with a parameter that has leading zeros
-        msg = MagicMock()
-        msg.code = Code._2411
-        msg.payload = {"parameter": "03F", "value": 75}
-
-        # Use the message store properly
-        hvac_ventilator._msgs[Code._2411] = msg
-        hvac_ventilator._msgs[f"{Code._2411}_3F"] = msg  # type: ignore[index]
+        # Set up the parameter with leading zeros in the parameter store
+        # The get_fan_param method normalizes "03F" to "3F"
+        hvac_ventilator._params_2411["3F"] = 75
         hvac_ventilator._supports_2411 = True
 
         # Test with different formats of the same parameter ID


### PR DESCRIPTION
Added a simple _params_2411 dict to hvac devices.
Removed references in param methods to the old message storage (_msgs).
On reset or clear cache, the dict is initialized again. A discovery msg is sent (param 3F) to hvac devices. On a valid response, all values for known parameters are requested and the dict and entities are updated.
No dateTime is registered since these are config values.