### PR TITLE
Refactor: OSI Layer 7 Decoupling and Event-Ready State Management (Phase 2.5) (#639)

### DIFF
--- a/src/ramses_rf/__init__.py
+++ b/src/ramses_rf/__init__.py
@@ -22,7 +22,7 @@ from . import exceptions  # noqa: F401
 from .device import Device  # noqa: F401
 from .exceptions import CommandInvalid  # noqa: F401
 from .gateway import Gateway, GatewayConfig  # noqa: F401
-from .message import Message
+from .messages import Message
 from .version import VERSION  # noqa: F401
 
 from .const import (  # noqa: F401, isort: skip, pylint: disable=unused-import

--- a/src/ramses_rf/binding_fsm.py
+++ b/src/ramses_rf/binding_fsm.py
@@ -17,7 +17,7 @@ import voluptuous as vol
 from ramses_tx import ALL_DEV_ADDR, ALL_DEVICE_ID, Command, DevType, Priority, QosParams
 
 from . import exceptions as exc
-from .message import Message
+from .messages import Message
 
 from .const import (  # noqa: F401, isort: skip, pylint: disable=unused-import
     I_,

--- a/src/ramses_rf/device/__init__.py
+++ b/src/ramses_rf/device/__init__.py
@@ -51,7 +51,7 @@ if TYPE_CHECKING:
     from ramses_rf import Gateway
     from ramses_tx import Address
 
-    from ..message import Message
+    from ..messages import Message
 
 
 __all__ = [

--- a/src/ramses_rf/device/base.py
+++ b/src/ramses_rf/device/base.py
@@ -20,7 +20,7 @@ from ramses_rf.const import (
     SZ_OEM_CODE,
     DevType,
 )
-from ramses_rf.entity_base import Entity, class_by_attr
+from ramses_rf.entity import Entity, class_by_attr
 from ramses_rf.exceptions import DeviceNotFaked, SchemaInconsistentError
 from ramses_rf.schemas import SZ_ALIAS, SZ_CLASS, SZ_FAKED, SZ_KNOWN_LIST
 from ramses_rf.topology import Child

--- a/src/ramses_rf/device/base.py
+++ b/src/ramses_rf/device/base.py
@@ -28,7 +28,7 @@ from ramses_tx import Command, Packet, Priority, QosParams
 from ramses_tx.ramses import CODES_BY_DEV_SLUG, CODES_ONLY_FROM_CTL
 from ramses_tx.typing import PayloadT
 
-from ..message import Message
+from ..messages import Message
 
 from ramses_rf.const import (  # noqa: F401, isort: skip, pylint: disable=unused-import
     I_,

--- a/src/ramses_rf/device/heat.py
+++ b/src/ramses_rf/device/heat.py
@@ -31,7 +31,7 @@ from ramses_rf.const import (
     DevType,
 )
 from ramses_rf.device import Device
-from ramses_rf.entity_base import Entity, class_by_attr
+from ramses_rf.entity import Entity, class_by_attr
 from ramses_rf.helpers import shrink
 from ramses_rf.quirks import QUARANTINED_OT_MSG_IDS
 from ramses_rf.schemas import SCH_TCS, SZ_ACTUATORS, SZ_CIRCUITS

--- a/src/ramses_rf/device/heat.py
+++ b/src/ramses_rf/device/heat.py
@@ -106,13 +106,13 @@ from ramses_tx.const import (
 )
 
 if TYPE_CHECKING:
-    from ramses_rf.application_message import ApplicationMessage
+    from ramses_rf.messages import ApplicationMessage
     from ramses_rf.models import DeviceTraits
     from ramses_rf.system import Evohome, Zone
     from ramses_tx import Address, Packet
     from ramses_tx.opentherm import OtDataId
 
-    from ..message import Message
+    from ..messages import Message
 
 
 QOS_LOW = {SZ_PRIORITY: Priority.LOW}  # FIXME:  deprecate QoS in kwargs

--- a/src/ramses_rf/device/hvac.py
+++ b/src/ramses_rf/device/hvac.py
@@ -53,7 +53,7 @@ from ramses_tx import Address, Command, Packet, Priority
 from ramses_tx.ramses import CODES_OF_HVAC_DOMAIN_ONLY, HVAC_KLASS_BY_VC_PAIR
 from ramses_tx.typing import PayloadT
 
-from ..message import Message
+from ..messages import Message
 from .base import BatteryState, DeviceHvac, Fakeable
 
 from ramses_rf.const import (  # noqa: F401, isort: skip, pylint: disable=unused-import

--- a/src/ramses_rf/device/hvac.py
+++ b/src/ramses_rf/device/hvac.py
@@ -47,7 +47,7 @@ from ramses_rf.const import (
     SZ_TEMPERATURE,
     DevType,
 )
-from ramses_rf.entity_base import class_by_attr
+from ramses_rf.entity import class_by_attr
 from ramses_rf.helpers import schedule_task
 from ramses_tx import Address, Command, Packet, Priority
 from ramses_tx.ramses import CODES_OF_HVAC_DOMAIN_ONLY, HVAC_KLASS_BY_VC_PAIR

--- a/src/ramses_rf/device_registry.py
+++ b/src/ramses_rf/device_registry.py
@@ -15,7 +15,7 @@ from .schemas import SCH_TRAITS, SZ_ALIAS, SZ_CLASS, SZ_FAKED
 from .typing import DeviceIdT, DeviceListT, DeviceTraitsT
 
 if TYPE_CHECKING:
-    from ramses_rf.message import Message
+    from ramses_rf.messages import Message
 
     from .device import Device
     from .gateway import Gateway

--- a/src/ramses_rf/discovery.py
+++ b/src/ramses_rf/discovery.py
@@ -23,6 +23,7 @@ from ramses_tx.ramses import CODES_SCHEMA
 from . import exceptions as exc
 from .helpers import schedule_task
 from .messages import Message
+from .routing import StateHeader
 
 if TYPE_CHECKING:
     from ramses_tx.const import MsgId
@@ -124,7 +125,7 @@ class DiscoveryService:
                         or msg.dst.id == self._entity.id[:9]
                     )
                 ):
-                    ctx = msg._pkt._ctx
+                    ctx = msg.context.value
                     _LOGGER.debug("Fetched OT ctx from index: %s", ctx)
                     val = f"{ctx:02X}" if isinstance(ctx, int) else str(ctx)
                     if val not in res:
@@ -133,7 +134,7 @@ class DiscoveryService:
             msgs = await self._entity.entity_state.get_all_messages()
             for msg in msgs:
                 if msg.code == Code._3220 and msg.verb == RP:
-                    ctx = msg._pkt._ctx
+                    ctx = msg.context.value
                     val = f"{ctx:02X}" if isinstance(ctx, int) else str(ctx)
                     if val not in res:
                         res.append(val)
@@ -244,10 +245,17 @@ class DiscoveryService:
         async def find_latest_msg(hdr: HeaderT, task: dict[str, Any]) -> Message | None:
             """Return the latest message for a header from any source."""
             msgs: list[Message] = []
+
+            code_str, _, src_id, *args = hdr.split("|")
+            ctx_val: str | bool | None = args[0] if args else None
+            if ctx_val == "True":
+                ctx_val = True
+            elif ctx_val == "False":
+                ctx_val = False
+
             for v in (I_, RP):
-                m = await self._entity.entity_state._get_msg_by_hdr(
-                    hdr[:5] + v + hdr[7:]
-                )
+                search_hdr = StateHeader.create(code_str, v, src_id, ctx_val)
+                m = await self._entity.entity_state._get_msg_by_hdr(search_hdr)
                 if m is not None:
                     msgs.append(m)
 
@@ -263,7 +271,7 @@ class DiscoveryService:
                                 if (
                                     m.code == cmd_code
                                     and m.verb in (I_, RP)
-                                    and str(m._pkt._ctx) == "True"
+                                    and str(m.context.value) == "True"
                                     and (
                                         m.src.id == tcs_id[:9] or m.dst.id == tcs_id[:9]
                                     )
@@ -285,7 +293,7 @@ class DiscoveryService:
                                 for m in tcs_msgs
                                 if m.code == cmd_code
                                 and m.verb == I_
-                                and m._pkt._ctx is True
+                                and m.context.value is True
                             ]
                             if found:
                                 msgs.append(max(found, key=lambda x: x.dtm))

--- a/src/ramses_rf/discovery.py
+++ b/src/ramses_rf/discovery.py
@@ -22,7 +22,7 @@ from ramses_tx.ramses import CODES_SCHEMA
 
 from . import exceptions as exc
 from .helpers import schedule_task
-from .message import Message
+from .messages import Message
 
 if TYPE_CHECKING:
     from ramses_tx.const import MsgId

--- a/src/ramses_rf/dispatcher.py
+++ b/src/ramses_rf/dispatcher.py
@@ -34,7 +34,7 @@ from .const import (
     DevType,
 )
 from .device import Device, Fakeable
-from .message import Message
+from .messages import Message
 
 if TYPE_CHECKING:
     from .gateway import Gateway

--- a/src/ramses_rf/entity.py
+++ b/src/ramses_rf/entity.py
@@ -1,4 +1,3 @@
-# src/ramses_rf/entity_base.py
 #!/usr/bin/env python3
 """RAMSES RF - Base class for all RAMSES-II objects: devices and constructs."""
 
@@ -8,13 +7,12 @@ import asyncio
 import logging
 from inspect import getmembers, isclass
 from sys import modules
-from types import ModuleType
 from typing import TYPE_CHECKING, Any, cast
 
 from ramses_tx import Priority, QosParams
 
 from .discovery import DiscoveryService
-from .entity_state import EntityState
+from .state import EntityState
 
 if TYPE_CHECKING:
     from ramses_tx import Command, Packet
@@ -44,8 +42,8 @@ def class_by_attr(name: str, attr: str) -> dict[str, Any]:
     :rtype: dict[str, Any]
     """
 
-    def predicate(m: ModuleType) -> bool:
-        return isclass(m) and m.__module__ == name and getattr(m, attr, None)
+    def predicate(m: Any) -> bool:
+        return isclass(m) and m.__module__ == name and bool(getattr(m, attr, None))
 
     return {getattr(c[1], attr): c[1] for c in getmembers(modules[name], predicate)}
 
@@ -110,7 +108,7 @@ class _Entity:
         """
         pass
 
-    def _send_cmd(self, cmd: Command, **kwargs: Any) -> asyncio.Task | None:
+    def _send_cmd(self, cmd: Command, **kwargs: Any) -> asyncio.Task[Any] | None:
         """Proxy command sending to the Gateway.
 
         :param cmd: The command to send.
@@ -118,7 +116,7 @@ class _Entity:
         :param kwargs: Optional sending parameters (e.g., priority).
         :type kwargs: Any
         :returns: The corresponding asyncio Task or None.
-        :rtype: asyncio.Task | None
+        :rtype: asyncio.Task[Any] | None
         """
         if self._qos_tx_count > _QOS_TX_LIMIT:
             _LOGGER.info(f"{cmd} < Sending was deprecated for {self}")
@@ -147,13 +145,20 @@ class _Entity:
             _LOGGER.warning(f"{cmd} < Sending was deprecated for {self}")
             return None
 
-        return await self._gwy.async_send_cmd(
-            cmd,
-            max_retries=qos.max_retries if qos else None,
-            priority=priority,
-            timeout=qos.timeout if qos else None,
-            wait_for_reply=qos.wait_for_reply if qos else None,
-        )
+        # Build kwargs dynamically to prevent passing `None` to strict Gateway args
+        kwargs: dict[str, Any] = {}
+        if priority is not None:
+            kwargs["priority"] = priority
+
+        if qos:
+            if hasattr(qos, "max_retries") and qos.max_retries is not None:
+                kwargs["max_retries"] = qos.max_retries
+            if hasattr(qos, "timeout") and qos.timeout is not None:
+                kwargs["timeout"] = qos.timeout
+            if hasattr(qos, "wait_for_reply") and qos.wait_for_reply is not None:
+                kwargs["wait_for_reply"] = qos.wait_for_reply
+
+        return await self._gwy.async_send_cmd(cmd, **kwargs)
 
 
 class Entity(_Entity):

--- a/src/ramses_rf/entity_base.py
+++ b/src/ramses_rf/entity_base.py
@@ -23,7 +23,7 @@ if TYPE_CHECKING:
     from .device import Controller
     from .gateway import Gateway
     from .interfaces import DeviceInterface
-    from .message import Message
+    from .messages import Message
     from .system import Evohome
 
 

--- a/src/ramses_rf/entity_state.py
+++ b/src/ramses_rf/entity_state.py
@@ -13,7 +13,7 @@ import logging
 from datetime import UTC, datetime as dt
 from typing import TYPE_CHECKING, Any, cast
 
-from ramses_rf.message import Message
+from ramses_rf.messages import Message
 from ramses_tx.address import ALL_DEVICE_ID
 
 # noqa: F401, isort: skip, pylint: disable=unused-import
@@ -24,7 +24,7 @@ from . import exceptions as exc
 from .const import SZ_DOMAIN_ID, SZ_NAME, SZ_ZONE_IDX
 
 if TYPE_CHECKING:
-    from ramses_rf.application_message import ApplicationMessage
+    from ramses_rf.messages import ApplicationMessage
     from ramses_tx.typing import HeaderT
 
     from .interfaces import DeviceInterface, GatewayInterface

--- a/src/ramses_rf/gateway.py
+++ b/src/ramses_rf/gateway.py
@@ -63,7 +63,6 @@ from .interfaces import (
     GatewayInterface,
     MessageStoreInterface,
 )
-from .message_store import MessageStore
 from .messages import Message
 from .schemas import (
     SCH_GLOBAL_SCHEMAS,
@@ -73,6 +72,7 @@ from .schemas import (
     SZ_ORPHANS,
     load_schema,
 )
+from .state import MessageStore
 from .system import Evohome
 from .typing import DeviceIdT, DeviceListT
 

--- a/src/ramses_rf/gateway.py
+++ b/src/ramses_rf/gateway.py
@@ -42,9 +42,8 @@ from ramses_tx.ramses import CODES_SCHEMA
 from ramses_tx.schemas import SZ_BLOCK_LIST, SZ_ENFORCE_KNOWN_LIST, SZ_KNOWN_LIST
 from ramses_tx.typing import PayloadT
 
-from . import message as rf_msg
-from .application_message import ApplicationMessage
 from .const import DONT_CREATE_MESSAGES, HIGH_VOLUME_STATUS_CODES
+from .messages import ApplicationMessage, Message as rf_msg
 
 from .const import (  # noqa: F401, isort: skip, pylint: disable=unused-import
     I_,
@@ -64,8 +63,8 @@ from .interfaces import (
     GatewayInterface,
     MessageStoreInterface,
 )
-from .message import Message
 from .message_store import MessageStore
+from .messages import Message
 from .schemas import (
     SCH_GLOBAL_SCHEMAS,
     SZ_CONFIG,

--- a/src/ramses_rf/interfaces.py
+++ b/src/ramses_rf/interfaces.py
@@ -4,7 +4,7 @@ from typing import TYPE_CHECKING, Any, Protocol
 
 from ramses_tx import Command, Packet, Priority, QosParams
 
-from .message import Message
+from .messages import Message
 from .typing import DeviceIdT, DeviceListT
 
 if TYPE_CHECKING:

--- a/src/ramses_rf/message_store.py
+++ b/src/ramses_rf/message_store.py
@@ -39,7 +39,7 @@ import orjson
 from ramses_tx import CODES_SCHEMA, RP, RQ, Code, Packet
 
 from .exceptions import DatabaseQueryError
-from .message import Message
+from .messages import Message
 from .sqlite_worker import PacketLogEntry, SQLiteWorker
 
 DtmStrT = NewType("DtmStrT", str)

--- a/src/ramses_rf/messages/__init__.py
+++ b/src/ramses_rf/messages/__init__.py
@@ -1,0 +1,6 @@
+"""RAMSES RF - Application and Transport Message Domain."""
+
+from .application import ApplicationMessage
+from .base import Message
+
+__all__ = ["ApplicationMessage", "Message"]

--- a/src/ramses_rf/messages/application.py
+++ b/src/ramses_rf/messages/application.py
@@ -28,6 +28,7 @@ class ApplicationMessage(Message):
     _engine: Engine | None = None
     _fraction_expired: float | None = None
     _gwy: Any | None = None
+    _delete_task_queued: bool = False
 
     @classmethod
     def from_dto(cls, dto: PacketDTO) -> ApplicationMessage:

--- a/src/ramses_rf/messages/application.py
+++ b/src/ramses_rf/messages/application.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-
 """RAMSES RF - The Application Message module."""
 
 from __future__ import annotations
@@ -10,8 +9,8 @@ from typing import TYPE_CHECKING, Any
 from ramses_tx.dtos import PacketDTO
 from ramses_tx.ramses import CODES_SCHEMA, SZ_LIFESPAN
 
-from .const import RQ, Code
-from .message import Message
+from ..const import RQ, Code
+from .base import Message
 
 if TYPE_CHECKING:
     from ramses_tx.engine import Engine
@@ -136,9 +135,9 @@ class ApplicationMessage(Message):
         # sync_cycle is a special case
         if self.code == Code._1F09 and self.verb != RQ:
             # RQs won't have remaining_seconds, RP/Ws have only partial
-            # cycle times
-            rem_secs = getattr(self.payload, "remaining_seconds", None)
-            if rem_secs is None and isinstance(self.payload, dict):
+            # cycle times. Use strictly safe dict access per Master Plan.
+            rem_secs = 0
+            if isinstance(self.payload, dict):
                 rem_secs = self.payload.get("remaining_seconds", 0)
 
             self._fraction_expired = fraction_expired(

--- a/src/ramses_rf/messages/base.py
+++ b/src/ramses_rf/messages/base.py
@@ -16,11 +16,12 @@ from ramses_tx.models import DeviceId, RawPacket, TransportMessage
 from ramses_tx.ramses import CODE_IDX_ARE_COMPLEX
 from ramses_tx.typing import DeviceIdT
 
-from . import exceptions as exc
-from .const import DEV_TYPE_MAP, SZ_DHW_IDX, SZ_DOMAIN_ID, SZ_UFH_IDX, SZ_ZONE_IDX
-from .parsers.decoder import decode_packet
+from .. import exceptions as exc
+from ..const import DEV_TYPE_MAP, SZ_DHW_IDX, SZ_DOMAIN_ID, SZ_UFH_IDX, SZ_ZONE_IDX
+from ..parsers.decoder import decode_packet
+from ..routing import RoutingContext, StateHeader
 
-from .const import (  # noqa: F401, isort: skip, pylint: disable=unused-import
+from ..const import (  # noqa: F401, isort: skip, pylint: disable=unused-import
     I_,
     RP,
     RQ,
@@ -30,7 +31,7 @@ from .const import (  # noqa: F401, isort: skip, pylint: disable=unused-import
 
 if TYPE_CHECKING:
     # pylint: disable=unused-import
-    from .const import IndexT, VerbT  # noqa: F401
+    from ..const import IndexT, VerbT  # noqa: F401
 
 
 __all__ = ["Message"]
@@ -60,13 +61,6 @@ PayloadT: TypeAlias = Any
 # TypeVar bound to Message to allow strict inheritance typing
 _MessageT = TypeVar("_MessageT", bound="Message")
 
-# Context Bridge
-_IS_CONTROLLER_CB: Callable[[str], bool] | None = None
-# Logging Bridge
-_GET_CODE_NAME_CB: Callable[[Code | str], str] | None = None
-# Routing Bridge
-_GET_MSG_IDX_CB: Callable[[Any], dict[str, str]] | None = None
-
 
 class _LegacyPktShim:
     """A temporary shim bridging PacketDTO to legacy L3 attributes."""
@@ -82,40 +76,20 @@ class _LegacyPktShim:
 
     @property
     def _ctx(self) -> Any:
-        """Calculate the context dynamically.
-
-        :return: The context value.
-        :rtype: Any
-        """
-        code = str(getattr(self._msg, "code", ""))
-        payload = getattr(self._dto, "payload", "")
-        if code == "3220" and len(payload) >= 6:
-            return payload[4:6]
-        return getattr(self._msg, "_idx_val", None)
+        """Legacy context bridge."""
+        return self._msg.context.value
 
     @property
     def _hdr(self) -> str:
-        """Calculate the header dynamically.
-
-        :return: The header string.
-        :rtype: str
-        """
-        ctx = self._ctx
-        if ctx is True:
-            ctx_str = "True"
-        elif ctx is False:
-            ctx_str = "False"
-        else:
-            ctx_str = str(ctx)
-
-        code = str(getattr(self._msg, "code", ""))
-        verb = str(getattr(self._msg, "verb", ""))
-        src_id = self._msg.src.id if hasattr(self._msg, "src") else ""
-        return f"{code}|{verb}|{src_id}|{ctx_str}"
+        """Legacy header bridge."""
+        return self._msg.state_header.legacy_hdr
 
     @property
     def _frame(self) -> str:
-        """Calculate the frame string dynamically."""
+        """Legacy frame bridge for backwards compatibility in tests.
+
+        Calculates the frame string dynamically from the L7 properties.
+        """
         seqn = self._msg.seqn if self._msg.seqn else "---"
         addr1 = self._msg._addrs[0].id
         addr2 = self._msg._addrs[1].id
@@ -139,8 +113,12 @@ class _LegacyPktShim:
 class Message:
     """The Message class; will trap/log invalid msgs."""
 
+    # Domain Bridges (Injected by Gateway)
+    _IS_CONTROLLER_CB: Callable[[str], bool] | None = None
+    _GET_CODE_NAME_CB: Callable[[Code | str], str] | None = None
+    _GET_MSG_IDX_CB: Callable[[Any], dict[str, str]] | None = None
+
     _gwy: Any | None = None
-    _is_controller_cb: Callable[[str], bool] | None = None
 
     def __init__(self, dto: PacketDTO) -> None:
         """Create a message from a valid packet.
@@ -192,6 +170,33 @@ class Message:
         self._idx_val: str | bool = dto.payload[:2] if dto.payload else False
 
         self._payload = self._validate(dto.payload)
+
+    @property
+    def context(self) -> RoutingContext:
+        """Calculate the sub-payload context natively.
+
+        :return: The context value.
+        :rtype: RoutingContext
+        """
+        code = str(getattr(self, "code", ""))
+        payload = getattr(self._dto, "payload", "")
+        if code == "3220" and len(payload) >= 6:
+            return RoutingContext(payload[4:6])
+        return RoutingContext(getattr(self, "_idx_val", None))
+
+    @property
+    def state_header(self) -> StateHeader:
+        """Calculate the state routing header natively.
+
+        :return: The state header instance.
+        :rtype: StateHeader
+        """
+        return StateHeader.create(
+            code=self.code,
+            verb=self.verb,
+            source_id=self.src.id,
+            context_val=self.context.value,
+        )
 
     @property
     def _pkt(self) -> Any:
@@ -270,8 +275,8 @@ class Message:
             name_0 = ""
             name_1 = self._name(self.src)
 
-        if _GET_CODE_NAME_CB is not None:
-            code_name = _GET_CODE_NAME_CB(self.code)
+        if Message._GET_CODE_NAME_CB is not None:
+            code_name = Message._GET_CODE_NAME_CB(self.code)
         else:
             code_name = f"unknown_{self.code}"
 
@@ -379,8 +384,8 @@ class Message:
             undetermined.
         :rtype: dict[str, str]
         """
-        if _GET_MSG_IDX_CB is not None:
-            return _GET_MSG_IDX_CB(self)
+        if Message._GET_MSG_IDX_CB is not None:
+            return Message._GET_MSG_IDX_CB(self)
 
         IDX_NAMES = {
             Code._0002: "other_idx",
@@ -430,9 +435,9 @@ class Message:
 
         # BRIDGED LOGIC:
         is_controller = True
-        if _IS_CONTROLLER_CB is not None:
+        if Message._IS_CONTROLLER_CB is not None:
             # Use the injected domain logic from ramses_rf
-            is_controller = _IS_CONTROLLER_CB(self.src.id)
+            is_controller = Message._IS_CONTROLLER_CB(self.src.id)
         else:
             # Fallback for legacy tests until they are updated
             is_controller = getattr(self.src, "_is_controller", True)

--- a/src/ramses_rf/parsers/dhw.py
+++ b/src/ramses_rf/parsers/dhw.py
@@ -20,7 +20,7 @@ from ramses_tx.typing import PayDictT
 from .registry import register_parser
 
 if TYPE_CHECKING:
-    from ramses_rf.message import Message
+    from ramses_rf.messages import Message
 
 
 # dhw (cylinder) params  # FIXME: a bit messy

--- a/src/ramses_rf/parsers/heating.py
+++ b/src/ramses_rf/parsers/heating.py
@@ -62,7 +62,7 @@ from ramses_tx.typing import PayDictT
 from .registry import register_parser
 
 if TYPE_CHECKING:
-    from ramses_rf.message import Message
+    from ramses_rf.messages import Message
 
 _LOGGER = logging.getLogger(__name__)
 _INFORM_DEV_MSG = "Support the development of ramses_rf by reporting this packet"

--- a/src/ramses_rf/parsers/hvac.py
+++ b/src/ramses_rf/parsers/hvac.py
@@ -60,7 +60,7 @@ from ramses_tx.typing import PayDictT
 from .registry import register_parser
 
 if TYPE_CHECKING:
-    from ramses_rf.message import Message
+    from ramses_rf.messages import Message
 
 _LOGGER = logging.getLogger(__name__)
 _INFORM_DEV_MSG = "Support the development of ramses_rf by reporting this packet"

--- a/src/ramses_rf/parsers/opentherm.py
+++ b/src/ramses_rf/parsers/opentherm.py
@@ -26,7 +26,7 @@ from ramses_tx.typing import PayDictT
 from .registry import register_parser
 
 if TYPE_CHECKING:
-    from ramses_rf.message import Message
+    from ramses_rf.messages import Message
 
 _LOGGER = logging.getLogger(__name__)
 _INFORM_DEV_MSG = "Support the development of ramses_rf by reporting this packet"

--- a/src/ramses_rf/parsers/pipeline.py
+++ b/src/ramses_rf/parsers/pipeline.py
@@ -19,7 +19,7 @@ from ramses_tx.ramses import CODES_SCHEMA, RQ_IDX_COMPLEX
 from .registry import get_parser
 
 if TYPE_CHECKING:
-    from ramses_rf.message import Message
+    from ramses_rf.messages import Message
 
 _LOGGER = logging.getLogger(__name__)
 _INFORM_DEV_MSG = "Support the development of ramses_rf by reporting this packet"

--- a/src/ramses_rf/parsers/system.py
+++ b/src/ramses_rf/parsers/system.py
@@ -98,7 +98,7 @@ from ramses_tx.version import VERSION
 from .registry import register_parser
 
 if TYPE_CHECKING:
-    from ramses_rf.message import Message
+    from ramses_rf.messages import Message
 
 _LOGGER = logging.getLogger(__name__)
 _INFORM_DEV_MSG = "Support the development of ramses_rf by reporting this packet"

--- a/src/ramses_rf/routing.py
+++ b/src/ramses_rf/routing.py
@@ -1,0 +1,135 @@
+#!/usr/bin/env python3
+"""RAMSES RF - Domain Routing and Addressing.
+
+This module provides the strictly-typed, immutable Data Transfer Objects
+responsible for L7 domain routing, replacing legacy L3 string parsing.
+It acts as the foundation for the asynchronous event-driven SSOT.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import StrEnum
+
+from ramses_tx.const import Code, VerbT
+from ramses_tx.typing import DeviceIdT
+
+
+class EventTopic(StrEnum):
+    """Strict enumeration of valid topics for the SSOT event bus."""
+
+    INFORMATION = "information"  # Maps to ' I'
+    TOPOLOGY_DISCOVERY = "topology_discovery"  # Maps to ' I' for 1FC9
+    REQUEST = "request"  # Maps to 'RQ'
+    WRITE = "write"  # Maps to ' W'
+    RESPONSE = "response"  # Maps to 'RP'
+
+
+@dataclass(frozen=True, slots=True)
+class RoutingContext:
+    """Represents the sub-payload context for routing within a device.
+
+    This acts as a Secondary Routing Key, guaranteeing isolation between
+    different sub-entities operating on the same physical device.
+    """
+
+    value: str | bool | None
+
+    @property
+    def as_string(self) -> str:
+        """Format the context safely for legacy string interpolation.
+
+        Examples:
+            RoutingContext(True) -> "True"
+            RoutingContext("00") -> "00"
+            RoutingContext(None) -> "None"
+
+        :return: The context value as a string.
+        :rtype: str
+        """
+        if self.value is True:
+            return "True"
+        if self.value is False:
+            return "False"
+        return str(self.value)
+
+
+@dataclass(frozen=True, slots=True)
+class StateHeader:
+    """The primary immutable routing key for state caching and CQRS.
+
+    Provides O(1) dictionary hashing and serves as the bridge toward
+    the event-driven Master Plan (routing into topics and dest_ids).
+    """
+
+    code: Code
+    verb: VerbT
+    source_id: DeviceIdT
+    context: RoutingContext
+
+    @classmethod
+    def create(
+        cls,
+        code: Code | str,
+        verb: VerbT | str,
+        source_id: DeviceIdT | str,
+        context_val: str | bool | None,
+    ) -> StateHeader:
+        """Cleanly generate a StateHeader from primitive or rich variables.
+
+        :param code: The message command code (e.g., '3220' or Code._3220).
+        :type code: Code | str
+        :param verb: The message verb (e.g., ' I', 'RP' or VerbT.I_).
+        :type verb: VerbT | str
+        :param source_id: The source L2 device ID (e.g., '01:123456').
+        :type source_id: DeviceIdT | str
+        :param context_val: The sub-payload context key.
+        :type context_val: str | bool | None
+        :return: The immutable StateHeader instance.
+        :rtype: StateHeader
+        """
+        # Safely promote strings to rich types if necessary
+        safe_code = Code(code) if isinstance(code, str) else code
+        safe_verb = VerbT(verb) if isinstance(verb, str) else verb
+        safe_src = DeviceIdT(source_id) if isinstance(source_id, str) else source_id
+
+        return cls(
+            code=safe_code,
+            verb=safe_verb,
+            source_id=safe_src,
+            context=RoutingContext(context_val),
+        )
+
+    @property
+    def legacy_hdr(self) -> str:
+        """Calculate the legacy state routing header natively.
+
+        Format: '{code}|{verb}|{src_id}|{ctx_str}'
+        Example: '3220|RP|01:123456|00'
+
+        :return: The legacy pipe-separated routing string.
+        :rtype: str
+        """
+        return f"{self.code}|{self.verb}|{self.source_id}|{self.context.as_string}"
+
+    @property
+    def topic(self) -> EventTopic:
+        """Master Plan alignment: Generate the SSOT event topic.
+
+        This provides the standardized envelope topic for the future
+        DecodedMessage event stream based on the verb/code.
+
+        :return: The strictly-typed event topic enum.
+        :rtype: EventTopic
+        """
+        if self.code == Code._1FC9:
+            return EventTopic.TOPOLOGY_DISCOVERY
+
+        if self.verb == VerbT.I_:
+            return EventTopic.INFORMATION
+        if self.verb == VerbT.RQ:
+            return EventTopic.REQUEST
+        if self.verb == VerbT.W_:
+            return EventTopic.WRITE
+
+        return EventTopic.RESPONSE

--- a/src/ramses_rf/state/__init__.py
+++ b/src/ramses_rf/state/__init__.py
@@ -1,0 +1,6 @@
+"""RAMSES RF - State Management and Single Source of Truth (SSOT)."""
+
+from .entity_state import EntityState, StateCache
+from .store import MessageStore
+
+__all__ = ["EntityState", "MessageStore", "StateCache"]

--- a/src/ramses_rf/state/entity_state.py
+++ b/src/ramses_rf/state/entity_state.py
@@ -2,8 +2,8 @@
 """RAMSES RF - State Storage and Database Query Component.
 
 This module provides the EntityState component, which manages database
-interactions and state querying for an entity, replacing the legacy
-_MessageDB inheritance model.
+interactions and state querying for an entity, bridging the Event-Driven
+architecture using native StateHeader dictionary lookups.
 """
 
 from __future__ import annotations
@@ -13,22 +13,22 @@ import logging
 from datetime import UTC, datetime as dt
 from typing import TYPE_CHECKING, Any, cast
 
-from ramses_rf.messages import Message
 from ramses_tx.address import ALL_DEVICE_ID
 
 # noqa: F401, isort: skip, pylint: disable=unused-import
 from ramses_tx.const import I_, RP, RQ, Code, VerbT
 from ramses_tx.ramses import CODES_SCHEMA
 
-from . import exceptions as exc
-from .const import SZ_DOMAIN_ID, SZ_NAME, SZ_ZONE_IDX
+from .. import exceptions as exc
+from ..const import SZ_DOMAIN_ID, SZ_NAME, SZ_ZONE_IDX
+from ..messages import ApplicationMessage, Message
+from ..routing import RoutingContext, StateHeader
 
 if TYPE_CHECKING:
-    from ramses_rf.messages import ApplicationMessage
     from ramses_tx.typing import HeaderT
 
-    from .interfaces import DeviceInterface, GatewayInterface
-    from .message_store import MessageStore
+    from ..interfaces import DeviceInterface, GatewayInterface
+    from .store import MessageStore
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -37,31 +37,40 @@ _ID_SLICE = 9
 
 
 class StateCache:
-    """Encapsulates the state cache data collection for an entity."""
+    """Encapsulates the state cache data collection for an entity.
+
+    Now natively powered by O(1) dictionary lookups via StateHeader DTOs.
+    """
 
     def __init__(self) -> None:
         """Initialize the StateCache."""
-        self._cache: dict[tuple[Code, VerbT, Any], ApplicationMessage] = {}
+        self._cache: dict[StateHeader, ApplicationMessage] = {}
 
-    def add(
-        self,
-        code: Code,
-        verb: VerbT,
-        ctx: Any,
-        msg: ApplicationMessage,
-    ) -> None:
-        """Add a message to the cache."""
-        self._cache[(code, verb, ctx)] = msg
+    def add(self, msg: ApplicationMessage) -> None:
+        """Add a message to the cache natively via its header."""
+        self._cache[msg.state_header] = msg
 
-    def get_message(
+    def get_message(self, header: StateHeader) -> ApplicationMessage | None:
+        """Retrieve a message directly by its StateHeader."""
+        return self._cache.get(header)
+
+    def get_by_routing_key(
         self, code: Code, verb: VerbT, ctx: Any
     ) -> ApplicationMessage | None:
-        """Retrieve a message by its code, verb, and context."""
-        return self._cache.get((code, verb, ctx))
+        """Fallback O(N) lookup when source_id is unknown."""
+        ctx_str = RoutingContext(ctx).as_string
+        for hdr, msg in self._cache.items():
+            if (
+                hdr.code == code
+                and hdr.verb == verb
+                and hdr.context.as_string == ctx_str
+            ):
+                return msg
+        return None
 
     def get_by_code(self, code: Code) -> list[ApplicationMessage]:
         """Retrieve all messages for a specific code."""
-        return [msg for (c, _, _), msg in self._cache.items() if c == code]
+        return [msg for hdr, msg in self._cache.items() if hdr.code == code]
 
     def get_all(self) -> list[ApplicationMessage]:
         """Retrieve all stored messages."""
@@ -71,71 +80,56 @@ class StateCache:
         self,
     ) -> list[tuple[Code, VerbT, Any, ApplicationMessage]]:
         """Retrieve all cache records as tuples of (code, verb, ctx, msg)."""
-        return [(c, v, cx, m) for (c, v, cx), m in self._cache.items()]
+        return [(h.code, h.verb, h.context.value, m) for h, m in self._cache.items()]
 
 
 class EntityState:
     """Manages database interactions and state queries for an entity.
 
     This class acts as a stateless facade. It delegates all heavy lifting
-    and data storage to the Gateway's central MessageStore RAM cache.
+    to the Gateway's central MessageStore while serving as the SSOT ingestion point.
     """
 
     def __init__(self, entity: DeviceInterface, gwy: GatewayInterface) -> None:
         """Initialize the EntityState."""
         self._entity = entity
         self._gwy = gwy
-        # NEW: Context-Aware O(1) Dictionary for Push-Model state caching
-        self._current_state: dict[tuple[Code, VerbT, Any], ApplicationMessage] = {}
-        # Tracks cursor position in global log (Rewritten: tracks memory ID)
-        self._last_msg_id: int | None = None
+        # Context-Aware O(1) Dictionary natively keyed by StateHeader DTO
+        self._current_state: dict[StateHeader, ApplicationMessage] = {}
+        self._log_cursor: int = 0  # Tracks cursor position in global log
 
     def _sync_state(self) -> None:
-        """Hybrid Push Model: Sync O(1) cache using a cursor on the
-        global log.
-        """
+        """Hybrid Push Model: Sync O(1) cache using a cursor on the global log."""
         if self._gwy.message_store is None:
             return
 
-        msg_store = cast("MessageStore", self._gwy.message_store)
-        msg_log = getattr(msg_store, "_message_log", None)
+        log_iterable = self._gwy.message_store.log_by_dtm
+        if isinstance(log_iterable, dict):
+            log_iterable = list(log_iterable.values())
 
-        # In production msg_log is an OrderedDict, but tests inject MagicMocks.
-        # This fallback prevents StopIteration when testing.
-        if isinstance(msg_log, dict):
-            if not msg_log:
-                if getattr(self, "_last_msg_id", None) is not None:
-                    # The global log was cleared (e.g. cache reset). Rebuild.
-                    self._current_state.clear()
-                    self._last_msg_id = None
-                return
-            last_msg = msg_log[next(reversed(msg_log))]
-        else:
-            log_iterable = msg_store.log_by_dtm
-            if not log_iterable:
-                if getattr(self, "_last_msg_id", None) is not None:
-                    # The global log was cleared (e.g. cache reset). Rebuild.
-                    self._current_state.clear()
-                    self._last_msg_id = None
-                return
-            last_msg = log_iterable[-1]
-
-        current_id = id(last_msg)
-
-        if getattr(self, "_last_msg_id", None) == current_id:
+        current_len = len(log_iterable)
+        if current_len == self._log_cursor:
             return  # No new packets, O(1) instant exit
 
-        self._last_msg_id = current_id
-
-        full_log = msg_store.log_by_dtm
-
-        # The global log was cleared (e.g. cache reset). Rebuild.
-        self._current_state.clear()
+        if current_len < self._log_cursor:
+            # The global log was cleared (e.g. cache reset). Rebuild.
+            self._log_cursor = 0
+            self._current_state.clear()
 
         # Only process NEW packets appended since the last sync
-        # (Rewritten: processing all to fix cursor millisecond-collision)
-        for msg in full_log:
-            self.update_state(cast("ApplicationMessage", msg))
+        new_msgs = log_iterable[self._log_cursor :]
+        for msg in new_msgs:
+            self.ingest_message(msg)
+
+        self._log_cursor = current_len
+
+    def ingest_message(self, msg: ApplicationMessage) -> None:
+        """SSOT async ingestion queue preparation.
+
+        In Phase 3, this will drop the DecodedMessage into an asyncio.Queue.
+        For now, it processes the state synchronously.
+        """
+        self.update_state(msg)
 
     def update_state(self, msg: ApplicationMessage) -> None:
         """Push model: Instantly cache relevant messages upon arrival."""
@@ -145,7 +139,7 @@ class EntityState:
         entity_id = self._entity.id
         is_dhw = entity_id[_ID_SLICE:] == "_HW"
         is_zone = len(entity_id) > 9 and not is_dhw
-        ctx = getattr(msg._pkt, "_ctx", None)
+        ctx = msg.context.value
 
         if is_zone:
             zone_idx = entity_id[_ID_SLICE + 1 :]
@@ -177,13 +171,11 @@ class EntityState:
             ):
                 return  # Payload does not belong to DHW
 
-        # Context-aware O(1) Overwrite guarantees isolation
-        self._current_state[(msg.code, msg.verb, ctx)] = msg
+        # Context-aware O(1) Overwrite directly keyed by the DTO guarantees isolation
+        self._current_state[msg.state_header] = msg
 
     def _is_relevant_msg(self, msg: ApplicationMessage) -> bool:
-        """Check if a central MessageStore packet is relevant to this
-        entity.
-        """
+        """Check if a central MessageStore packet is relevant to this entity."""
         return bool(
             msg.src.id == self._entity.id[:_ID_SLICE]
             or (msg.dst.id == self._entity.id[:_ID_SLICE] and msg.verb != RQ)
@@ -213,38 +205,58 @@ class EntityState:
     async def _delete_msg(self, msg: ApplicationMessage) -> None:
         """Remove the msg from the central state databases."""
         if self._gwy.message_store:
-            await cast("MessageStore", self._gwy.message_store).rem(msg)
+            store = cast("MessageStore", self._gwy.message_store)
+            await store.rem(msg)
 
-    async def _get_msg_by_hdr(self, hdr: HeaderT) -> ApplicationMessage | None:
+    async def _get_msg_by_hdr(
+        self, hdr: HeaderT | StateHeader
+    ) -> ApplicationMessage | None:
         """Return a msg, if any, that matches a given header."""
+        if isinstance(hdr, str):
+            code_str, verb_str, src_id, *args = hdr.split("|")
+            ctx_val: str | bool | None = args[0] if args else None
+            if ctx_val == "True":
+                ctx_val = True
+            elif ctx_val == "False":
+                ctx_val = False
+            header = StateHeader.create(code_str, verb_str, src_id, ctx_val)
+        else:
+            header = hdr
+
         if self._gwy.message_store:
-            msgs = await self._gwy.message_store.get(hdr=hdr)
+            store = cast("MessageStore", self._gwy.message_store)
+            msgs = await store.get(hdr=header)
             if msgs:
-                if msgs[0]._pkt._hdr != hdr:
+                if (
+                    msgs[0].state_header != header
+                    and msgs[0].state_header.legacy_hdr != hdr
+                ):
                     raise exc.DatabaseQueryError(
-                        f"Header mismatch: {msgs[0]._pkt._hdr} != {hdr}"
+                        f"Header mismatch: {msgs[0].state_header.legacy_hdr} != {hdr}"
                     )
                 return cast("ApplicationMessage", msgs[0])
             return None
 
-        code_str, verb_str, _, *args = hdr.split("|")
-        code = Code(code_str)
-        verb = VerbT(verb_str)
         cache = await self._build_state_cache()
+        msg = cache.get_message(header)
 
-        msg = None
-        if args and (ctx := args[0]):
-            msg = cache.get_message(code, verb, ctx)
-        else:
-            msg = cache.get_message(code, verb, False)
-            if msg is None:
-                msg = cache.get_message(code, verb, None)
+        # Fallbacks for unknown source ID routing
+        if msg is None:
+            msg = cache.get_by_routing_key(
+                header.code, header.verb, header.context.value
+            )
+        if msg is None:
+            msg = cache.get_by_routing_key(header.code, header.verb, False)
+        if msg is None:
+            msg = cache.get_by_routing_key(header.code, header.verb, None)
 
         if msg is None:
             return None
 
-        if msg._pkt._hdr != hdr:
-            raise exc.DatabaseQueryError(f"Header mismatch: {msg._pkt._hdr} != {hdr}")
+        if msg.state_header != header and msg.state_header.legacy_hdr != hdr:
+            raise exc.DatabaseQueryError(
+                f"Header mismatch: {msg.state_header.legacy_hdr} != {hdr}"
+            )
         return msg
 
     async def get_flag(self, code: Code, key: str, idx: int) -> bool | None:
@@ -306,12 +318,12 @@ class EntityState:
                     if not ctx and is_dhw:
                         ctx = kwargs.get("dhw_idx", "HW")
 
-                    msg = cache.get_message(cd, verb, ctx)
+                    msg = cache.get_by_routing_key(cd, verb, ctx)
                     if msg is None:
                         # Fallbacks for base devices
-                        msg = cache.get_message(cd, verb, False)
+                        msg = cache.get_by_routing_key(cd, verb, False)
                     if msg is None:
-                        msg = cache.get_message(cd, verb, None)
+                        msg = cache.get_by_routing_key(cd, verb, None)
                 else:
                     msg = None
             except KeyError:
@@ -338,7 +350,7 @@ class EntityState:
             return None
         elif getattr(msg, "_expired", False):
             if not getattr(msg, "_delete_task_queued", False):
-                msg._delete_task_queued = True  # type: ignore[attr-defined]
+                msg._delete_task_queued = True  # Prevent queue flooding
                 loop = getattr(self._gwy, "_loop", asyncio.get_running_loop())
                 loop.create_task(self._delete_msg(msg))
 
@@ -525,9 +537,7 @@ class EntityState:
         return []
 
     async def get_message_log_flat(self) -> dict[Code, ApplicationMessage]:
-        """Dynamically build a flat dict of all I/RP messages logged for
-        this entity.
-        """
+        """Dynamically build a flat dict of all I/RP messages logged for this entity."""
         self._sync_state()
         _msg_dict: dict[Code, ApplicationMessage] = {}
 
@@ -548,8 +558,8 @@ class EntityState:
         cache = StateCache()
 
         # Extremely fast O(1) iteration, bypassing global history!
-        for (code, verb, ctx), msg in self._current_state.items():
-            cache.add(code, verb, ctx, msg)
+        for _hdr, msg in self._current_state.items():
+            cache.add(msg)
 
         return cache
 

--- a/src/ramses_rf/state/store.py
+++ b/src/ramses_rf/state/store.py
@@ -2,7 +2,7 @@
 """
 RAMSES RF - Message database and index.
 
-.. table:: Database Query Methods[^1][#fn1]
+.. table:: Database Query Methods
    :widths: auto
 
    =====  ============  ===========  ==========  ====  ========================
@@ -12,14 +12,6 @@ RAMSES RF - Message database and index.
    i2     contains      kwargs       bool        i1    EntityState
    i7     get_rp_codes  src, dst     list(Code)        Discovery-supported_cmds
    =====  ============  ===========  ==========  ====  ========================
-
-[#fn1] A word of explanation.[^1]: This table documents the primary
-methods used by external components (like `EntityState`) to query the
-central message store. As of Phase 2.5, legacy SQL-based query methods
-(`qry`, `qry_field`, `_select_from`) have been removed. The system now
-relies exclusively on fast RAM-based dictionary lookups to support a
-CQRS-style architecture and eliminate SQLite thread contention during
-tests.
 """
 
 from __future__ import annotations
@@ -38,9 +30,10 @@ import orjson
 
 from ramses_tx import CODES_SCHEMA, RP, RQ, Code, Packet
 
-from .exceptions import DatabaseQueryError
-from .messages import Message
-from .sqlite_worker import PacketLogEntry, SQLiteWorker
+from ..exceptions import DatabaseQueryError
+from ..messages.base import Message
+from ..routing import StateHeader
+from ..sqlite_worker import PacketLogEntry, SQLiteWorker
 
 DtmStrT = NewType("DtmStrT", str)
 
@@ -97,8 +90,7 @@ def payload_keys(parsed_payload: list[dict[str, Any]] | dict[str, Any]) -> str:
 class MessageStore:
     """A central in-memory SQLite3 database for indexing RF messages.
     Index holds all the latest messages to & from all devices by `dtm`
-    (timestamp) and `hdr` header
-    (example of a hdr: ``000C|RP|01:223036|0208``)."""
+    (timestamp) and strictly-typed `StateHeader` DTOs."""
 
     _housekeeping_task: asyncio.Task[None]
     _hydration_task: asyncio.Task[None]
@@ -115,8 +107,8 @@ class MessageStore:
         # In-memory RAM caches (Filled & cleaned up in housekeeping_loop)
         # stores all messages for retrieval.
         self._message_log: MsgDdT = OrderedDict()
-        # Caches the latest message per header (hdr) for fast state lookups.
-        self._state_cache: dict[str, Message] = {}
+        # Caches the latest message per strictly-typed StateHeader.
+        self._state_cache: dict[StateHeader, Message] = {}
 
         # Synchronous Test Mode: Bypass background worker entirely if testing
         self._is_testing = "PYTEST_CURRENT_TEST" in os.environ
@@ -172,7 +164,7 @@ class MessageStore:
         self.start()
 
     def __repr__(self) -> str:
-        return f"MessageStore({len(self._message_log)} messages)"  # or msg_db.count()
+        return f"MessageStore({len(self._message_log)} messages)"
 
     def start(self) -> None:
         """Start the housekeeper loop."""
@@ -226,8 +218,8 @@ class MessageStore:
         return tuple(self._message_log.values())
 
     @property
-    def state_cache(self) -> dict[str, Message]:
-        """Return the latest messages in the index by header."""
+    def state_cache(self) -> dict[StateHeader, Message]:
+        """Return the latest messages in the index natively keyed by StateHeader."""
         return self._state_cache
 
     def flush(self) -> None:
@@ -287,7 +279,7 @@ class MessageStore:
                     msg._payload = orjson.loads(payload_blob)
 
                     self._message_log[dtm_str] = msg
-                    self._state_cache[hdr] = msg
+                    self._state_cache[msg.state_header] = msg
                 except Exception as err:
                     _LOGGER.debug("Failed to reconstruct message for %s: %s", hdr, err)
         finally:
@@ -327,8 +319,8 @@ class MessageStore:
 
                 valid_dtms = set(self._message_log.keys())
                 self._state_cache = {
-                    hdr: m
-                    for hdr, m in self._state_cache.items()
+                    m.state_header: m
+                    for m in self._state_cache.values()
                     if cast(DtmStrT, m.dtm.isoformat(timespec="microseconds"))
                     in valid_dtms
                 }
@@ -373,8 +365,7 @@ class MessageStore:
             pass
         else:
             self._message_log[dtm_str] = msg
-            if msg._pkt._hdr is not None:
-                self._state_cache[msg._pkt._hdr] = msg
+            self._state_cache[msg.state_header] = msg
         finally:
             pass
 
@@ -387,7 +378,7 @@ class MessageStore:
             _LOGGER.debug(
                 "Overwrote dtm (%s) for %s: %s (contrived log?)",
                 msg.dtm,
-                msg._pkt._hdr,
+                msg.state_header.legacy_hdr,
                 dup[0]._pkt,
             )
 
@@ -429,7 +420,7 @@ class MessageStore:
             Packet(_now, f"... {verb} --- {src} --:------ {src} {code} 005 0000000000")
         )
         self._message_log[dtm] = msg
-        self._state_cache[hdr] = msg
+        self._state_cache[msg.state_header] = msg
 
     def _insert_into(self, msg: Message) -> Message | None:
         """
@@ -437,15 +428,6 @@ class MessageStore:
 
         :returns: any message replaced (by same hdr)
         """
-        assert msg._pkt._hdr is not None, f"Skipping: Packet has no hdr: {msg._pkt}"
-
-        if msg._pkt._ctx is True:
-            msg_pkt_ctx = "True"
-        elif msg._pkt._ctx is False:
-            msg_pkt_ctx = "False"
-        else:
-            msg_pkt_ctx = msg._pkt._ctx  # can be None
-
         if self._worker:
             try:
                 payload_blob = orjson.dumps(msg.payload)
@@ -459,8 +441,8 @@ class MessageStore:
                 src=msg.src.id,
                 dst=msg.dst.id,
                 code=str(msg.code),
-                ctx=msg_pkt_ctx,
-                hdr=msg._pkt._hdr,
+                ctx=msg.context.as_string,
+                hdr=msg.state_header.legacy_hdr,
                 plk=payload_keys(msg.payload),
                 payload_blob=payload_blob,
                 frame=getattr(msg._pkt, "_frame", ""),
@@ -480,7 +462,7 @@ class MessageStore:
         verb: str | None = None,
         code: str | None = None,
         ctx: Any | None = None,
-        hdr: str | None = None,
+        hdr: str | StateHeader | None = None,
     ) -> tuple[Message, ...] | None:
         """Remove a set of message(s) from the index."""
         kwargs = {
@@ -540,8 +522,7 @@ class MessageStore:
                 for m in msgs:
                     dtm_val = cast(DtmStrT, m.dtm.isoformat(timespec="microseconds"))
                     self._message_log.pop(dtm_val, None)
-                    if m._pkt._hdr is not None:
-                        self._state_cache.pop(m._pkt._hdr, None)
+                    self._state_cache.pop(m.state_header, None)
         return msgs
 
     async def get(
@@ -554,7 +535,7 @@ class MessageStore:
         verb: str | None = None,
         code: str | None = None,
         ctx: Any | None = None,
-        hdr: str | None = None,
+        hdr: str | StateHeader | None = None,
     ) -> tuple[Message, ...]:
         """Public method to get a set of message(s) from the index."""
         kwargs = {
@@ -607,18 +588,17 @@ class MessageStore:
                 elif k == "code" and str(m.code) != v:
                     match = False
                     break
-                elif k == "hdr" and m._pkt._hdr != v:
-                    match = False
-                    break
+                elif k == "hdr":
+                    if isinstance(v, StateHeader):
+                        if m.state_header != v:
+                            match = False
+                            break
+                    else:
+                        if m.state_header.legacy_hdr != v:
+                            match = False
+                            break
                 elif k == "ctx":
-                    m_ctx = (
-                        "True"
-                        if m._pkt._ctx is True
-                        else "False"
-                        if m._pkt._ctx is False
-                        else str(m._pkt._ctx)
-                    )
-                    if m_ctx != v:
+                    if m.context.as_string != str(v):
                         match = False
                         break
             if match:
@@ -635,7 +615,7 @@ class MessageStore:
         verb: str | None = None,
         code: str | None = None,
         ctx: Any | None = None,
-        hdr: str | None = None,
+        hdr: str | StateHeader | None = None,
     ) -> bool:
         """Check if the MessageStore contains at least 1 record that
         matches the provided fields."""

--- a/src/ramses_rf/system/faultlog.py
+++ b/src/ramses_rf/system/faultlog.py
@@ -21,7 +21,7 @@ from ramses_tx.const import (
 from ramses_tx.helpers import parse_fault_log_entry
 from ramses_tx.typing import DeviceIdT, PayloadT
 
-from ..message import Message
+from ..messages import Message
 
 from ramses_rf.const import (  # noqa: F401, isort: skip, pylint: disable=unused-import
     I_,

--- a/src/ramses_rf/system/heat.py
+++ b/src/ramses_rf/system/heat.py
@@ -63,7 +63,7 @@ from ramses_tx import (
 )
 from ramses_tx.typing import PayDictT, PayloadT
 
-from ..message import Message
+from ..messages import Message
 from .faultlog import FaultLog
 from .zones import zone_factory
 

--- a/src/ramses_rf/system/heat.py
+++ b/src/ramses_rf/system/heat.py
@@ -36,7 +36,7 @@ from ramses_rf.device import (
     Temperature,
     UfhController,
 )
-from ramses_rf.entity_base import Entity, class_by_attr
+from ramses_rf.entity import Entity, class_by_attr
 from ramses_rf.exceptions import ScheduleFlowError, SchemaInconsistentError
 from ramses_rf.helpers import shrink
 from ramses_rf.schemas import (

--- a/src/ramses_rf/system/schedule.py
+++ b/src/ramses_rf/system/schedule.py
@@ -23,7 +23,7 @@ from ramses_rf.const import (
     SZ_TOTAL_FRAGS,
     SZ_ZONE_IDX,
 )
-from ramses_rf.message import Message
+from ramses_rf.messages import Message
 from ramses_tx.command import Command
 from ramses_tx.const import SZ_CHANGE_COUNTER, Priority
 from ramses_tx.exceptions import ProtocolSendFailed

--- a/src/ramses_rf/system/zones.py
+++ b/src/ramses_rf/system/zones.py
@@ -35,7 +35,7 @@ from ramses_rf.device import (
     TrvActuator,
     UfhController,
 )
-from ramses_rf.entity_base import _ID_SLICE, Entity, class_by_attr
+from ramses_rf.entity import _ID_SLICE, Entity, class_by_attr
 from ramses_rf.helpers import shrink
 from ramses_rf.schemas import (
     SCH_TCS_DHW,

--- a/src/ramses_rf/system/zones.py
+++ b/src/ramses_rf/system/zones.py
@@ -52,7 +52,7 @@ from ramses_tx import Address, Command, Priority
 from ramses_tx.exceptions import ProtocolSendFailed, ProtocolTimeoutError
 from ramses_tx.typing import HeaderT, PayDictT, PayloadT
 
-from ..message import Message
+from ..messages import Message
 from .schedule import InnerScheduleT, OuterScheduleT, Schedule
 
 if TYPE_CHECKING:

--- a/src/ramses_rf/topology.py
+++ b/src/ramses_rf/topology.py
@@ -15,7 +15,7 @@ from .const import DEV_TYPE_MAP, F9, FA, FC, FF, SZ_ACTUATORS, SZ_SENSOR, SZ_ZON
 from .schemas import SZ_CIRCUITS
 
 if TYPE_CHECKING:
-    from ramses_rf.message import Message
+    from ramses_rf.messages import Message
     from ramses_tx.typing import DeviceIdT
 
     from .device import Controller

--- a/src/ramses_rf/topology.py
+++ b/src/ramses_rf/topology.py
@@ -19,7 +19,7 @@ if TYPE_CHECKING:
     from ramses_tx.typing import DeviceIdT
 
     from .device import Controller
-    from .entity_base import Entity
+    from .entity import Entity
     from .system import Evohome
 
 

--- a/tests/deprecated/_test_apis_mock.py
+++ b/tests/deprecated/_test_apis_mock.py
@@ -4,7 +4,7 @@
 from datetime import datetime as dt
 
 from ramses_rf.helpers import shrink
-from ramses_rf.message import Message
+from ramses_rf.messages import Message
 from ramses_tx.packet import Packet
 
 from .mocked_devices.command import MockCommand as Command

--- a/tests/deprecated/_test_mock_schedule.py
+++ b/tests/deprecated/_test_mock_schedule.py
@@ -24,7 +24,7 @@ from ramses_rf.system.schedule import (
     SZ_SWITCHPOINTS,
     SZ_TIME_OF_DAY,
 )
-from ramses_rf.message import Message
+from ramses_rf.messages import Message
 
 WORK_DIR = f"{TEST_DIR}/configs"
 CONFIG_FILE = "config_heat.json"

--- a/tests/tests/helpers.py
+++ b/tests/tests/helpers.py
@@ -16,8 +16,8 @@ import voluptuous as vol
 from ramses_rf import Gateway
 from ramses_rf.gateway import GatewayConfig
 from ramses_rf.helpers import shrink
-from ramses_rf.message_store import MessageStore
 from ramses_rf.schemas import SCH_GLOBAL_CONFIG, SCH_GLOBAL_SCHEMAS
+from ramses_rf.state import MessageStore
 from ramses_tx.config import EngineConfig
 from ramses_tx.schemas import SCH_GLOBAL_TRAITS_DICT
 

--- a/tests/tests/test_apis_binding.py
+++ b/tests/tests/test_apis_binding.py
@@ -14,7 +14,7 @@ from ramses_rf.device.hvac import (  # initiate_binding_process
     HvacDisplayRemote,
     HvacRemote,
 )
-from ramses_rf.message_store import MessageStore
+from ramses_rf.state import MessageStore
 from ramses_tx.address import Address
 from ramses_tx.const import Code
 

--- a/tests/tests/test_apis_heat.py
+++ b/tests/tests/test_apis_heat.py
@@ -7,7 +7,7 @@ from datetime import datetime as dt
 
 from ramses_rf.const import SZ_DOMAIN_ID
 from ramses_rf.helpers import shrink
-from ramses_rf.message import Message
+from ramses_rf.messages import Message
 from ramses_tx.address import HGI_DEV_ADDR
 from ramses_tx.command import Command
 from ramses_tx.const import SZ_TIMESTAMP

--- a/tests/tests/test_apis_hvac.py
+++ b/tests/tests/test_apis_hvac.py
@@ -5,7 +5,7 @@ from collections.abc import Callable
 from datetime import datetime as dt
 from typing import Any
 
-from ramses_rf.message import Message
+from ramses_rf.messages import Message
 from ramses_tx.command import CODE_API_MAP, Command
 from ramses_tx.packet import Packet
 

--- a/tests/tests/test_devices.py
+++ b/tests/tests/test_devices.py
@@ -5,7 +5,7 @@ from pathlib import Path, PurePath
 
 import pytest
 
-from ramses_rf.message import Message
+from ramses_rf.messages import Message
 from ramses_tx import exceptions as exc
 from ramses_tx.packet import Packet
 

--- a/tests/tests/test_parsers.py
+++ b/tests/tests/test_parsers.py
@@ -5,7 +5,7 @@ from pathlib import Path, PurePath
 
 import pytest
 
-from ramses_rf.message import Message
+from ramses_rf.messages import Message
 from ramses_tx.const import Code
 from ramses_tx.exceptions import PacketInvalid
 from ramses_tx.packet import Packet

--- a/tests/tests/test_sqlite_worker.py
+++ b/tests/tests/test_sqlite_worker.py
@@ -10,8 +10,8 @@ from pathlib import Path
 
 import pytest
 
-from ramses_rf.message_store import MessageStore
 from ramses_rf.messages import Message
+from ramses_rf.state import MessageStore
 from ramses_tx.packet import Packet
 
 

--- a/tests/tests/test_sqlite_worker.py
+++ b/tests/tests/test_sqlite_worker.py
@@ -10,8 +10,8 @@ from pathlib import Path
 
 import pytest
 
-from ramses_rf.message import Message
 from ramses_rf.message_store import MessageStore
+from ramses_rf.messages import Message
 from ramses_tx.packet import Packet
 
 

--- a/tests/tests/test_systems.py
+++ b/tests/tests/test_systems.py
@@ -17,8 +17,8 @@ import pytest
 
 from ramses_rf import Gateway
 from ramses_rf.helpers import shrink
-from ramses_rf.message import Message
 from ramses_rf.message_store import MessageStore
+from ramses_rf.messages import Message
 from ramses_tx import exceptions as exc
 from ramses_tx.packet import Packet
 
@@ -95,7 +95,7 @@ def global_test_patches() -> Generator[None, None, None]:
         patch("ramses_rf.gateway.dt", AwareDatetime),
         patch("ramses_tx.engine.dt", AwareDatetime),
         patch("ramses_tx.packet.dt", AwareDatetime),
-        patch("ramses_rf.message.Message._pkt", property(mocked_pkt_prop)),
+        patch("ramses_rf.messages.Message._pkt", property(mocked_pkt_prop)),
         patch(
             "ramses_rf.gateway.Gateway.async_send_cmd",
             patched_async_send_cmd,

--- a/tests/tests/test_systems.py
+++ b/tests/tests/test_systems.py
@@ -17,8 +17,8 @@ import pytest
 
 from ramses_rf import Gateway
 from ramses_rf.helpers import shrink
-from ramses_rf.message_store import MessageStore
 from ramses_rf.messages import Message
+from ramses_rf.state import MessageStore
 from ramses_tx import exceptions as exc
 from ramses_tx.packet import Packet
 
@@ -70,6 +70,15 @@ class PacketShim:
         self._dto = dto
         self._hdr = getattr(dto, "code", "0000")
         self._frame = getattr(dto, "payload", "")
+
+    @property
+    def _ctx(self) -> Any:
+        """Mock the native L3 context extraction."""
+        code = getattr(self._dto, "code", "")
+        payload = getattr(self._dto, "payload", "")
+        if code == "3220" and len(payload) >= 6:
+            return payload[4:6]
+        return None
 
     def __getattr__(self, name: str) -> Any:
         return getattr(self._dto, name)
@@ -250,12 +259,6 @@ async def test_fuzz_from_log_file(dir_name: Path) -> None:
     expected: dict = load_expected_results(dir_name) or {}
     gwy: Gateway = await load_test_gwy(dir_name)
 
-    # for dev in gwy.device_registry.devices:
-    #     if dev._msgs:
-    #         assert dev._msgs == gwy.message_store.get(
-    #             src=dev.id, dtms=list(dev._msgs.keys())
-    #         ), f"Assert 0: {dev} qry != _msgs_"
-
     schema, packets = await gwy.get_state(include_expired=True)
 
     # This loop is non-deterministic, but should be stable (fails rarely)
@@ -265,12 +268,6 @@ async def test_fuzz_from_log_file(dir_name: Path) -> None:
         packets = shuffle_dict(packets)
         await gwy._restore_cached_packets(packets)
         await assert_expected_set(gwy, expected)
-
-    # for dev in gwy.device_registry.devices:
-    #     if dev._msgs:
-    #         assert dev._msgs == gwy.message_store.get(
-    #             src=dev.id, dtms=list(dev._msgs.keys())
-    #         ), f"Assert 2: {dev} qry != _msgs_"
 
     await gwy.stop()
 
@@ -290,12 +287,6 @@ async def test_fuzz_from_log_file_sql(dir_name: Path) -> None:
     ):
         gwy: Gateway = await load_test_gwy(dir_name)
 
-    # for dev in gwy.device_registry.devices:
-    #     if dev._msgs:
-    #         assert dev._msgs == gwy.message_store.get(
-    #             src=dev.id, dtms=list(dev._msgs.keys())
-    #         ), f"Assert 1: {dev} qry != _msgs_"
-
     schema, packets = await gwy.get_state(include_expired=True)
 
     # This loop is non-deterministic, but should be stable (fails rarely)
@@ -309,11 +300,5 @@ async def test_fuzz_from_log_file_sql(dir_name: Path) -> None:
         await asyncio.sleep(0)  # Yield to allow flush callbacks to fire
 
         await assert_expected_set(gwy, expected)
-
-    # for dev in gwy.device_registry.devices:
-    #     if dev._msgs:
-    #         assert dev._msgs == gwy.message_store.get(
-    #             src=dev.id, dtms=list(dev._msgs.keys())
-    #         ), f"Assert 3: {dev} qry != _msgs_"
 
     await gwy.stop()

--- a/tests/tests_cli/test_client.py
+++ b/tests/tests_cli/test_client.py
@@ -33,8 +33,8 @@ from ramses_cli.client import (
 from ramses_rf import GracefulExit
 from ramses_rf.const import DEV_TYPE_MAP, I_, Code
 from ramses_rf.gateway import Gateway, GatewayConfig
-from ramses_rf.message import Message
 from ramses_rf.message_store import MessageStore
+from ramses_rf.messages import Message
 from ramses_rf.schemas import SZ_CONFIG, SZ_DISABLE_DISCOVERY
 from ramses_tx import exceptions as exc
 from ramses_tx.schemas import SZ_PACKET_LOG, SZ_SERIAL_PORT

--- a/tests/tests_cli/test_client.py
+++ b/tests/tests_cli/test_client.py
@@ -33,9 +33,9 @@ from ramses_cli.client import (
 from ramses_rf import GracefulExit
 from ramses_rf.const import DEV_TYPE_MAP, I_, Code
 from ramses_rf.gateway import Gateway, GatewayConfig
-from ramses_rf.message_store import MessageStore
 from ramses_rf.messages import Message
 from ramses_rf.schemas import SZ_CONFIG, SZ_DISABLE_DISCOVERY
+from ramses_rf.state import MessageStore
 from ramses_tx import exceptions as exc
 from ramses_tx.schemas import SZ_PACKET_LOG, SZ_SERIAL_PORT
 

--- a/tests/tests_rf/device/test_hvac_ventilator.py
+++ b/tests/tests_rf/device/test_hvac_ventilator.py
@@ -10,7 +10,7 @@ from ramses_rf import exceptions as exc
 from ramses_rf.const import DevType
 from ramses_rf.device.hvac import HvacVentilator
 from ramses_rf.gateway import Gateway
-from ramses_rf.message_store import MessageStore
+from ramses_rf.state import MessageStore
 from ramses_tx import Address
 from ramses_tx.const import Code, Priority
 from ramses_tx.typing import DeviceIdT

--- a/tests/tests_rf/test_device_heat.py
+++ b/tests/tests_rf/test_device_heat.py
@@ -18,7 +18,7 @@ from ramses_rf.device.heat import (
     TrvActuator,
 )
 from ramses_rf.exceptions import DeviceNotFaked
-from ramses_rf.message import Message
+from ramses_rf.messages import Message
 from ramses_tx import Code, Priority
 from ramses_tx.address import Address
 from ramses_tx.const import I_, RP, SZ_TEMPERATURE, MsgId

--- a/tests/tests_rf/test_dispatcher.py
+++ b/tests/tests_rf/test_dispatcher.py
@@ -10,8 +10,8 @@ import pytest
 
 from ramses_rf import Device, dispatcher
 from ramses_rf.gateway import Gateway, GatewayConfig
-from ramses_rf.message import Message
 from ramses_rf.message_store import MessageStore
+from ramses_rf.messages import Message
 from ramses_tx import Address, DeviceIdT, Packet
 
 

--- a/tests/tests_rf/test_dispatcher.py
+++ b/tests/tests_rf/test_dispatcher.py
@@ -10,8 +10,8 @@ import pytest
 
 from ramses_rf import Device, dispatcher
 from ramses_rf.gateway import Gateway, GatewayConfig
-from ramses_rf.message_store import MessageStore
 from ramses_rf.messages import Message
+from ramses_rf.state import MessageStore
 from ramses_tx import Address, DeviceIdT, Packet
 
 

--- a/tests/tests_rf/test_entity_base.py
+++ b/tests/tests_rf/test_entity_base.py
@@ -11,8 +11,8 @@ from ramses_rf.const import I_, RP
 from ramses_rf.entity_base import Entity, _Entity
 from ramses_rf.entity_state import StateCache
 from ramses_rf.gateway import Gateway
-from ramses_rf.message import Message
 from ramses_rf.message_store import MessageStore
+from ramses_rf.messages import Message
 from ramses_tx import Code, DeviceIdT, Packet
 
 

--- a/tests/tests_rf/test_entity_base.py
+++ b/tests/tests_rf/test_entity_base.py
@@ -11,7 +11,7 @@ from ramses_rf.const import I_, RP
 from ramses_rf.entity import Entity, _Entity
 from ramses_rf.gateway import Gateway
 from ramses_rf.messages import Message
-from ramses_rf.routing import StateHeader
+from ramses_rf.routing import RoutingContext, StateHeader
 from ramses_rf.state import MessageStore, StateCache
 from ramses_tx import Code, DeviceIdT, Packet
 
@@ -323,6 +323,10 @@ async def test_gh_396_sqlite_ot_context_type() -> None:
     mock_msg._pkt._hdr = "3220|RP|01:123456|0"
     mock_msg._idx_val = 0
 
+    # NEW: Properly mock the Native L7 domain properties
+    mock_msg.context = RoutingContext(0)
+    mock_msg.state_header = StateHeader.create(Code._3220, RP, "01:123456", 0)
+
     gwy.message_store.log_by_dtm = [mock_msg]
 
     # Instantiate the entity
@@ -361,7 +365,8 @@ async def test_gh_396_legacy_ot_context() -> None:
     mock_msg._pkt._hdr = "3220|RP|01:123456|05"
     mock_msg._idx_val = "05"
 
-    # NEW: Mock the native L7 state header
+    # NEW: Properly mock the Native L7 domain properties
+    mock_msg.context = RoutingContext("05")
     mock_msg.state_header = StateHeader.create(Code._3220, RP, "01:123456", "05")
 
     # Construct the mock StateCache

--- a/tests/tests_rf/test_entity_base.py
+++ b/tests/tests_rf/test_entity_base.py
@@ -8,11 +8,11 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from ramses_rf.const import I_, RP
-from ramses_rf.entity_base import Entity, _Entity
-from ramses_rf.entity_state import StateCache
+from ramses_rf.entity import Entity, _Entity
 from ramses_rf.gateway import Gateway
-from ramses_rf.message_store import MessageStore
 from ramses_rf.messages import Message
+from ramses_rf.routing import StateHeader
+from ramses_rf.state import MessageStore, StateCache
 from ramses_tx import Code, DeviceIdT, Packet
 
 
@@ -114,11 +114,20 @@ class Test_entity_base:
             ]
         ), "_msg_list wrong"
 
-        # create _msgz
+        # create _msgz - use StateHeader objects for lookups
         cache = await dev.entity_state._build_state_cache()
-        assert cache.get_message(Code._12B0, I_, "01") == self.msg7
-        assert cache.get_message(Code._3150, I_, "01") == self.msg5
-        assert cache.get_message(Code._3220, RP, "11") == self.msg6
+        assert (
+            cache.get_message(StateHeader.create(Code._12B0, I_, "04:189078", "01"))
+            == self.msg7
+        )
+        assert (
+            cache.get_message(StateHeader.create(Code._3150, I_, "04:189078", "01"))
+            == self.msg5
+        )
+        assert (
+            cache.get_message(StateHeader.create(Code._3220, RP, "01:145038", "11"))
+            == self.msg6
+        )
         assert len(cache.get_all()) == 3, "base state_cache wrong"
 
         mock_gateway.message_store.stop()  # close sqlite3 connection
@@ -162,8 +171,14 @@ class Test_entity_base:
 
         # create _msgz
         cache = await dev.entity_state._build_state_cache()
-        assert cache.get_message(Code._12B0, I_, "01") == self.msg7
-        assert cache.get_message(Code._3150, I_, "01") == self.msg5
+        assert (
+            cache.get_message(StateHeader.create(Code._12B0, I_, "04:189078", "01"))
+            == self.msg7
+        )
+        assert (
+            cache.get_message(StateHeader.create(Code._3150, I_, "04:189078", "01"))
+            == self.msg5
+        )
         assert len(cache.get_all()) == 2, "zone state_cache wrong"
 
         mock_gateway.message_store.stop()  # close sqlite3 connection
@@ -223,8 +238,14 @@ class Test_entity_base:
 
         # create _msgz
         cache = await dev.entity_state._build_state_cache()
-        assert cache.get_message(Code._1260, RP, "00") == self.msg9
-        assert cache.get_message(Code._3150, I_, "FC") == self.msg8
+        assert (
+            cache.get_message(StateHeader.create(Code._1260, RP, "01:145038", "00"))
+            == self.msg9
+        )
+        assert (
+            cache.get_message(StateHeader.create(Code._3150, I_, "01:145038", "FC"))
+            == self.msg8
+        )
         assert len(cache.get_all()) == 2, "dhw state_cache wrong"
 
         mock_gateway.message_store.stop()  # close sqlite3 connection
@@ -340,9 +361,12 @@ async def test_gh_396_legacy_ot_context() -> None:
     mock_msg._pkt._hdr = "3220|RP|01:123456|05"
     mock_msg._idx_val = "05"
 
+    # NEW: Mock the native L7 state header
+    mock_msg.state_header = StateHeader.create(Code._3220, RP, "01:123456", "05")
+
     # Construct the mock StateCache
     fake_cache = StateCache()
-    fake_cache.add(Code._3220, RP, "05", mock_msg)
+    fake_cache.add(mock_msg)
 
     # Execute
     with patch.object(

--- a/tests/tests_rf/test_entity_state.py
+++ b/tests/tests_rf/test_entity_state.py
@@ -6,7 +6,8 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from ramses_rf.entity_state import EntityState
+from ramses_rf.routing import RoutingContext, StateHeader
+from ramses_rf.state import EntityState
 from ramses_tx.const import I_, Code
 
 
@@ -28,6 +29,12 @@ class DummyMsg:
 
         self._payload_dict = payload_dict
         self.payload_access_count = 0
+
+        # NEW: Native L7 properties to satisfy the O(1) StateCache
+        self.context = RoutingContext(False)
+        self.state_header = StateHeader.create(
+            self.code, self.verb, self.src.id, self.context.value
+        )
 
     @property
     def payload(self) -> dict[str, Any]:
@@ -64,10 +71,10 @@ async def test_o1_push_model_ingest(zone_entity: EntityState) -> None:
     # Action: Simulate the Dispatcher pushing a newly arrived packet
     zone_entity.update_state(msg)
 
-    # Assert: The dictionary holds the message under the new context-aware tuple
-    expected_key = (Code._30C9, I_, False)
-    assert expected_key in zone_entity._current_state
-    assert zone_entity._current_state[expected_key] == msg
+    # Assert: The dictionary holds the message under the new DTO
+    expected_hdr = StateHeader.create(Code._30C9, I_, "04:123456", False)
+    assert expected_hdr in zone_entity._current_state
+    assert zone_entity._current_state[expected_hdr] == msg
 
 
 @pytest.mark.asyncio

--- a/tests/tests_rf/test_message_store.py
+++ b/tests/tests_rf/test_message_store.py
@@ -3,8 +3,8 @@
 
 from datetime import datetime as dt, timedelta as td
 
-from ramses_rf.message import Message
 from ramses_rf.message_store import MessageStore
+from ramses_rf.messages import Message
 from ramses_tx import Code, Packet
 
 

--- a/tests/tests_rf/test_message_store.py
+++ b/tests/tests_rf/test_message_store.py
@@ -3,8 +3,8 @@
 
 from datetime import datetime as dt, timedelta as td
 
-from ramses_rf.message_store import MessageStore
 from ramses_rf.messages import Message
+from ramses_rf.state import MessageStore
 from ramses_tx import Code, Packet
 
 

--- a/tests/tests_rf/test_routing.py
+++ b/tests/tests_rf/test_routing.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python3
+"""Tests for the L7 domain routing components."""
+
+from ramses_rf.routing import EventTopic, RoutingContext, StateHeader
+
+
+def test_routing_context_string_formatting() -> None:
+    """Test that RoutingContext handles legacy string casting safely."""
+    assert RoutingContext(True).as_string == "True"
+    assert RoutingContext(False).as_string == "False"
+    assert RoutingContext("00").as_string == "00"
+    assert RoutingContext("FA").as_string == "FA"
+    assert RoutingContext(None).as_string == "None"
+
+
+def test_state_header_legacy_formatting() -> None:
+    """Test that StateHeader perfectly replicates the legacy _hdr format."""
+    hdr = StateHeader.create(
+        code="3220",
+        verb="RP",
+        source_id="01:123456",
+        context_val="00",
+    )
+    assert hdr.legacy_hdr == "3220|RP|01:123456|00"
+
+    base_hdr = StateHeader.create(
+        code="10A0",
+        verb=" I",
+        source_id="04:654321",
+        context_val=True,
+    )
+    assert base_hdr.legacy_hdr == "10A0| I|04:654321|True"
+
+
+def test_state_header_hashing() -> None:
+    """Test that StateHeader can be used as an O(1) dictionary key."""
+    hdr1 = StateHeader.create("000C", "RP", "01:111111", "01")
+    hdr2 = StateHeader.create("000C", "RP", "01:111111", "01")
+    hdr3 = StateHeader.create("000C", "RP", "01:111111", "02")
+
+    cache = {hdr1: "payload_data"}
+
+    assert hdr2 in cache
+    assert hdr3 not in cache
+
+
+def test_state_header_topic_generation() -> None:
+    """Test the Master Plan topic generation logic."""
+    # Note: using the exact string spaces to map to the Enum
+    state_hdr = StateHeader.create("30C9", " I", "01:123456", "00")
+    assert state_hdr.topic is EventTopic.INFORMATION
+
+    disc_hdr = StateHeader.create("1FC9", " I", "01:123456", "00")
+    assert disc_hdr.topic is EventTopic.TOPOLOGY_DISCOVERY
+
+    req_hdr = StateHeader.create("3220", "RQ", "01:123456", "00")
+    assert req_hdr.topic is EventTopic.REQUEST
+
+    write_hdr = StateHeader.create("2309", " W", "01:123456", "00")
+    assert write_hdr.topic is EventTopic.WRITE

--- a/tests/tests_rf/test_system_heat.py
+++ b/tests/tests_rf/test_system_heat.py
@@ -11,7 +11,7 @@ import pytest
 
 from ramses_rf import Gateway
 from ramses_rf.const import FC, I_, SZ_DOMAIN_ID, Code
-from ramses_rf.message import Message
+from ramses_rf.messages import Message
 from ramses_rf.system.heat import SystemBase
 from ramses_tx import Packet
 from ramses_tx.address import HGI_DEVICE_ID

--- a/tests/tests_rf/test_system_zones.py
+++ b/tests/tests_rf/test_system_zones.py
@@ -13,7 +13,7 @@ from ramses_rf.exceptions import (
     SystemInconsistent,
     SystemSchemaInconsistent,
 )
-from ramses_rf.message import Message
+from ramses_rf.messages import Message
 from ramses_rf.system.zones import (
     DhwZone,
     EleZone,

--- a/tests/tests_tx/test_engine.py
+++ b/tests/tests_tx/test_engine.py
@@ -9,8 +9,8 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from ramses_rf.application_message import ApplicationMessage
 from ramses_rf.gateway import Gateway
+from ramses_rf.messages import ApplicationMessage
 from ramses_tx.address import HGI_DEV_ADDR
 from ramses_tx.command import Command
 from ramses_tx.config import EngineConfig

--- a/tests/tests_tx/test_message.py
+++ b/tests/tests_tx/test_message.py
@@ -7,9 +7,7 @@ from unittest.mock import Mock
 
 import pytest
 
-import ramses_rf.message as rf_msg
-from ramses_rf.application_message import ApplicationMessage
-from ramses_rf.message import Message
+from ramses_rf.messages import ApplicationMessage, Message
 from ramses_tx.packet import Packet
 
 # Constants for testing frames
@@ -27,9 +25,9 @@ def patch_parsers(monkeypatch: pytest.MonkeyPatch) -> None:
     :type monkeypatch: pytest.MonkeyPatch
     :return: None
     """
+    # Patch the function at the module level where it is used
     monkeypatch.setattr(
-        rf_msg,
-        "decode_packet",
+        "ramses_rf.messages.base.decode_packet",
         lambda dto: {
             "mock_key": "mock_val",
             "phase": "confirm",
@@ -37,8 +35,9 @@ def patch_parsers(monkeypatch: pytest.MonkeyPatch) -> None:
         },
     )
 
+    # Patch the class variable on the Message class directly
     monkeypatch.setattr(
-        rf_msg,
+        Message,
         "_GET_CODE_NAME_CB",
         lambda code: f"mock_name_{code}",
     )
@@ -139,7 +138,7 @@ def test_message_string_representations(patch_parsers: Any) -> None:
 def test_startup_empty_payload_reproduction(monkeypatch: pytest.MonkeyPatch) -> None:
     """Test that an empty payload bypasses strict regex and parses safely."""
     # Ensure this test is completely isolated from the global ramses_rf bridge
-    monkeypatch.setattr(rf_msg, "decode_packet", lambda dto: {})
+    monkeypatch.setattr("ramses_rf.messages.base.decode_packet", lambda dto: {})
 
     dtm = dt.now(tz=UTC)
     packet = Packet(dtm, FRAME_STR_EMPTY)


### PR DESCRIPTION
### The Problem:

The L7 application domain was heavily entangled with legacy L3 string-parsing technical debt (e.g., relying on `msg._pkt._ctx` and `_pkt._hdr`). State management relied on O(N) iterative iterative searches, string slicing, and regex evaluations, causing severe CPU thrashing at scale. Additionally, there were type-casting bugs related to integer vs. string contexts in OpenTherm discovery (Issue #396) and SQLite worker queue flooding when Home Assistant repeatedly polled expired entities.

### Consequences:

If left unaddressed, the system experiences CPU bottlenecks during state queries on large networks. Polling expired packets cascades into an overwhelmed SQLite database worker queue, leading to latency and potential silent failures. Furthermore, the tight coupling prevents the implementation of the asynchronous Event-Driven Single Source of Truth (SSOT) queues required for Phase 3.

### The Fix:

Extracted the L7 message domain into its own strictly-typed namespace, implemented O(1) state hashing, and fully decoupled the state caching engine from legacy transport properties. Discovery and entity state now rely entirely on native Python Data Transfer Objects (DTOs) rather than raw string parsing.

### Technical Implementation:
- **Domain Extraction:** Moved `message.py` and `application_message.py` to `src/ramses_rf/messages/`, and `entity_state.py`/`message_store.py` to `src/ramses_rf/state/` to enforce the Single Responsibility Principle.
- **O(1) Hashing:** Created immutable `StateHeader` and `RoutingContext` DTOs. Replaced O(N) list iteration in `StateCache` and `EntityState` with O(1) dictionary lookups natively keyed by `StateHeader`.
- **Discovery Refactor:** Updated `DiscoveryService` to natively consume `msg.state_header` and `msg.context`, eradicating legacy `_pkt` dependencies and resolving the OpenTherm type-casting bug.
- **Queue Flooding Protection:** Added a `_delete_task_queued` boolean flag to `ApplicationMessage` to ensure expired packets spawn exactly one async database deletion task, regardless of polling frequency.
- **Legacy Shim:** Retained `_frame` exclusively inside a `_LegacyPktShim` adapter to preserve backwards compatibility for older L3 regex testing suites.

### Testing Performed:
- Achieved a 100% `pytest` pass rate across all 33,000+ tests.
- **Performance Tests:** Wrote `test_entity_state.py` to explicitly verify the O(1) push model ingestion and prove the O(N^2) CPU thrashing bug is eradicated (payload access counts dropped from 15,000+ to 1).
- **Spam Prevention:** Added `test_expired_message_deletion_queued_once` to assert the async event loop only registers a single DB deletion task per expired message.
- **Type Safety:** Ran `mypy --strict` across the entire OSI decoupled boundary, achieving zero errors to guarantee DTO compliance.
- **Systems Logs:** Validated end-to-end system restoration and fuzzing against expected historical payloads in `test_systems.py`.

### Risks of NOT Implementing:

Scaling limitations due to CPU thrashing. Inability to advance the "IoT Radio Protocol Refactoring Master Plan" to Phase 3 (Outbound TX Parity). Continued exposure to fragile string-parsing bugs and database locking issues.

### Risks of Implementing:

Potential regressions in legacy L3 regex filters or edge-case OpenTherm discovery if a context string/integer mismatch slips through the mock boundaries and into production routing.

### Mitigation Steps:

Implemented a strict "Parallel Change" pattern throughout the refactoring process. We maintained a passive bridge to validate the new Data Transfer Objects against legacy snapshot tests before fully migrating the transport layer. The `_LegacyPktShim` insulates downstream regex components, and strict Mypy typing provides compile-time guarantees against namespace or context type mismatches.

### AI Assistance Disclosure:

This contribution was developed with the assistance of Google Gemini 3.1 Pro for code generation and documentation. No Agentic AI systems were employed; all logic and implementations were reviewed, verified, and manually committed by the author.
