### PR TITLE
Fix: Prevent 1-byte heartbeat payloads from crashing parsers and dropping devices offline

### DIFF
--- a/src/ramses_tx/message.py
+++ b/src/ramses_tx/message.py
@@ -313,7 +313,12 @@ class MessageBase:
 
         try:  # parse the payload
             # TODO: only accept invalid packets to/from HGI when flag raised
-            _check_msg_payload(self, self._pkt.payload)  # ? InvalidPayloadError
+            try:
+                _check_msg_payload(self, self._pkt.payload)  # ? InvalidPayloadError
+            except exc.PacketPayloadInvalid as err:
+                if not self._has_payload:
+                    return {}  # Heartbeat fallback for null payloads
+                raise err
 
             if not self._has_payload and (
                 self.verb == RQ and self.code not in RQ_IDX_COMPLEX
@@ -484,10 +489,6 @@ def _check_msg_payload(msg: MessageBase, payload: str) -> None:
 
     if not regex:
         raise exc.PacketInvalid(f"Unknown verb/code pair: {msg.verb}/{msg.code}")
-
-    # Bypass strict regex validation if the payload is functionally empty ("00")
-    if not msg._has_payload:
-        return
 
     if not re_compile_re_match(str(regex), payload):
         raise exc.PacketPayloadInvalid(

--- a/tests/tests_rf/test_dispatcher.py
+++ b/tests/tests_rf/test_dispatcher.py
@@ -172,3 +172,77 @@ class TestDispatcherErrorHandling:
         assert any(r.levelname == "WARNING" for r in caplog.records)
         # Check that traceback information is present (exc_info=True)
         assert any(r.exc_info is not None for r in caplog.records)
+
+
+class TestDispatcherHeartbeats:
+    """Test that heartbeat (empty) payloads are correctly dispatched to devices."""
+
+    @pytest.mark.parametrize(
+        ("pkt_line", "src_id", "dev_type"),
+        [
+            # TRV sending a 3150 heat demand heartbeat (1-byte "00" payload, I verb)
+            (
+                "045  I --- 04:123456 --:------ 04:123456 3150 001 00",
+                "04:123456",
+                "TRV",
+            ),
+            # FAN sending a 2411 fan parameters heartbeat (1-byte "00" payload, RP verb)
+            (
+                "045 RP --- 32:155617 29:123160 --:------ 2411 001 00",
+                "32:155617",
+                "FAN",
+            ),
+            # TRV sending a 12B0 window state heartbeat (1-byte "00" payload, I verb)
+            (
+                "045  I --- 04:123456 --:------ 04:123456 12B0 001 00",
+                "04:123456",
+                "TRV",
+            ),
+            # TRV sending an empty 2309 setpoint heartbeat (1-byte "00" payload, I verb)
+            (
+                "045  I --- 04:123456 --:------ 04:123456 2309 001 00",
+                "04:123456",
+                "TRV",
+            ),
+        ],
+    )
+    async def test_heartbeat_dispatch(
+        self,
+        mock_gateway: MagicMock,
+        pkt_line: str,
+        src_id: str,
+        dev_type: str,
+    ) -> None:
+        """Test that empty payload heartbeats are routed to update device timestamps."""
+        # 1. Parse the packet into a Message
+        # This confirms that message.py correctly validates and bypasses empty heartbeats
+        dtm = dt.now()
+        packet = Packet(dtm, pkt_line)
+        msg = Message(packet)
+
+        # Confirm it safely processed as an empty heartbeat message
+        assert msg._has_payload is False
+        assert msg.payload == {}
+
+        # 2. Setup the mock registry and device
+        # We mock a device matching the source ID and set its slug to pass validation
+        mock_dev = MagicMock(spec=Device)
+        mock_dev.id = src_id
+        mock_dev._SLUG = dev_type
+        mock_dev._is_binding = False
+        mock_dev.is_faked = False
+
+        # Inject the mock device into the registry so _create_devices_from_addrs maps to it
+        mock_gateway.device_registry.device_by_id[src_id] = mock_dev
+        mock_gateway.device_registry.get_device.return_value = mock_dev
+
+        # Give the mocked HGI a different ID so the packet is treated as remote
+        mock_gateway.hgi.id = "18:000730"
+
+        # 3. Process the message through the dispatcher
+        await dispatcher.process_msg(mock_gateway, msg)
+
+        # 4. Assert the message was explicitly dispatched to the device
+        # The dispatcher queues the update via gwy._engine._loop.call_soon()
+        # which triggers mock_dev._handle_msg(msg) containing the timestamp updates
+        mock_gateway._engine._loop.call_soon.assert_any_call(mock_dev._handle_msg, msg)

--- a/tests/tests_tx/test_message.py
+++ b/tests/tests_tx/test_message.py
@@ -126,16 +126,36 @@ def test_message_string_representations(patch_parsers: Any) -> None:
 def test_startup_empty_payload_reproduction() -> None:
     """Test that an empty payload bypasses strict regex and parses safely.
 
-    This test confirms the fix: functionally empty payloads ("00")
-    no longer raise PacketPayloadInvalid.
+    This test runs WITHOUT mock parsers to confirm the heartbeat fallback:
+    functionally empty payloads ("00") that fail validation return {}.
 
     :return: None
     """
     dtm = dt.now()
     packet = Packet(dtm, FRAME_STR_EMPTY)
 
-    # With the fix applied, this should instantiate without raising an exception
+    # With the fix applied, 2411 RP "00" fails validation but safely returns {}
     message = Message(packet)
 
     assert message._has_payload is False
     assert message.len == 1
+    assert message.payload == {}
+
+
+def test_message_valid_empty_payload() -> None:
+    """Test that a valid empty payload is accurately parsed and NOT dropped.
+
+    Some protocol commands (like 1FC9 ' I') legitimately use a "00" payload
+    as actionable data (e.g., the "Confirm" phase of a binding process).
+    This ensures they are routed to the parser rather than fallback logic.
+
+    :return: None
+    """
+    dtm = dt.now()
+    # 1FC9 explicitly allows "00" in CODES_SCHEMA. It must successfully parse.
+    packet = Packet(dtm, "045  I --- 18:006402 13:049798 --:------ 1FC9 001 00")
+    message = Message(packet)
+
+    assert message._has_payload is False
+    assert message.payload.get("phase") == "confirm"
+    assert "bindings" in message.payload


### PR DESCRIPTION
### The Problem:

Following the recent upgrade to version `0.56.2`, users reported regressions where OpenTherm sensors remained in an "Unknown" state and the controller's `system_mode` was stuck on "Auto".

Investigation of the logs revealed a flood of `KeyError`, `ValueError`, and `TypeError` tracebacks originating from `ramses_tx/parsers.py`. The root cause was 1-byte `"00"` payloads (standard RF heartbeat / keep-alive packets) bypassing regex validation in `message.py`. Because they skipped validation, they were passed directly to the payload parsers, which strictly expect 2+ bytes of state data. Attempting to slice a 1-byte string (e.g., `payload[2:4]`) evaluated to an empty string `""`, which subsequently crashed the hex converters and dictionary lookups.

Because these exceptions occurred during `Message` instantiation, the heartbeat packets were completely dropped. Consequently, the dispatcher never received them, device `last_seen` timestamps stagnated, and Home Assistant automatically marked the devices (like the OpenTherm Bridge) as "Unavailable", effectively deadlocking the UI.

### Consequences:

If this isn't fixed, the integration will suffer from silent functional failures and severe log spam. Battery-powered devices and OpenTherm bridges relying on `"00"` payloads to announce their presence will periodically drop off the network, causing Home Assistant to mark their sensors as "Unknown" and locking out user controls.

### The Fix:

Refactored the payload validation sequence in `message.py` to strictly enforce `CODES_SCHEMA` regex rules on all state-carrying verbs, preventing invalid 1-byte payloads from ever reaching the parsers. Simultaneously implemented a "Heartbeat Fallback" to gracefully catch these rejected empty payloads, returning an empty dictionary `{}` so the `Message` object is successfully created and dispatched purely to update device `last_seen` timestamps.

### Technical Implementation:
1. **Removed the Bypass in `_check_msg_payload()`:** Removed the overly broad `if not msg._has_payload: return` clause. All payloads for `RP`, `I`, and `W` verbs are now forced to face their respective `CODES_SCHEMA` regex.
2. **Added Heartbeat Fallback in `_validate()`:** Wrapped `_check_msg_payload()` in a `try/except` block specifically catching `exc.PacketPayloadInvalid`. If this exception is raised and the payload is functionally empty (`not self._has_payload`), we intercept the error and return `{}`.
3. **Preserved Valid Short Payloads:** Valid 1-byte payloads (such as `"00"` used during the confirm phase of an `1FC9` binding) naturally pass the regex schema, bypass the exception handler entirely, and are correctly routed to `parse_payload(self)` to yield their actionable dictionaries.

### Testing Performed:
- **`tests/tests_tx/test_message.py`:** Added `test_startup_empty_payload_reproduction` to prove that `"00"` heartbeats successfully trigger the fallback logic and return `{}`. Added `test_message_valid_empty_payload` to prove that an `1FC9` confirm packet passes validation and correctly yields `{"phase": "confirm", ...}`.
- **`tests/tests_rf/test_dispatcher.py`:** Added a new test class, `TestDispatcherHeartbeats`. Utilizing `pytest.mark.parametrize`, we simulate raw `"00"` heartbeat packets across multiple schemas (`3150`, `2411`, `12B0`, `2309`) and device types (`TRV`, `FAN`). The test asserts that the dispatcher successfully processes the empty payloads and queues them via the event loop (`call_soon`) to trigger `_handle_msg`, ensuring the device tracking timestamps will update.

### Risks of NOT Implementing:

Leaving the code as-is results in a highly unstable experience for users with chatty RF environments, OpenTherm bridges, or battery-operated sensors. Core climate entities will drop offline randomly, causing major user confusion and breaking Home Assistant automations.

### Risks of Implementing:

There is a minor theoretical risk that a legitimately malformed packet that happens to have a payload of exactly `"00"` will be treated as a valid heartbeat rather than logging a strict error.

### Mitigation Steps:

Extensive unit testing was added to ensure the fallback mechanism strictly relies on the `PacketPayloadInvalid` exception combined with the `not self._has_payload` boolean flag. Valid protocol bindings (like `1FC9`) were explicitly tested to guarantee they do not get swallowed by the heartbeat fallback.

### AI Assistance Disclosure:

This contribution was developed with the assistance of Google Gemini 3.1 Pro for code generation and documentation. No Agentic AI systems were employed; all logic and implementations were reviewed, verified, and manually committed by the author.

---

  
