### PR TITLE
chore(mypy): remove unused module overrides from pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -239,22 +239,6 @@
     "assignment",  # transport var reassigned between ZigbeeTransport and MqttTransport branches
   ]
 
-#[[tool.mypy.overrides]]
-#  module = "ramses_tx.parsers"
-#
-#  disallow_any_generics = false  # 89 - will be lots of work
-
-[[tool.mypy.overrides]]
-  module = "ramses_rf.entity_base.*"
-
-  disallow_any_generics = false     # 14
-  no_implicit_optional = false      # 12
-
-  disable_error_code = [
-    "arg-type",  #     13 (but a can of worms)
-    "unreachable",  #  13 (but a can of worms)
-  ]
-
 [[tool.mypy.overrides]]
   module = "ramses_rf.device.*"
 
@@ -307,7 +291,6 @@
   module = [
     "ramses_cli.*",
     "ramses_rf.*",
-    "ramses_tx.parsers",
     "tests",
   ]
 


### PR DESCRIPTION
### The Problem:

Running `mypy --strict` (after a version bump of mypy in PR #655 - chore(deps-dev): update mypy requirement from >=1.20.2 to >=2.1.0) flagged unused override sections in `pyproject.toml` targeting `ramses_rf.entity_base.*` and `ramses_tx.parsers`. These sections became orphaned due to recent file moving and renaming within the project structure.

### Consequences:

Leaving this unaddressed results in lingering configuration cruft, unnecessary technical debt, and persistent warning noise in local development and CI/CD type-checking logs, which can obscure real issues.

### The Fix:

Removed the orphaned Mypy configuration sections from the `pyproject.toml` file to align the type-checking config with the current project structure.

### Technical Implementation:
- Deleted the entire `[[tool.mypy.overrides]]` block targeting `module = "ramses_rf.entity_base.*"`.
- Removed `"ramses_tx.parsers"` from the module list in the final `[[tool.mypy.overrides]]` block (which sets `disallow_any_explicit = false`).

### Testing Performed:
- Ran `mypy --strict` locally to confirm the "unused section(s)" warning is resolved and that the codebase maintains a 100% strict typing pass rate natively without these crutches.
- Executed the full `pytest` suite to ensure no behavioral regressions; all tests passed successfully.

### Risks of NOT Implementing:

Minor but persistent technical debt. It leaves dead code in the configuration file and creates warning fatigue for developers checking Mypy outputs.

### Risks of Implementing:

Extremely low risk. The primary risk would be if the files still existed under those exact paths and actually required the relaxed typing rules, but Mypy's explicit "unused" warning confirms this is not the case.

### Mitigation Steps:

Relied on both the strict type checker (`mypy --strict`) and the comprehensive `pytest` suite to guarantee no type safety or functional regressions were introduced by removing these lines.

### AI Assistance Disclosure:

This contribution was developed with the assistance of Google Gemini 3.1 Pro for code generation and documentation. No Agentic AI systems were employed; all logic and implementations were reviewed, verified, and manually committed by the author.
