### PR TITLE
Fix ValueError in `parser_31e0` for empty CO2 sensor payloads (Issue #570)

### DIFF
--- a/src/ramses_tx/parsers.py
+++ b/src/ramses_tx/parsers.py
@@ -3169,6 +3169,10 @@ def parser_31e0(payload: str, msg: Message) -> dict | list[dict]:  # TODO: only 
     :raises AssertionError: If the payload suffix is not a recognized constant.
     """
 
+    # guard clause to return an empty dictionary when receiving a "00" payload
+    if payload == "00":
+        return {}
+
     # coding note:
     # case 0x31E0:  ' 12768:
     # {


### PR DESCRIPTION
### The Problem:

Issue #570 reports a `ValueError: Invalid value: , is not a 2-char hex string` during cache restore/hydration. This occurs because `parser_31e0` receives a short `"00"` payload from a Vasco CO2 sensor and attempts to extract ventilation demand using `seqx[4:6]`. This results in an empty string being passed to `hex_to_percent()`, which raises the exception.

### Consequences:

The parser crashes and throws an unhandled exception that disrupts message parsing and system cache hydration. This causes log spam and potential system instability for users with specific devices broadcasting this packet.

### The Fix:

Added a guard clause to safely and silently handle functionally empty `"00"` payloads before any string slicing occurs.

### Technical Implementation:

Inserted `if payload == "00": return {}` at the very beginning of the `parser_31e0` function in `src/ramses_tx/parsers.py`. This short-circuits the parsing logic, safely bypassing the nested `_parser` and `hex_to_percent` functions. This matches the established pattern used in other parsers (e.g., `parser_10e0`).

### Testing Performed:

Ran `mypy --strict` to ensure type compliance with zero errors. Executed the full `pytest` test suite, which passed completely, verifying no regressions in existing parsing logic.

### Risks of NOT Implementing:

Users with Vasco CO2 sensors (or other devices sending `31E0 001 00`) will continue to experience parsing crashes, error log spam, and halted cache hydration.

### Risks of Implementing:

Extremely low risk. The only potential risk is if downstream systems specifically expect a different representation of a null `31E0` payload rather than an empty dictionary.

### Mitigation Steps:

Returning `{}` perfectly aligns with the established `ramses_rf` codebase conventions for handling empty or functionally null payloads (as seen in `parser_10e0`, `parser_0004`, `parser_0100`, etc.). The successful execution of the full test suite further mitigates any risk of dependent logic breaking.

### AI Assistance Disclosure:

This contribution was developed with the assistance of Google Gemini 3.1 Pro for code generation and documentation. No Agentic AI systems were employed; all logic and implementations were reviewed, verified, and manually committed by the author.