### PR TITLE
Refactor: Elevate L7 Address Domain Knowledge (Phase 2.6 - Part 1)

### DIFF
--- a/src/ramses_rf/address.py
+++ b/src/ramses_rf/address.py
@@ -1,0 +1,224 @@
+#!/usr/bin/env python3
+"""RAMSES RF - The device Address L7 domain module."""
+
+from __future__ import annotations
+
+from functools import lru_cache
+from typing import Final, cast
+
+from ramses_tx import exceptions as exc
+from ramses_tx.typing import DeviceIdT
+
+from .const import DEV_TYPE_MAP as _DEV_TYPE_MAP, DEVICE_ID_REGEX, DevType
+
+DEVICE_LOOKUP: dict[str, str] = {
+    k: _DEV_TYPE_MAP._hex(k)
+    for k in _DEV_TYPE_MAP.SLUGS
+    if k not in (DevType.JIM, DevType.JST)
+}
+DEVICE_LOOKUP |= {"NUL": "63", "---": "--"}
+DEV_TYPE_MAP: dict[str, str] = {v: k for k, v in DEVICE_LOOKUP.items()}
+
+
+HGI_DEVICE_ID: DeviceIdT = "18:000730"  # type: ignore[assignment]
+NON_DEVICE_ID: DeviceIdT = "--:------"  # type: ignore[assignment]
+ALL_DEVICE_ID: DeviceIdT = "63:262142"  # type: ignore[assignment]
+
+# NOTE: All debug flags should be False for deployment to end-users
+_DBG_DISABLE_STRICT_CHECKING: Final[bool] = False
+_DBG_DISABLE_DEV_HVAC = False
+
+
+class Address:
+    """The device Address class."""
+
+    _SLUG = None
+
+    def __init__(self, device_id: DeviceIdT) -> None:
+        """Create an address from a valid device ID.
+
+        :param device_id: The RAMSES II device ID (e.g., '01:123456')
+        :type device_id: DeviceIdT
+        :raises ValueError: If the device_id is not a valid format.
+        """
+
+        self.id = device_id
+        self.type = device_id[:2]  # dex, drops 2nd part, incl. ":"
+        self._hex_id: str = None  # type: ignore[assignment]
+
+        if not self.is_valid(device_id):
+            raise ValueError(f"Invalid device_id: {device_id}")
+
+    def __repr__(self) -> str:
+        return str(self.id)
+
+    def __str__(self) -> str:
+        return self._friendly(self.id).strip()
+
+    def __eq__(self, other: object) -> bool:
+        if not hasattr(other, "id"):  # can compare Address with Device
+            return NotImplemented
+        return self.id == other.id  # type: ignore[no-any-return]
+
+    @property
+    def hex_id(self) -> str:
+        if self._hex_id is not None:
+            return self._hex_id
+        self._hex_id = self.convert_to_hex(self.id)  # type: ignore[unreachable]
+        return self._hex_id
+
+    @staticmethod
+    def is_valid(value: str) -> bool:
+        return isinstance(value, str) and (
+            value == NON_DEVICE_ID or DEVICE_ID_REGEX.ANY.match(value)
+        )
+
+    @classmethod
+    def _friendly(cls, device_id: DeviceIdT) -> str:
+        """Convert (say) '01:145038' to 'CTL:145038'."""
+
+        if not cls.is_valid(device_id):
+            raise TypeError
+
+        _type, _tmp = device_id.split(":")
+
+        return f"{DEV_TYPE_MAP.get(_type, f'{_type:>3}')}:{_tmp}"
+
+    @classmethod
+    def convert_from_hex(cls, device_hex: str, friendly_id: bool = False) -> str:
+        """Convert a 6-character hex string to a device ID.
+
+        :param device_hex: The hex string to convert (e.g., '06368E')
+        :type device_hex: str
+        :param friendly_id: If True, returns a named ID, defaults to False
+        :type friendly_id: bool
+        :return: The formatted device ID string
+        :rtype: str
+        """
+
+        if device_hex == "FFFFFE":  # aka '63:262142'
+            return ">null dev<" if friendly_id else ALL_DEVICE_ID
+
+        if not device_hex.strip():  # aka '--:------'
+            return f"{'':10}" if friendly_id else NON_DEVICE_ID
+
+        _tmp = int(device_hex, 16)
+        device_id: DeviceIdT = f"{(_tmp & 0xFC0000) >> 18:02d}:{_tmp & 0x03FFFF:06d}"  # type: ignore[assignment]
+
+        return cls._friendly(device_id) if friendly_id else device_id
+
+    @classmethod
+    def convert_to_hex(cls, device_id: DeviceIdT) -> str:
+        """Convert (say) '01:145038' (or 'CTL:145038') to '06368E'."""
+
+        if not cls.is_valid(device_id):
+            raise TypeError
+
+        if len(device_id) == 9:  # e.g. '01:123456'
+            dev_type = device_id[:2]
+
+        else:  # len(device_id) == 10, e.g. 'CTL:123456', or ' 63:262142'
+            dev_type = DEVICE_LOOKUP.get(device_id[:3], device_id[1:3])
+
+        return f"{(int(dev_type) << 18) + int(device_id[-6:]):0>6X}"
+
+
+@lru_cache(maxsize=256)
+def id_to_address(device_id: DeviceIdT) -> Address:
+    """Factory method to cache & return device Address from device ID."""
+    return Address(device_id=device_id)
+
+
+HGI_DEV_ADDR = Address(HGI_DEVICE_ID)  # 18:000730
+NON_DEV_ADDR = Address(NON_DEVICE_ID)  # --:------
+ALL_DEV_ADDR = Address(ALL_DEVICE_ID)  # 63:262142
+
+
+def dev_id_to_hex_id(device_id: DeviceIdT) -> str:
+    """Convert (say) '01:145038' (or 'CTL:145038') to '06368E'."""
+
+    if len(device_id) == 9:  # e.g. '01:123456'
+        dev_type = device_id[:2]
+
+    elif len(device_id) == 10:  # e.g. '01:123456'
+        dev_type = DEVICE_LOOKUP.get(device_id[:3], device_id[1:3])
+
+    else:  # len(device_id) == 10, e.g. 'CTL:123456', or ' 63:262142'
+        raise ValueError(f"Invalid value: {device_id}, is not 9-10 characters long")
+
+    return f"{(int(dev_type) << 18) + int(device_id[-6:]):0>6X}"
+
+
+def hex_id_to_dev_id(device_hex: str, friendly_id: bool = False) -> DeviceIdT:
+    """Convert (say) '06368E' to '01:145038' (or 'CTL:145038')."""
+    if device_hex == "FFFFFE":  # aka '63:262142'
+        return cast(DeviceIdT, "NUL:262142" if friendly_id else ALL_DEVICE_ID)
+
+    if not device_hex.strip():  # aka '--:------'
+        return cast(DeviceIdT, f"{'':10}" if friendly_id else NON_DEVICE_ID)
+
+    _tmp = int(device_hex, 16)
+    dev_type = f"{(_tmp & 0xFC0000) >> 18:02d}"
+
+    if friendly_id:
+        dev_type = DEV_TYPE_MAP.get(dev_type, f"{dev_type:<3}")
+
+    return cast(DeviceIdT, f"{dev_type}:{_tmp & 0x03FFFF:06d}")
+
+
+@lru_cache(maxsize=128)
+def is_valid_dev_id(value: str, dev_class: None | str = None) -> bool:
+    """Return True if a device_id is valid."""
+
+    if not isinstance(value, str) or not DEVICE_ID_REGEX.ANY.match(value):
+        return False
+
+    return not _DBG_DISABLE_DEV_HVAC or value.split(":", 1)[0] in DEV_TYPE_MAP
+
+
+@lru_cache(maxsize=256)
+def pkt_addrs(
+    addr_fragment: str,
+) -> tuple[Address, Address, Address, Address, Address]:
+    """Parse address fields from a 30-character address fragment.
+
+    :param addr_fragment: The 30-char fragment
+    :type addr_fragment: str
+    :return: A tuple of (src_addr, dst_addr, addr_0, addr_1, addr_2)
+    :rtype: tuple[Address, Address, Address, Address, Address]
+    :raises PacketAddrSetInvalid: If the address fields are not valid.
+    """
+    try:
+        addrs = tuple(id_to_address(addr_fragment[i : i + 9]) for i in range(0, 30, 10))
+    except ValueError as err:
+        raise exc.PacketAddrSetInvalid(
+            f"Invalid address set: {addr_fragment}: {err}"
+        ) from None
+
+    if not _DBG_DISABLE_STRICT_CHECKING and (
+        not (
+            addrs[0] not in (NON_DEV_ADDR, ALL_DEV_ADDR)
+            and addrs[1] == NON_DEV_ADDR
+            and addrs[2] != NON_DEV_ADDR
+        )
+        and not (
+            addrs[0] not in (NON_DEV_ADDR, ALL_DEV_ADDR)
+            and addrs[1] not in (NON_DEV_ADDR, addrs[0])
+            and addrs[2] == NON_DEV_ADDR
+        )
+        and not (
+            addrs[2] not in (NON_DEV_ADDR, ALL_DEV_ADDR)
+            and addrs[0] == NON_DEV_ADDR
+            and addrs[1] == NON_DEV_ADDR
+        )
+    ):
+        raise exc.PacketAddrSetInvalid(f"Invalid address set: {addr_fragment}")
+
+    device_addrs = list(filter(lambda a: a.type != "--", addrs))  # dex
+    src_addr = device_addrs[0]
+    dst_addr = device_addrs[1] if len(device_addrs) > 1 else NON_DEV_ADDR
+
+    if src_addr.id == dst_addr.id:  # incl. HGI_DEV_ADDR == HGI_DEV_ADDR
+        src_addr = dst_addr
+
+    return src_addr, dst_addr, addrs[0], addrs[1], addrs[2]

--- a/src/ramses_rf/device/__init__.py
+++ b/src/ramses_rf/device/__init__.py
@@ -49,7 +49,7 @@ from .hvac import (  # noqa: F401, isort: skip, pylint: disable=unused-import
 
 if TYPE_CHECKING:
     from ramses_rf import Gateway
-    from ramses_tx import Address
+    from ramses_rf.address import Address
 
     from ..messages import Message
 

--- a/src/ramses_rf/device/base.py
+++ b/src/ramses_rf/device/base.py
@@ -12,6 +12,7 @@ from collections.abc import Iterable
 from datetime import UTC, datetime as dt, timedelta as td
 from typing import TYPE_CHECKING, Any, cast
 
+from ramses_rf.address import Address
 from ramses_rf.binding_fsm import BindingManager, Vendor
 from ramses_rf.const import (
     DEV_TYPE_MAP,
@@ -42,7 +43,8 @@ if TYPE_CHECKING:
     from ramses_rf import Gateway
     from ramses_rf.models import DeviceTraits
     from ramses_rf.system import Zone
-    from ramses_tx import Address, DeviceIdT, IndexT
+    from ramses_tx.const import IndexT
+    from ramses_tx.typing import DeviceIdT
 
 
 BIND_WAITING_TIMEOUT = 300  # how long to wait, listening for an offer

--- a/src/ramses_rf/device/heat.py
+++ b/src/ramses_rf/device/heat.py
@@ -9,6 +9,7 @@ from datetime import timedelta as td
 from typing import TYPE_CHECKING, Any, Final, Literal, cast
 
 from ramses_rf import exceptions as exc
+from ramses_rf.address import NON_DEV_ADDR
 from ramses_rf.const import (
     DEV_ROLE_MAP,
     DEV_TYPE_MAP,
@@ -36,7 +37,7 @@ from ramses_rf.helpers import shrink
 from ramses_rf.quirks import QUARANTINED_OT_MSG_IDS
 from ramses_rf.schemas import SCH_TCS, SZ_ACTUATORS, SZ_CIRCUITS
 from ramses_rf.topology import Child, Parent
-from ramses_tx import NON_DEV_ADDR, Command, Priority
+from ramses_tx import Command, Priority
 from ramses_tx.const import SZ_NUM_REPEATS, SZ_PRIORITY, MsgId
 from ramses_tx.opentherm import (
     PARAMS_DATA_IDS,
@@ -106,10 +107,11 @@ from ramses_tx.const import (
 )
 
 if TYPE_CHECKING:
+    from ramses_rf.address import Address
     from ramses_rf.messages import ApplicationMessage
     from ramses_rf.models import DeviceTraits
     from ramses_rf.system import Evohome, Zone
-    from ramses_tx import Address, Packet
+    from ramses_tx import Packet
     from ramses_tx.opentherm import OtDataId
 
     from ..messages import Message

--- a/src/ramses_rf/device/hvac.py
+++ b/src/ramses_rf/device/hvac.py
@@ -11,6 +11,7 @@ from datetime import timedelta as td
 from typing import TYPE_CHECKING, Any, TypeVar, cast
 
 from ramses_rf import exceptions as exc
+from ramses_rf.address import Address
 from ramses_rf.const import (
     HEARTBEAT_TIMEOUT_FILTER,
     HEARTBEAT_TIMEOUT_REMOTE,
@@ -49,7 +50,7 @@ from ramses_rf.const import (
 )
 from ramses_rf.entity import class_by_attr
 from ramses_rf.helpers import schedule_task
-from ramses_tx import Address, Command, Packet, Priority
+from ramses_tx import Command, Packet, Priority
 from ramses_tx.ramses import CODES_OF_HVAC_DOMAIN_ONLY, HVAC_KLASS_BY_VC_PAIR
 from ramses_tx.typing import PayloadT
 

--- a/src/ramses_rf/device_registry.py
+++ b/src/ramses_rf/device_registry.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import logging
 from typing import TYPE_CHECKING, Any, cast
 
-from ramses_tx import Address, is_valid_dev_id
+from ramses_rf.address import Address, is_valid_dev_id
 
 from .const import SZ_DEVICES
 from .device import DeviceHeat, DeviceHvac, Fakeable, device_factory
@@ -43,7 +43,8 @@ class DeviceRegistry:
 
         :param dev: The device instance to add.
         :type dev: Device
-        :raises SchemaInconsistentError: If the device already exists in the registry.
+        :raises SchemaInconsistentError: If the device already exists in
+            the registry.
         """
         if dev.id in self.device_by_id:
             raise SchemaInconsistentError(f"Device already exists: {dev.id}")
@@ -62,32 +63,34 @@ class DeviceRegistry:
     ) -> Device:
         """Return a device, creating it if it does not already exist.
 
-        :param device_id: The unique identifier for the device (e.g., '01:123456').
+        :param device_id: The unique identifier for the device.
         :type device_id: DeviceIdT
         :param msg: An optional initial message for the device to process.
         :type msg: Message | None
         :param parent: The parent entity of this device, if any.
         :type parent: Parent | None
-        :param child_id: The specific ID of the child component if applicable.
+        :param child_id: Specific ID of the child component if applicable.
         :type child_id: str | None
-        :param is_sensor: Indicates if this device should be treated as a sensor.
+        :param is_sensor: Indicates if this device is treated as a sensor.
         :type is_sensor: bool | None
         :returns: The existing or newly created device instance.
         :rtype: Device
-        :raises DeviceNotFoundError: If the device ID is blocked or not in the known_list.
+        :raises DeviceNotFoundError: If device ID is blocked or unknown.
         """
         try:
             self._gwy._device_filter.check_filter_lists(device_id)
         except DeviceNotFoundError:
             # have to allow for GWY not being in known_list...
-            # Proper composition fix: get the configured HGI ID directly from the Engine
+            # Proper composition fix: get the configured HGI ID directly
+            # from the Engine
             if device_id != self._gwy._engine._hgi_id:
                 raise
 
         dev = self.device_by_id.get(device_id)
 
         if not dev:
-            # voluptuous bug workaround: https://github.com/alecthomas/voluptuous/pull/524
+            # voluptuous bug workaround:
+            # https://github.com/alecthomas/voluptuous/pull/524
             _traits_raw: dict[str, Any] = dict(
                 self._gwy._engine._include.get(device_id, {})
             )
@@ -147,7 +150,8 @@ class DeviceRegistry:
         raise DeviceNotFaked(f"The device is not fakeable: {device_id}")
 
     async def known_list(self) -> DeviceListT:
-        """Return the working known_list (a superset of the provided known_list).
+        """Return the working known_list (a superset of the provided
+        known_list).
 
         :returns: A dictionary mapping device IDs to their traits.
         :rtype: DeviceListT

--- a/src/ramses_rf/messages/base.py
+++ b/src/ramses_rf/messages/base.py
@@ -9,7 +9,7 @@ from dataclasses import dataclass
 from datetime import datetime as dt
 from typing import TYPE_CHECKING, Any, TypeAlias, TypeVar
 
-from ramses_tx.address import Address
+from ramses_rf.address import Address
 from ramses_tx.command import Command
 from ramses_tx.dtos import PacketDTO
 from ramses_tx.models import DeviceId, RawPacket, TransportMessage

--- a/src/ramses_rf/system/heat.py
+++ b/src/ramses_rf/system/heat.py
@@ -68,7 +68,8 @@ from .faultlog import FaultLog
 from .zones import zone_factory
 
 if TYPE_CHECKING:
-    from ramses_tx import Address, Packet
+    from ramses_rf.address import Address
+    from ramses_tx import Packet
 
     from .faultlog import FaultIdxT, FaultLogEntry
     from .zones import DhwZone, Zone

--- a/src/ramses_rf/system/zones.py
+++ b/src/ramses_rf/system/zones.py
@@ -9,6 +9,7 @@ from datetime import datetime as dt, timedelta as td
 from typing import TYPE_CHECKING, Any, TypeVar, cast
 
 from ramses_rf import exceptions as exc
+from ramses_rf.address import Address
 from ramses_rf.const import (
     DEV_ROLE_MAP,
     DEV_TYPE_MAP,
@@ -48,7 +49,7 @@ from ramses_rf.schemas import (
     SZ_SENSOR,
 )
 from ramses_rf.topology import Child, Parent
-from ramses_tx import Address, Command, Priority
+from ramses_tx import Command, Priority
 from ramses_tx.exceptions import ProtocolSendFailed, ProtocolTimeoutError
 from ramses_tx.typing import HeaderT, PayDictT, PayloadT
 

--- a/src/ramses_tx/__init__.py
+++ b/src/ramses_tx/__init__.py
@@ -10,14 +10,7 @@ from functools import partial
 from logging.handlers import QueueListener
 from typing import TYPE_CHECKING, Any
 
-from .address import (
-    ALL_DEV_ADDR,
-    ALL_DEVICE_ID,
-    NON_DEV_ADDR,
-    NON_DEVICE_ID,
-    Address,
-    is_valid_dev_id,
-)
+from .address import ALL_DEV_ADDR, ALL_DEVICE_ID, NON_DEV_ADDR, NON_DEVICE_ID, Address
 from .command import CODE_API_MAP, Command
 from .const import (
     DEV_ROLE_MAP,
@@ -145,6 +138,8 @@ __all__ = [
     "Engine",
 ]
 
+
+is_valid_dev_id = Address.is_valid
 
 if TYPE_CHECKING:
     from logging import Logger

--- a/src/ramses_tx/address.py
+++ b/src/ramses_tx/address.py
@@ -1,253 +1,46 @@
+# src/ramses_tx/address.py
 #!/usr/bin/env python3
-"""RAMSES RF - a RAMSES-II protocol decoder & analyser."""
+"""RAMSES RF - The strict L2 MAC address module (Temporary Proxy)."""
 
 from __future__ import annotations
 
-from functools import lru_cache
-from typing import TYPE_CHECKING, Final
-
-from . import exceptions as exc
-from .const import DEV_TYPE_MAP as _DEV_TYPE_MAP, DEVICE_ID_REGEX, DevType
-
-if TYPE_CHECKING:
-    from .typing import DeviceIdT
-
-DEVICE_LOOKUP: dict[str, str] = {
-    k: _DEV_TYPE_MAP._hex(k)
-    for k in _DEV_TYPE_MAP.SLUGS
-    if k not in (DevType.JIM, DevType.JST)
-}
-DEVICE_LOOKUP |= {"NUL": "63", "---": "--"}
-DEV_TYPE_MAP: dict[str, str] = {v: k for k, v in DEVICE_LOOKUP.items()}
-
-
-HGI_DEVICE_ID: DeviceIdT = "18:000730"  # type: ignore[assignment]
-NON_DEVICE_ID: DeviceIdT = "--:------"  # type: ignore[assignment]
-ALL_DEVICE_ID: DeviceIdT = "63:262142"  # type: ignore[assignment]  # aka 'FFFFFE'
-
-#
-# NOTE: All debug flags should be False for deployment to end-users
-_DBG_DISABLE_STRICT_CHECKING: Final[bool] = False  # a convenience for the test suite
-_DBG_DISABLE_DEV_HVAC = False
-
-
-class Address:
-    """The device Address class."""
-
-    _SLUG = None
-
-    def __init__(self, device_id: DeviceIdT) -> None:
-        """Create an address from a valid device ID.
-
-        :param device_id: The RAMSES II device ID (e.g., '01:123456')
-        :type device_id: DeviceIdT
-        :raises ValueError: If the device_id is not a valid format.
-        """
-
-        # if device_id is None:
-        #     device_id = NON_DEVICE_ID
-
-        self.id = device_id  # TODO: check is a valid id...
-        self.type = device_id[:2]  # dex, drops 2nd part, incl. ":"
-        self._hex_id: str = None  # type: ignore[assignment]
-
-        if not self.is_valid(device_id):
-            raise ValueError(f"Invalid device_id: {device_id}")
-
-    def __repr__(self) -> str:
-        return str(self.id)
-
-    def __str__(self) -> str:
-        return self._friendly(self.id).strip()
-
-    def __eq__(self, other: object) -> bool:
-        if not hasattr(other, "id"):  # can compare Address with Device
-            return NotImplemented
-        return self.id == other.id  # type: ignore[no-any-return]
-
-    @property
-    def hex_id(self) -> str:
-        if self._hex_id is not None:
-            return self._hex_id
-        self._hex_id = self.convert_to_hex(self.id)  # type: ignore[unreachable]
-        return self._hex_id
-
-    @staticmethod
-    def is_valid(value: str) -> bool:  # Union[str, Match[str], None]:
-        # if value[:2] not in DEV_TYPE_MAP:
-        #     return False
-
-        return isinstance(value, str) and (
-            value == NON_DEVICE_ID or DEVICE_ID_REGEX.ANY.match(value)
-        )
-
-    @classmethod
-    def _friendly(cls, device_id: DeviceIdT) -> str:
-        """Convert (say) '01:145038' to 'CTL:145038'."""
-
-        if not cls.is_valid(device_id):
-            raise TypeError
-
-        _type, _tmp = device_id.split(":")
-
-        return f"{DEV_TYPE_MAP.get(_type, f'{_type:>3}')}:{_tmp}"
-
-    @classmethod
-    def convert_from_hex(cls, device_hex: str, friendly_id: bool = False) -> str:
-        """Convert a 6-character hex string to a device ID.
-
-        :param device_hex: The hex string to convert (e.g., '06368E')
-        :type device_hex: str
-        :param friendly_id: If True, returns a named ID (e.g., 'CTL:145038'), defaults to False
-        :type friendly_id: bool
-        :return: The formatted device ID string
-        :rtype: str
-        """
-
-        if device_hex == "FFFFFE":  # aka '63:262142'
-            return ">null dev<" if friendly_id else ALL_DEVICE_ID
-
-        if not device_hex.strip():  # aka '--:------'
-            return f"{'':10}" if friendly_id else NON_DEVICE_ID
-
-        _tmp = int(device_hex, 16)
-        device_id: DeviceIdT = f"{(_tmp & 0xFC0000) >> 18:02d}:{_tmp & 0x03FFFF:06d}"  # type: ignore[assignment]
-
-        return cls._friendly(device_id) if friendly_id else device_id
-
-    @classmethod
-    def convert_to_hex(cls, device_id: DeviceIdT) -> str:
-        """Convert (say) '01:145038' (or 'CTL:145038') to '06368E'."""
-
-        if not cls.is_valid(device_id):
-            raise TypeError
-
-        if len(device_id) == 9:  # e.g. '01:123456'
-            dev_type = device_id[:2]
-
-        else:  # len(device_id) == 10, e.g. 'CTL:123456', or ' 63:262142'
-            dev_type = DEVICE_LOOKUP.get(device_id[:3], device_id[1:3])
-
-        return f"{(int(dev_type) << 18) + int(device_id[-6:]):0>6X}"  # no preceding 0x
-
-    # @classmethod
-    # def from_hex(cls, hex_id: DeviceIdT):
-    #     """Call as: d = Address.from_hex('06368E')."""
-
-    #     return cls(cls.convert_from_hex(hex_id))
-
-
-@lru_cache(maxsize=256)
-def id_to_address(device_id: DeviceIdT) -> Address:
-    """Factory method to cache & return device Address from device ID."""
-    return Address(device_id=device_id)
-
-
-HGI_DEV_ADDR = Address(HGI_DEVICE_ID)  # 18:000730
-NON_DEV_ADDR = Address(NON_DEVICE_ID)  # --:------
-ALL_DEV_ADDR = Address(ALL_DEVICE_ID)  # 63:262142
-
-
-def dev_id_to_hex_id(device_id: DeviceIdT) -> str:
-    """Convert (say) '01:145038' (or 'CTL:145038') to '06368E'."""
-
-    if len(device_id) == 9:  # e.g. '01:123456'
-        dev_type = device_id[:2]
-
-    elif len(device_id) == 10:  # e.g. '01:123456'
-        dev_type = DEVICE_LOOKUP.get(device_id[:3], device_id[1:3])
-
-    else:  # len(device_id) == 10, e.g. 'CTL:123456', or ' 63:262142'
-        raise ValueError(f"Invalid value: {device_id}, is not 9-10 characters long")
-
-    return f"{(int(dev_type) << 18) + int(device_id[-6:]):0>6X}"
-
-
-def hex_id_to_dev_id(device_hex: str, friendly_id: bool = False) -> DeviceIdT:
-    """Convert (say) '06368E' to '01:145038' (or 'CTL:145038')."""
-    if device_hex == "FFFFFE":  # aka '63:262142'
-        return "NUL:262142" if friendly_id else ALL_DEVICE_ID  # type: ignore[return-value]
-
-    if not device_hex.strip():  # aka '--:------'
-        return f"{'':10}" if friendly_id else NON_DEVICE_ID  # type: ignore[return-value]
-
-    _tmp = int(device_hex, 16)
-    dev_type = f"{(_tmp & 0xFC0000) >> 18:02d}"
-
-    if friendly_id:
-        dev_type = DEV_TYPE_MAP.get(dev_type, f"{dev_type:<3}")
-
-    return f"{dev_type}:{_tmp & 0x03FFFF:06d}"  # type: ignore[return-value]
-
-
-@lru_cache(maxsize=128)
-def is_valid_dev_id(value: str, dev_class: None | str = None) -> bool:
-    """Return True if a device_id is valid."""
-
-    if not isinstance(value, str) or not DEVICE_ID_REGEX.ANY.match(value):
-        return False
-
-    return not _DBG_DISABLE_DEV_HVAC or value.split(":", 1)[0] in DEV_TYPE_MAP
-
-    # if _DBG_DISABLE_DEV_HVAC and value.split(":", 1)[0] not in DEV_TYPE_MAP:
-    #     return False
-
-    # # TODO: specify device type (for HVAC)
-    # # elif dev_type is not None and dev_type != value.split(":", maxsplit=1)[0]:
-    # #     raise TypeError(f"The device type does not match '{dev_type}'")
-
-    # # assert value == hex_id_to_dev_id(dev_id_to_hex_id(value))
-    # return True
-
-
-@lru_cache(maxsize=256)  # there is definite benefit in caching this
-def pkt_addrs(addr_fragment: str) -> tuple[Address, Address, Address, Address, Address]:
-    """Parse address fields from a 30-character address fragment.
-
-    :param addr_fragment: The 30-char fragment (e.g., '01:078710 --:------ 01:144246')
-    :type addr_fragment: str
-    :return: A tuple of (src_addr, dst_addr, addr_0, addr_1, addr_2)
-    :rtype: tuple[Address, Address, Address, Address, Address]
-    :raises PacketAddrSetInvalid: If the address fields are not valid.
-    """
-    # for debug: print(pkt_addrs.cache_info())
-
-    try:
-        addrs = tuple(id_to_address(addr_fragment[i : i + 9]) for i in range(0, 30, 10))
-    except ValueError as err:
-        raise exc.PacketAddrSetInvalid(
-            f"Invalid address set: {addr_fragment}: {err}"
-        ) from None
-
-    if not _DBG_DISABLE_STRICT_CHECKING and (
-        not (
-            # .I --- 01:145038 --:------ 01:145038 1F09 003 FF073F # valid
-            # .I --- 04:108173 --:------ 01:155341 2309 003 0001F4 # valid
-            addrs[0] not in (NON_DEV_ADDR, ALL_DEV_ADDR)
-            and addrs[1] == NON_DEV_ADDR
-            and addrs[2] != NON_DEV_ADDR
-        )
-        and not (
-            # .I --- 32:206250 30:082155 --:------ 22F1 003 00020A         # valid
-            # .I --- 29:151550 29:237552 --:------ 22F3 007 00023C03040000 # valid
-            addrs[0] not in (NON_DEV_ADDR, ALL_DEV_ADDR)
-            and addrs[1] not in (NON_DEV_ADDR, addrs[0])
-            and addrs[2] == NON_DEV_ADDR
-        )
-        and not (
-            # .I --- --:------ --:------ 10:105624 1FD4 003 00AAD4 # valid
-            addrs[2] not in (NON_DEV_ADDR, ALL_DEV_ADDR)
-            and addrs[0] == NON_DEV_ADDR
-            and addrs[1] == NON_DEV_ADDR
-        )
-    ):
-        raise exc.PacketAddrSetInvalid(f"Invalid address set: {addr_fragment}")
-
-    device_addrs = list(filter(lambda a: a.type != "--", addrs))  # dex
-    src_addr = device_addrs[0]
-    dst_addr = device_addrs[1] if len(device_addrs) > 1 else NON_DEV_ADDR
-
-    if src_addr.id == dst_addr.id:  # incl. HGI_DEV_ADDR == HGI_DEV_ADDR
-        src_addr = dst_addr
-
-    return src_addr, dst_addr, addrs[0], addrs[1], addrs[2]
+from typing import Final
+
+# TEMPORARY SHIM: We proxy all address logic to the elevated L7 module
+# to ensure 100% test parity while the legacy L3 command builders still exist.
+# This proxy will be completely deleted in Phase 5.
+from ramses_rf.address import (
+    ALL_DEV_ADDR,
+    ALL_DEVICE_ID,
+    DEV_TYPE_MAP,
+    DEVICE_LOOKUP,
+    HGI_DEV_ADDR,
+    HGI_DEVICE_ID,
+    NON_DEV_ADDR,
+    NON_DEVICE_ID,
+    Address,
+    dev_id_to_hex_id,
+    hex_id_to_dev_id,
+    id_to_address,
+    is_valid_dev_id,
+    pkt_addrs,
+)
+
+_DBG_DISABLE_STRICT_CHECKING: Final[bool] = False
+
+__all__ = [
+    "ALL_DEV_ADDR",
+    "ALL_DEVICE_ID",
+    "Address",
+    "DEVICE_LOOKUP",
+    "DEV_TYPE_MAP",
+    "HGI_DEV_ADDR",
+    "HGI_DEVICE_ID",
+    "NON_DEV_ADDR",
+    "NON_DEVICE_ID",
+    "dev_id_to_hex_id",
+    "hex_id_to_dev_id",
+    "id_to_address",
+    "is_valid_dev_id",
+    "pkt_addrs",
+]

--- a/src/ramses_tx/command/system.py
+++ b/src/ramses_tx/command/system.py
@@ -8,7 +8,7 @@ from datetime import datetime as dt
 from typing import TYPE_CHECKING, Any, TypeVar, cast
 
 from .. import exceptions as exc
-from ..address import ALL_DEV_ADDR, Address, dev_id_to_hex_id
+from ..address import ALL_DEV_ADDR, dev_id_to_hex_id
 from ..const import (
     DEV_TYPE_MAP,
     FAULT_DEVICE_CLASS,
@@ -356,7 +356,7 @@ class SystemMixins(CommandBase):
         if not kodes:
             raise exc.CommandInvalid(f"Invalid codes for a bind offer: {codes}")
 
-        hex_id = Address.convert_to_hex(cast(DeviceIdT, src_id))
+        hex_id = dev_id_to_hex_id(cast(DeviceIdT, src_id))
         payload = "".join(f"00{c}{hex_id}" for c in kodes)
 
         if oem_code:
@@ -379,7 +379,7 @@ class SystemMixins(CommandBase):
         if not codes:
             raise exc.CommandInvalid(f"Invalid codes for a bind accept: {codes}")
 
-        hex_id = Address.convert_to_hex(cast(DeviceIdT, src_id))
+        hex_id = dev_id_to_hex_id(cast(DeviceIdT, src_id))
         payload = "".join(f"{idx or '00'}{c}{hex_id}" for c in codes)
 
         return cls.from_attrs(W_, dst_id, Code._1FC9, PayloadT(payload), from_id=src_id)
@@ -396,7 +396,7 @@ class SystemMixins(CommandBase):
         if not codes:
             payload = idx or "00"
         else:
-            hex_id = Address.convert_to_hex(cast(DeviceIdT, src_id))
+            hex_id = dev_id_to_hex_id(cast(DeviceIdT, src_id))
             payload = f"{idx or '00'}{codes[0]}{hex_id}"
 
         return cls.from_attrs(I_, dst_id, Code._1FC9, PayloadT(payload), from_id=src_id)

--- a/tests/tests_rf/test_hgi_behaviors.py
+++ b/tests/tests_rf/test_hgi_behaviors.py
@@ -52,8 +52,14 @@ pytestmark = pytest.mark.asyncio()
 @pytest.fixture(autouse=True)
 def patch_strict_checking(monkeypatch: pytest.MonkeyPatch) -> None:
     """Apply the strict checking monkeypatch globally to all tests in this module."""
+    # Retain the legacy transport patch
     monkeypatch.setattr(
         "ramses_tx.address._DBG_DISABLE_STRICT_CHECKING",
+        _DBG_DISABLE_STRICT_CHECKING,
+    )
+    # Target the new OSI L7 boundary where the logic actually lives
+    monkeypatch.setattr(
+        "ramses_rf.address._DBG_DISABLE_STRICT_CHECKING",
         _DBG_DISABLE_STRICT_CHECKING,
     )
 


### PR DESCRIPTION
### The Problem:

The `ramses_tx` (Transport Layer) was handling L7 domain logic (such as `DEV_TYPE_MAP` and semantic logical addressing rules), violating the strict OSI boundaries and Single Responsibility Principle defined in our Strangler Fig migration plan (Ref: #639).

### Consequences:

Leaving domain logic inside the transport layer causes circular dependencies and tightly couples the physical modem operations to high-level device logic. This entanglement actively blocks our ability to decompose the Gateway and implement the new async event-driven pipeline.

### The Fix:

Extracted all L7 addressing domain knowledge into a new `ramses_rf.address` module and updated all L7 downstream dependencies to consume from this new boundary, effectively severing the Domain layer's reliance on the Transport layer for address resolution.

### Technical Implementation:
- Created `src/ramses_rf/address.py` housing the rich `Address` domain model, `DEV_TYPE_MAP`, and semantic parsing logic.
- Updated downstream L7 routing components (`device/base.py`, `device_registry.py`, `system/heat.py`, `system/zones.py`) to strictly consume from the new `ramses_rf` boundary.
- Re-aliased `is_valid_dev_id` and legacy exports in `ramses_tx/address.py` to act as a backward-compatible proxy. This ensures unmigrated L3 legacy builders (`Command`, `Packet`) continue to function perfectly during the Strangler Fig transition.
- Updated Pytest monkeypatching in `test_hgi_behaviors.py` to target the new `ramses_rf.address._DBG_DISABLE_STRICT_CHECKING` flag.
- Achieved 100% compliance with `mypy --strict`.

### Testing Performed:

Executed the full `pytest` suite. Verified that legacy L3 command builder tests (`test_parser_helpers.py`) and HGI behavior tests (`test_hgi_behaviors.py`) pass without issue, confirming that the temporary L3 proxy module safely bridges the gap for legacy code.

### Risks of NOT Implementing:

Failure to implement this layer decoupling halts the entire architectural migration. We cannot safely break apart the Gateway God Object (Part 2) if the transport layer remains burdened by domain-level routing logic.

### Risks of Implementing:

Because unmigrated legacy L3 components still exist, there is a risk that the proxy shim fails to accurately represent the old `ramses_tx.address` namespace, potentially causing unexpected failures in legacy packet parsing.

### Mitigation Steps:

Implemented a strict proxy pattern in `ramses_tx/address.py` to transparently route imports to `ramses_rf.address`. Kept the legacy logical filtering inside `pkt_addrs` intact to maintain 100% test parity until the legacy builders are officially deprecated in Phase 5.

### AI Assistance Disclosure:

This contribution was developed with the assistance of Google Gemini 3.1 Pro for code generation and documentation. No Agentic AI systems were employed; all logic and implementations were reviewed, verified, and manually committed by the author.
