### PR TITLE
Fix: Resolve SQLite database locking by routing deletions through single-writer queue

### DIFF
--- a/src/ramses_rf/message_store.py
+++ b/src/ramses_rf/message_store.py
@@ -516,9 +516,8 @@ class MessageStore:
                 ctx=ctx,
                 hdr=hdr,
             )
-            cx = getattr(self, "_cx", None)
 
-            if self._worker and cx is not None:
+            if self._worker:
                 if msg:
                     kwargs["dtm"] = msg.dtm
 
@@ -527,13 +526,7 @@ class MessageStore:
 
                 sql_params = tuple(kwargs.values())
 
-                def _execute_delete(
-                    conn: sqlite3.Connection, query: str, params: tuple[Any, ...]
-                ) -> None:
-                    with self._db_lock:
-                        conn.execute(query, params)
-
-                await asyncio.to_thread(_execute_delete, cx, sql, sql_params)
+                self._worker.submit_delete_message(sql, sql_params)
 
             msgs = tuple(msgs_to_remove)
 

--- a/src/ramses_rf/sqlite_worker.py
+++ b/src/ramses_rf/sqlite_worker.py
@@ -41,7 +41,27 @@ class SnapshotRequest(NamedTuple):
     pass
 
 
-QueueItem = PacketLogEntry | PruneRequest | SnapshotRequest | tuple[str, Any] | None
+class DeleteMessageRequest(NamedTuple):
+    """Represents a request to delete a specific message or set of messages."""
+
+    query: str
+    params: tuple[Any, ...]
+
+
+class FlushRequest(NamedTuple):
+    """Represents a request to flush the queue and signal completion."""
+
+    event: threading.Event
+
+
+QueueItem = (
+    PacketLogEntry
+    | PruneRequest
+    | SnapshotRequest
+    | DeleteMessageRequest
+    | FlushRequest
+    | None
+)
 
 
 class SQLiteWorker:
@@ -78,11 +98,15 @@ class SQLiteWorker:
         """Submit a disk snapshot request (Non-blocking)."""
         self._queue.put(SnapshotRequest())
 
+    def submit_delete_message(self, query: str, params: tuple[Any, ...]) -> None:
+        """Submit a request to delete specific messages (Non-blocking)."""
+        self._queue.put(DeleteMessageRequest(query, params))
+
     def flush(self, timeout: float = 10.0) -> None:
         """Block until all currently pending tasks are processed."""
         # We inject a special marker into the queue
         sentinel = threading.Event()
-        self._queue.put(("MARKER", sentinel))
+        self._queue.put(FlushRequest(sentinel))
 
         # Wait for the worker to set the sentinel
         if not sentinel.wait(timeout):
@@ -222,6 +246,14 @@ class SQLiteWorker:
                     except sqlite3.Error as err:
                         _LOGGER.error("SQL Prune Failed: %s", err)
 
+                elif isinstance(item, DeleteMessageRequest):
+                    try:
+                        conn.execute(item.query, item.params)
+                        conn.commit()
+                        _LOGGER.debug("Deleted specific message via queue.")
+                    except sqlite3.Error as err:
+                        _LOGGER.error("SQL Delete Message Failed: %s", err)
+
                 elif isinstance(item, SnapshotRequest):
                     if self._disk_path:
                         try:
@@ -232,9 +264,9 @@ class SQLiteWorker:
                         except sqlite3.Error as err:
                             _LOGGER.error("SQL Snapshot Failed: %s", err)
 
-                elif isinstance(item, tuple) and item[0] == "MARKER":
+                elif isinstance(item, FlushRequest):
                     # Flush requested
-                    item[1].set()
+                    item.event.set()
 
             except Exception as err:
                 _LOGGER.exception("SQLiteWorker encountered an error: %s", err)

--- a/tests/tests/test_sqlite_worker.py
+++ b/tests/tests/test_sqlite_worker.py
@@ -172,3 +172,49 @@ async def test_storage_worker_persistence(tmp_path: Path) -> None:
         # Restore the Pytest environment variable for all subsequent tests
         if pytest_env is not None:
             os.environ["PYTEST_CURRENT_TEST"] = pytest_env
+
+
+@pytest.mark.asyncio
+async def test_storage_worker_delete(tmp_path: Path) -> None:
+    """Verify that the StorageWorker safely processes delete requests asynchronously."""
+    db_path = tmp_path / "test_async_delete.sqlite"
+    disk_path = tmp_path / "ramses_delete.db"
+
+    pytest_env = os.environ.pop("PYTEST_CURRENT_TEST", None)
+    try:
+        idx = MessageStore(db_path=str(db_path), disk_path=str(disk_path))
+
+        # Allow tables to initialize
+        for _ in range(50):
+            if db_path.exists():
+                break
+            await asyncio.sleep(0.01)
+
+        # 1. Insert a test message
+        msg = create_dummy_message(1)
+        idx.add(msg)
+
+        # Flush queue to disk so we can read it directly
+        assert idx._worker is not None
+        idx._worker.flush()
+
+        # Check DB row count == 1
+        conn = sqlite3.connect(str(db_path))
+        cursor = conn.cursor()
+        cursor.execute("SELECT COUNT(*) FROM messages")
+        assert cursor.fetchone()[0] == 1, "Failed to persist single insert."
+
+        # 2. Delete the message via the async queue pattern
+        await idx.rem(msg=msg)
+        idx._worker.flush()  # Force wait until delete transaction is processed
+
+        # Check DB row count == 0
+        cursor.execute("SELECT COUNT(*) FROM messages")
+        assert cursor.fetchone()[0] == 0, "Failed to async delete record."
+
+        conn.close()
+        idx.stop()
+
+    finally:
+        if pytest_env is not None:
+            os.environ["PYTEST_CURRENT_TEST"] = pytest_env

--- a/tests/tests_rf/test_message_store.py
+++ b/tests/tests_rf/test_message_store.py
@@ -157,6 +157,27 @@ class TestMessageStore:
 
         msg_db.stop()  # close sqlite3 connection
 
+    async def test_rem_msg(self) -> None:
+        """Remove a message from the MessageStore."""
+        msg_db = MessageStore(disk_path=None)
+        msg_db.add(self.msg1)
+        msg_db.add(self.msg2)
+        msg_db.add(self.msg3)
+
+        assert len(await msg_db.all()) == 3
+
+        # 1. Remove by exact message object
+        await msg_db.rem(msg=self.msg1)
+        assert len(await msg_db.all()) == 2
+        assert not await msg_db.contains(dtm=self.msg1.dtm)
+
+        # 2. Remove by specific kwargs matching
+        await msg_db.rem(code="2309")  # Target msg3
+        assert len(await msg_db.all()) == 1
+        assert not await msg_db.contains(code="2309")
+
+        msg_db.stop()
+
     async def test_fat_database_payload_serialization(self) -> None:
         """Phase 2.5: Verify large payloads decode properly from the RAM cache."""
         msg_db = MessageStore(maintain=False, disk_path=None)


### PR DESCRIPTION
### The Problem:

Users are experiencing frequent `sqlite3.OperationalError: database table is locked` tracebacks. This occurs because `message_store.rem()` was bypassing the `SQLiteWorker` daemon thread and using `asyncio.to_thread` to spawn unmanaged threads for `DELETE` queries. When these rogue threads collided with the background worker (which holds the WAL lock for inserts/pruning), SQLite rejected the concurrent write attempts.

### Consequences:

If left unfixed, this concurrency collision causes constant database write failures. On slower hardware (like Raspberry Pi SD cards), the resulting disk I/O bottleneck aggressively starves the Home Assistant asyncio event loop, causing system-wide timeouts, dropped RF telemetry, and corrupted serial buffers.

### The Fix:

Enforced a strict single-writer policy for the database. All `DELETE` operations are now routed through the `queue.SimpleQueue` so they are executed sequentially by the dedicated `SQLiteWorker` background thread, completely eliminating concurrent write collisions.

### Technical Implementation:
- Created a strongly-typed `DeleteMessageRequest(NamedTuple)` in `sqlite_worker.py` to safely pass SQL queries and parameters into the queue.
- Added `submit_delete_message()` to expose this functionality to the frontend.
- Refactored `message_store.rem()` to drop its `asyncio.to_thread` logic and instead push the dynamically generated `DELETE` query to the worker queue.
- Replaced the generic tuple used for flushing the queue with a strictly-typed `FlushRequest(NamedTuple)` to satisfy `mypy --strict`.

### Testing Performed:
- **`test_message_store.py::test_rem_msg`**: Added to verify that messages are accurately removed from the RAM cache (`self._message_log` and `self._state_cache`) using both exact message objects and arbitrary `kwargs` (e.g., `code="2309"`).
- **`test_sqlite_worker.py::test_storage_worker_delete`**: Added to verify that the async worker successfully consumes the `DeleteMessageRequest`, executes the SQL, and permanently removes the record from the physical `.sqlite` file.
- Verified that the entire project (137 source files) successfully passes `mypy --strict` with no issues.

### Risks of NOT Implementing:

Users will continue to experience fatal SQLite locking tracebacks. On lower-end hardware, the resulting I/O wait times will continue to crash surrounding Home Assistant integrations and corrupt incoming RF packet streams.

### Risks of Implementing:

If the `SQLiteWorker` background thread were to silently crash, deletions (and insertions) would continue to succeed in the RAM cache but would never persist to the disk, creating a silent failure where the queue grows indefinitely in memory.

### Mitigation Steps:

The `SQLiteWorker` includes broad exception handling within its `_run` loop to catch and log specific `sqlite3.Error` tracebacks without killing the daemon thread itself. Furthermore, we implemented explicit `flush()` mechanics in the test suite to physically verify that queue items are drained and committed to disk rather than just hanging in memory.

### AI Assistance Disclosure:

This contribution was developed with the assistance of Google Gemini 3.1 Pro for code generation and documentation. No Agentic AI systems were employed; all logic and implementations were reviewed, verified, and manually committed by the author.
