### PR TITLE
Fix `PacketPayloadInvalid` warnings for empty payloads during initialization

### DIFF
--- a/src/ramses_tx/message.py
+++ b/src/ramses_tx/message.py
@@ -485,6 +485,10 @@ def _check_msg_payload(msg: MessageBase, payload: str) -> None:
     if not regex:
         raise exc.PacketInvalid(f"Unknown verb/code pair: {msg.verb}/{msg.code}")
 
+    # Bypass strict regex validation if the payload is functionally empty ("00")
+    if not msg._has_payload:
+        return
+
     if not re_compile_re_match(str(regex), payload):
         raise exc.PacketPayloadInvalid(
             f"Payload doesn't match {msg.verb}/{msg.code}: {payload} != {regex}"

--- a/tests/tests_tx/test_message.py
+++ b/tests/tests_tx/test_message.py
@@ -2,6 +2,7 @@
 """Test the Message class and its exposed attributes, including RSSI."""
 
 from datetime import datetime as dt
+from typing import Any
 
 import pytest
 
@@ -11,9 +12,10 @@ from ramses_tx.packet import Packet
 # Constants for testing frames
 FRAME_STR_1 = "045 RQ --- 18:006402 13:049798 --:------ 1FC9 001 00"
 FRAME_STR_2 = "095  I --- 01:145038 --:------ 01:145038 1F09 003 0004B5"
+FRAME_STR_EMPTY = "045 RP --- 37:153226 29:123160 --:------ 2411 001 00"
 
 
-@pytest.fixture(autouse=True)
+@pytest.fixture
 def patch_parsers(monkeypatch: pytest.MonkeyPatch) -> None:
     """Mock out payload validation and parsing for isolated testing.
 
@@ -29,9 +31,11 @@ def patch_parsers(monkeypatch: pytest.MonkeyPatch) -> None:
     )
 
 
-def test_message_attributes() -> None:
+def test_message_attributes(patch_parsers: Any) -> None:
     """Test that the Message class correctly surfaces basic attributes and RSSI.
 
+    :param patch_parsers: The mock fixture for parsers.
+    :type patch_parsers: Any
     :return: None
     """
     dtm = dt(2023, 1, 1, 12, 0, 0)
@@ -51,9 +55,11 @@ def test_message_attributes() -> None:
     assert message._has_payload is False
 
 
-def test_message_parsing_and_rssi() -> None:
+def test_message_parsing_and_rssi(patch_parsers: Any) -> None:
     """Test that a different frame correctly sets RSSI and parses payload.
 
+    :param patch_parsers: The mock fixture for parsers.
+    :type patch_parsers: Any
     :return: None
     """
     dtm = dt.now()
@@ -70,9 +76,11 @@ def test_message_parsing_and_rssi() -> None:
     assert message.payload.get("mock_key") == "mock_val"
 
 
-def test_message_equality_and_comparison() -> None:
+def test_message_equality_and_comparison(patch_parsers: Any) -> None:
     """Test the equality and less-than operators of the Message class.
 
+    :param patch_parsers: The mock fixture for parsers.
+    :type patch_parsers: Any
     :return: None
     """
     dtm1 = dt(2023, 1, 1, 12, 0, 0)
@@ -94,9 +102,11 @@ def test_message_equality_and_comparison() -> None:
     assert msg1 < msg3
 
 
-def test_message_string_representations() -> None:
+def test_message_string_representations(patch_parsers: Any) -> None:
     """Test the string and repr outputs of the Message class.
 
+    :param patch_parsers: The mock fixture for parsers.
+    :type patch_parsers: Any
     :return: None
     """
     dtm = dt(2023, 1, 1, 12, 0, 0)
@@ -111,3 +121,21 @@ def test_message_string_representations() -> None:
     assert "18:006402" in msg_str
     assert "13:049798" in msg_str
     assert "RQ" in msg_str
+
+
+def test_startup_empty_payload_reproduction() -> None:
+    """Test that an empty payload bypasses strict regex and parses safely.
+
+    This test confirms the fix: functionally empty payloads ("00")
+    no longer raise PacketPayloadInvalid.
+
+    :return: None
+    """
+    dtm = dt.now()
+    packet = Packet(dtm, FRAME_STR_EMPTY)
+
+    # With the fix applied, this should instantiate without raising an exception
+    message = Message(packet)
+
+    assert message._has_payload is False
+    assert message.len == 1


### PR DESCRIPTION
Fixes #565

### The Problem:

During Home Assistant startup ("init calls"), the gateway sends and receives numerous query and response packets with functionally empty payloads (e.g., `"00"`). The recent typing and validation refactor in `_check_msg_payload` routes all packets through strict regex validation based on `CODES_SCHEMA`. Because `"00"` does not match the structural regexes designed for fully populated parameters (like `2411` or `31E0`), it raises `PacketPayloadInvalid` exceptions, resulting in log spam.

### Consequences:

If left unfixed, users will experience significant and confusing warning log spam every time Home Assistant restarts or the gateway initializes. It also adds unnecessary processing overhead as the system repeatedly catches and logs these expected exceptions.

### The Fix:

Bypassed the strict regex validation step in `_check_msg_payload` exclusively for packets that do not contain a functional payload.

### Technical Implementation:

Added a guard clause (`if not msg._has_payload: return`) immediately before the `re_compile_re_match` execution in `src/ramses_tx/message.py`. This explicitly separates the concept of validating the *structure* of data from the reality of handling protocol nulls.

### Testing Performed:

Added `test_startup_empty_payload_reproduction` in `tests/tests_tx/test_message.py`. This test mocks an initialization packet with an empty `"00"` payload that previously failed regex validation. The test asserts that the packet safely instantiates, bypassing the exception, and correctly sets `_has_payload` to `False` with a length of `1`.

### Risks of NOT Implementing:

Maintainers and users will be distracted by false-positive warnings in the logs, potentially masking actual malformed payload errors that the system needs to catch.

### Risks of Implementing:

The risk is extremely low. There is a theoretical edge case where a severely malformed 1-byte packet might bypass the regex. However, it will still be caught gracefully by the downstream `parse_payload()` step.

### Mitigation Steps:

Relied on the existing architecture: if a packet bypasses the regex but contains unparsable parameters, the downstream parsers still catch it and log a safe, descriptive warning rather than crashing the integration.

### AI Assistance Disclosure:

This contribution was developed with the assistance of Google Gemini 3.1 Pro for code generation and documentation. No Agentic AI systems were employed; all logic and implementations were reviewed, verified, and manually committed by the author.