### PR TITLE
Fix: Resolve circular import crash during initialization by relocating `LOOKUP_PUZZ`

### DIFF
--- a/src/ramses_rf/parsers.py
+++ b/src/ramses_rf/parsers.py
@@ -31,6 +31,7 @@ from ramses_tx.const import (
     FAULT_DEVICE_CLASS,
     FAULT_STATE,
     FAULT_TYPE,
+    LOOKUP_PUZZ,
     SYS_MODE_MAP,
     SZ_ACCEPT,
     SZ_ACTIVE,
@@ -176,16 +177,6 @@ if TYPE_CHECKING:
     from ramses_tx.message import Message
 
 _2411_TABLE = {k: v["description"] for k, v in _2411_PARAMS_SCHEMA.items()}
-
-LOOKUP_PUZZ = {
-    "10": "engine",  # .    # version str, e.g. v0.14.0
-    "11": "impersonating",  # pkt header, e.g. 30C9| I|03:123001 (15 characters, packed)
-    "12": "message",  # .   # message only, max len is 16 ascii characters
-    "13": "message",  # .   # message only, but without a timestamp, max len 22 chars
-    "20": "engine",  # .    # version str, e.g. v0.50.0, has higher-precision timestamp
-    "7F": "null",  # .      # packet is null / was nullified: payload to be ignored
-}  # "00" is reserved
-
 
 _INFORM_DEV_MSG = "Support the development of ramses_rf by reporting this packet"
 

--- a/src/ramses_tx/command/system.py
+++ b/src/ramses_tx/command/system.py
@@ -7,8 +7,6 @@ from collections.abc import Iterable
 from datetime import datetime as dt
 from typing import TYPE_CHECKING, Any, TypeVar, cast
 
-from ramses_rf.parsers import LOOKUP_PUZZ
-
 from .. import exceptions as exc
 from ..address import ALL_DEV_ADDR, Address, dev_id_to_hex_id
 from ..const import (
@@ -19,6 +17,7 @@ from ..const import (
     FC,
     FF,
     I_,
+    LOOKUP_PUZZ,
     RP,
     RQ,
     SYS_MODE_MAP,

--- a/src/ramses_tx/const.py
+++ b/src/ramses_tx/const.py
@@ -1016,3 +1016,13 @@ IndexT = Literal[
     "F0", "F1", "F2", "F3", "F4", "F5", "F6", "F7", "F8", "F9", "FA", "FB", "FC", "FD", "FE", "FF"
 ]
 # fmt: on
+
+
+LOOKUP_PUZZ = {
+    "10": "engine",  # .    # version str, e.g. v0.14.0
+    "11": "impersonating",  # pkt header, e.g. 30C9| I|03:123001 (15 characters, packed)
+    "12": "message",  # .   # message only, max len is 16 ascii characters
+    "13": "message",  # .   # message only, but without a timestamp, max len 22 chars
+    "20": "engine",  # .    # version str, e.g. v0.50.0, has higher-precision timestamp
+    "7F": "null",  # .      # packet is null / was nullified: payload to be ignored
+}  # "00" is reserved


### PR DESCRIPTION
### The Problem:

A circular dependency exists between the foundational transport layer (`ramses_tx`) and the higher-level parsing layer (`ramses_rf`). During initialization, `ramses_tx/command/system.py` attempts to import `LOOKUP_PUZZ` from `ramses_rf/parsers.py`, which in turn triggers `ramses_rf` to attempt an import of `Command` back from a partially initialized `ramses_tx`.

### Consequences:

Home Assistant completely fails to load the `ramses_cc` custom component. The event loop throws an `ImportError` on startup, resulting in a fatal failure of the integration for users running the current master branch.

### The Fix:

Relocated the `LOOKUP_PUZZ` constant to the lower-level foundational library (`ramses_tx`) to break the reverse dependency and enforce a clean, unidirectional initialization sequence.

### Technical Implementation:
- Moved the `LOOKUP_PUZZ` dictionary definition to `src/ramses_tx/const.py`.
- Updated `src/ramses_tx/command/system.py` to import `LOOKUP_PUZZ` locally from the `ramses_tx` namespace.
- Updated `src/ramses_rf/parsers.py` to import `LOOKUP_PUZZ` from its new home in `ramses_tx.const`.
- This severs the link where the lower layer depends on the upper layer, allowing `ramses_tx` to finish loading before `ramses_rf` is called.

### Testing Performed:
- Verified module loading sequence manually to ensure `ramses_tx` initializes fully without triggering `ramses_rf`.
- Simulated integration startup to confirm the `ImportError` regarding `Command` from `ramses_tx` no longer occurs in the Home Assistant logs.

### Risks of NOT Implementing:

The `master` branch will remain fundamentally broken, and the `ramses_cc` integration will continue to crash on startup for any users attempting to run it.

### Risks of Implementing:

Any external, un-updated scripts or third-party integrations that explicitly rely on importing `LOOKUP_PUZZ` directly from `ramses_rf.parsers` will encounter an `ImportError`.

### Mitigation Steps:

Audited internal project files to ensure all known internal references now point to the correct location in `src/ramses_tx/const.py`. The architectural benefit of decoupling the libraries heavily outweighs the risk of breaking undocumented, direct access to parsing constants.

### AI Assistance Disclosure:

This contribution was developed with the assistance of Google Gemini 3.1 Pro for code generation and documentation. No Agentic AI systems were employed; all logic and implementations were reviewed, verified, and manually committed by the author.