### PR TITLE
fix/outbound frames not being logged in packet log

### DIFF
--- a/src/ramses_tx/transport/base.py
+++ b/src/ramses_tx/transport/base.py
@@ -237,12 +237,27 @@ class _FullTransport(_ReadTransport):
         if self._closing is True:
             raise exc.TransportError("Transport is closing or has closed")
 
+        self._log_tx_packet(frame)
         self._track_transmit_rate()
         await self._write_frame(frame)
 
     async def _write_frame(self, frame: str) -> None:
         """Write some data bytes to the underlying transport."""
         raise NotImplementedError("_write_frame() not implemented here")
+
+    def _log_tx_packet(self, frame: str) -> None:
+        """Emit outbound frames to the packet log for symmetry with inbound logs."""
+        frame_clean = frame.strip()
+        if not frame_clean:
+            return
+
+        if not frame_clean[:3].isdigit():
+            frame_clean = f"000 {frame_clean}"
+
+        try:
+            Packet(dt_now(), frame_clean)
+        except Exception as err:  # pragma: no cover - defensive
+            _LOGGER.debug("Failed to log Tx frame: %s", err)
 
 
 _RegexRuleT: TypeAlias = dict[str, str]


### PR DESCRIPTION
I noticed we again don't publish outbound messages to the packet_log.
I know a lot of work is going on around this, so i'm not sure if you want this PR...
Just have a look at it...

Summary

Add _log_tx_packet() to _FullTransport and call it from write_frame() so every outbound frame is written to the packet log before hitting the transport implementation @ramses_tx/transport/base.py#234-256.
Keep the MQTT transport’s log_all_mqtt flag limited to console info logging so packet-log coverage applies uniformly across all transports @ramses_tx/transport/mqtt.py#328-452.
Leave simulator hooks untouched except for removing the earlier gateway-RQ mirroring to avoid duplicate entries once the core transport handles Tx logging (already done downstream).
