### PR TITLE
fix: cc 834, 843/855, 835, 854 + discovery verb normalization

### DIFF
--- a/src/ramses_rf/commands/builders/__init__.py
+++ b/src/ramses_rf/commands/builders/__init__.py
@@ -28,6 +28,7 @@ BUILDERS: dict[Action, Callable[[Command], CommandDTO]] = {
     Action.SET_FAN_PARAM: hvac.build_set_fan_param,
     Action.GET_FAN_PARAM: hvac.build_get_fan_param,
     Action.GET_HVAC_FAN_31DA: hvac.build_get_hvac_fan_31da,
+    Action.SET_PROGRAM_ENABLED: hvac.build_set_program_enabled,
     # Heat Commands
     Action.PUT_OUTDOOR_TEMP: heat.build_put_outdoor_temp,
     Action.PUT_DHW_TEMP: heat.build_put_dhw_temp,

--- a/src/ramses_rf/commands/builders/hvac.py
+++ b/src/ramses_rf/commands/builders/hvac.py
@@ -437,3 +437,48 @@ def build_get_hvac_fan_31da(intent: Command) -> CommandDTO:
         priority=Priority.DEFAULT,
         num_repeats=DEFAULT_NUM_REPEATS,
     )
+
+
+def build_set_program_enabled(intent: Command) -> CommandDTO:
+    """Translate a SET_PROGRAM_ENABLED intent into a CommandDTO.
+
+    The 22B0 (programme_status) packet enables or disables the HVAC
+    calendar/programme on a ventilation device. The REM (37:) sends a
+    ``W`` to the fan (32:), which echoes back an ``I`` frame.
+
+    Observed payloads (see ``parsers/hvac.py:parser_22b0``):
+
+    .. code-block:: text
+
+        .W --- 37:171871 32:155617 --:------ 22B0 002 0005  # enable,  calendar on
+        .W --- 37:171871 32:155617 --:------ 22B0 002 0006  # disable, calendar off
+
+    :param intent: The SET_PROGRAM_ENABLED intent. It is expected to
+        contain ``enabled`` (bool) in its data dictionary.
+    :return: A populated CommandDTO.
+    :raises ValueError: If ``enabled`` is missing or not a bool.
+    """
+    enabled = intent.get("enabled")
+
+    if enabled is None:
+        raise ValueError("Missing 'enabled' in intent data")
+    if not isinstance(enabled, bool):
+        raise ValueError(
+            f"'enabled' must be a bool, got {type(enabled).__name__}: {enabled!r}"
+        )
+
+    # 05 = calendar on, 06 = calendar off (per parser_22b0)
+    state = "05" if enabled else "06"
+    payload = f"00{state}"
+
+    addr1, addr2, addr3 = resolve_addrs(intent.src, intent.dst)
+    return CommandDTO(
+        verb=W_,
+        addr1=addr1,
+        addr2=addr2,
+        addr3=addr3,
+        code=Code._22B0,
+        payload=payload,
+        priority=Priority.DEFAULT,
+        num_repeats=DEFAULT_NUM_REPEATS,
+    )

--- a/src/ramses_rf/devices/__init__.py
+++ b/src/ramses_rf/devices/__init__.py
@@ -118,7 +118,22 @@ _HVAC_CLASSES = (
 )
 _HVAC_CLASS_BY_SLUG = {cls._SLUG: cls for cls in _HVAC_CLASSES if hasattr(cls, "_SLUG")}
 
-_CLASS_BY_SLUG = _BASE_CLASS_BY_SLUG | _HEAT_CLASS_BY_SLUG | _HVAC_CLASS_BY_SLUG
+# Aliases for DevType slugs that have no dedicated device class.  The
+# discovery scan engine labels devices with these slugs (e.g. 34: → RND),
+# but _CLASS_BY_SLUG only contains slugs that have a _SLUG attribute on a
+# Device subclass.  Without these aliases, ramses_cc logs a warning every
+# 5 minutes for schema entries with these slugs (issue 854).
+_SLUG_ALIASES: dict[str, type[Device]] = {
+    DevType.RND: _HEAT_CLASS_BY_SLUG[DevType.THM],  # 34: round thermostat
+    DevType.DT2: _HEAT_CLASS_BY_SLUG[DevType.THM],  # 22: digital thermostat
+    DevType.DTS: _HEAT_CLASS_BY_SLUG[DevType.THM],  # 12: digital thermostat
+    DevType.HCW: _HEAT_CLASS_BY_SLUG[DevType.THM],  # 03: thermostat (not STA)
+    DevType.TR0: _HEAT_CLASS_BY_SLUG[DevType.TRV],  # 00: radiator valve
+}
+
+_CLASS_BY_SLUG = (
+    _BASE_CLASS_BY_SLUG | _HEAT_CLASS_BY_SLUG | _HVAC_CLASS_BY_SLUG | _SLUG_ALIASES
+)
 
 HEAT_DEV_CLASS_BY_SLUG = {
     k: v for k, v in _HEAT_CLASS_BY_SLUG.items() if k is not DevType.HEA

--- a/src/ramses_rf/devices/dev_registry.py
+++ b/src/ramses_rf/devices/dev_registry.py
@@ -599,9 +599,12 @@ class DeviceRegistry:
         if getattr(dev, "_child_id", None) != FA:
             return
 
-        if old_parent.sensor is not None:
-            return  # system genuinely has DHW; BDR may truly be hotwater_valve
-
+        # Re-parent even if the DhwZone has a sensor — the FC binding
+        # (appliance_control) is a higher-confidence signal than the FA
+        # binding (hotwater_valve).  In issue 834, the DhwZone was created
+        # spuriously from the 000C HTG binding, and a 07: DHW sensor may
+        # have been auto-assigned even though the system has no DHW.
+        # See: https://github.com/ramses-rf/ramses_cc/issues/834
         _LOGGER.info(
             "RE-PARENTING: %s from DhwZone (hotwater_valve) to "
             "System (appliance_control)",

--- a/src/ramses_rf/discovery.py
+++ b/src/ramses_rf/discovery.py
@@ -198,10 +198,10 @@ class DiscoveryService:
         :type timeout: float | None, optional
         :raises CommandInvalid: If the header is missing.
         """
-        cmd_key = HeaderT(str(cmd))
+        cmd_key = HeaderT(cmd.rx_header or "")
         if not cmd_key:
             raise exc.CommandInvalid(
-                f"cmd({cmd}): invalid command not added to discovery"
+                f"cmd({cmd}): invalid (null) header not added to discovery"
             )
 
         if cmd_key in self.cmds:

--- a/src/ramses_rf/dispatcher.py
+++ b/src/ramses_rf/dispatcher.py
@@ -82,6 +82,7 @@ from .protocol.ramses import (
     CODES_OF_HVAC_DOMAIN_ONLY,
 )
 from .protocol_schema import CODES_BY_DEV_SLUG
+from .systems.zones import DhwZone
 
 if TYPE_CHECKING:
     from .gateway import Gateway
@@ -313,6 +314,51 @@ def validate_slugs(gwy: Gateway, msg: Message) -> bool:
     return gwy.config.reduce_processing < DONT_UPDATE_ENTITIES
 
 
+# DHW opcodes that carry no zone_idx/domain_id and need special routing.
+_DHW_OPCODES: Final[frozenset[Code]] = frozenset({Code._1260, Code._10A0, Code._1F41})
+
+
+def _get_dhw_zone_from_msg(msg: Message, src_dev: Any) -> DhwZone | None:
+    """Resolve the DhwZone that should ingest a DHW opcode (1260/10A0/1F41).
+
+    These payloads carry no ``zone_idx``/``domain_id``, so the standard
+    routing in ``_resolve_logical_targets`` (and the equivalent block in
+    ``StateProjector.process_message_state``) misses the DhwZone.
+
+    ``1260`` is sent by the DhwSensor (or relayed by the Controller as an
+    RP); ``10A0``/``1F41`` are sent by the Controller.  The
+    appliance_control (OTB) also emits ``10A0``/``1260`` with different
+    semantics (CH setpoint / null temp) and is excluded to avoid
+    clobbering the DHW read-models.
+
+    See: https://github.com/ramses-rf/ramses_cc/issues/843
+
+    :param msg: The inbound message.
+    :type msg: Message
+    :param src_dev: The source device (DhwSensor or Controller).
+    :return: The DhwZone to route to, or ``None`` if the message is not
+        a DHW opcode or the source is not a DHW sender.
+    :rtype: DhwZone | None
+    """
+    if msg.code not in _DHW_OPCODES or src_dev is None:
+        return None
+
+    src_slug = getattr(src_dev, "_SLUG", "")
+    if msg.code == Code._1260:
+        is_dhw_src = src_slug in ("DHW", "CTL")
+    else:  # 10A0 / 1F41 are owned by the Controller
+        is_dhw_src = src_slug == "CTL"
+
+    if not is_dhw_src:
+        return None
+
+    tcs = getattr(src_dev, "tcs", None)
+    if tcs is None:
+        return None
+
+    return getattr(tcs, "dhw", None)
+
+
 def _resolve_logical_targets(
     gwy: Gateway, msg: Message, p: dict[str, Any]
 ) -> list[Any]:
@@ -380,25 +426,11 @@ def _resolve_logical_targets(
         targets.append(src_dev.tcs)
 
     # 7. DHW opcodes (1260/10A0/1F41) carry no domain_id/zone_idx, so steps
-    #    4/5 miss the DhwZone.  1260 is sent by the DhwSensor (or relayed by
-    #    the Controller as an RP); 10A0/1F41 are sent by the Controller.  The
-    #    appliance_control (OTB) also emits 10A0/1260 with different semantics
-    #    (CH setpoint / null temp) and must be excluded to avoid clobbering
-    #    the DHW read-models.  Without this, the CQRS read-models
-    #    (temp_state/dhw_state) on the DhwZone are never hydrated and the
-    #    ramses_cc water_heater entity shows no current/target temperature.
+    #    4/5 miss the DhwZone.  Route them via the shared helper.
     #    See: https://github.com/ramses-rf/ramses_cc/issues/843
-    if msg.code in (Code._1260, Code._10A0, Code._1F41) and src_dev:
-        src_slug = getattr(src_dev, "_SLUG", "")
-        if msg.code == Code._1260:
-            is_dhw_src = src_slug in ("DHW", "CTL")
-        else:  # 10A0 / 1F41 are owned by the Controller
-            is_dhw_src = src_slug == "CTL"
-        if is_dhw_src:
-            tcs = getattr(src_dev, "tcs", None)
-            dhw = getattr(tcs, "dhw", None) if tcs is not None else None
-            if dhw is not None and dhw not in targets:
-                targets.append(dhw)
+    dhw = _get_dhw_zone_from_msg(msg, src_dev)
+    if dhw is not None and dhw not in targets:
+        targets.append(dhw)
 
     return targets
 
@@ -677,7 +709,7 @@ def _update_dhw_state(target: Any, p: dict[str, Any], msg: Message) -> None:
     (setpoint/overrun/differential from 10A0, mode/active/until from 1F41)
     in addition to ``temp_state``.
     """
-    if not hasattr(target, "dhw_state"):
+    if not isinstance(target, DhwZone):
         return
 
     updates: dict[str, Any] = {}
@@ -703,13 +735,12 @@ def _update_dhw_state(target: Any, p: dict[str, Any], msg: Message) -> None:
     target.dhw_state = new_state
 
     event = StateUpdatedEvent(
-        entity_id=getattr(target, "id", "unknown"),
+        entity_id=target.id,
         state=new_state,
         correlation_id=getattr(msg, "correlation_id", uuid.uuid4()),
         causation_id=getattr(msg, "message_id", uuid.uuid4()),
     )
-    if hasattr(target, "apply_state_update"):
-        target.apply_state_update(event)
+    target.apply_state_update(event)
 
 
 def _cqrs_ingestion_engine(gwy: Gateway, msg: Message) -> None:

--- a/src/ramses_rf/entity.py
+++ b/src/ramses_rf/entity.py
@@ -20,6 +20,7 @@ from .models import (
     ScheduleState,
     StateUpdatedEvent,
     TemperatureState,
+    ZoneState,
 )
 from .state import EntityState
 
@@ -142,6 +143,8 @@ class _Entity:
             setattr(self, "opentherm_state", event.state)  # noqa: B010
         elif isinstance(event.state, HvacState) and hasattr(self, "hvac_state"):
             setattr(self, "hvac_state", event.state)  # noqa: B010
+        elif isinstance(event.state, ZoneState) and hasattr(self, "zone_state"):
+            setattr(self, "zone_state", event.state)  # noqa: B010
 
     def _send_cmd(self, cmd: CommandDTO, **kwargs: Any) -> asyncio.Task[Any] | None:
         """Proxy command sending to the Gateway.

--- a/src/ramses_rf/enums.py
+++ b/src/ramses_rf/enums.py
@@ -44,6 +44,7 @@ class Action(StrEnum):
     SET_FAN_PARAM = "set_fan_param"
     GET_FAN_PARAM = "get_fan_param"
     GET_HVAC_FAN_31DA = "get_hvac_fan_31da"
+    SET_PROGRAM_ENABLED = "set_program_enabled"
 
     GET_SCHEDULE_VERSION = "get_schedule_version"
     GET_SCHEDULE_FRAGMENT = "get_schedule_fragment"

--- a/src/ramses_rf/parsers/heating.py
+++ b/src/ramses_rf/parsers/heating.py
@@ -758,7 +758,8 @@ def parser_2309(
     if msg.verb == RQ and msg.len == 1:  # some RQs have a payload (why?)
         return {}
 
-    return {SZ_SETPOINT: hex_to_temp(payload[2:])}
+    # payload[:2] is the zone_idx (zz), payload[2:] is the setpoint
+    return {SZ_ZONE_IDX: payload[:2], SZ_SETPOINT: hex_to_temp(payload[2:])}
 
 
 # zone_mode  # TODO: messy
@@ -786,6 +787,7 @@ def parser_2349(payload: str, msg: Message) -> PayDictT._2349 | PayDictT.EMPTY:
 
     assert payload[6:8] in ZON_MODE_MAP, f"unknown zone_mode: {payload[6:8]}"
     result: PayDictT._2349 = {
+        SZ_ZONE_IDX: payload[:2],  # zz — zone_idx
         SZ_MODE: ZON_MODE_MAP.get(payload[6:8]),  # type: ignore[typeddict-item]
         SZ_SETPOINT: hex_to_temp(payload[2:6]),
     }

--- a/src/ramses_rf/pipeline/ingestion.py
+++ b/src/ramses_rf/pipeline/ingestion.py
@@ -85,6 +85,7 @@ from ramses_rf.const import (
     SZ_ZONE_IDX,
     Code,
 )
+from ramses_rf.dispatcher import _get_dhw_zone_from_msg
 from ramses_rf.enums import Action
 from ramses_rf.messages import Message
 from ramses_rf.models import (
@@ -332,35 +333,20 @@ class StateProjector:
 
             # Route DHW opcodes (1260/10A0/1F41) to the DhwZone.
             # These payloads carry no zone_idx/domain_id, so the block above
-            # misses the DhwZone.  1260 is sent by the DhwSensor (or relayed
-            # by the Controller as an RP); 10A0/1F41 are sent by the
-            # Controller.  All of these expose a ``tcs`` attribute whose
-            # ``dhw`` is the DhwZone.  The appliance_control (OTB) also emits
-            # 10A0/1260 with different semantics (CH setpoint / null temp), so
-            # it must be excluded to avoid clobbering the DHW read-models.
-            # Without this, the CQRS read-models (temp_state/dhw_state) on the
-            # DhwZone are never hydrated and the ramses_cc water_heater entity
-            # shows no current/target temperature.
+            # misses the DhwZone.  The shared helper in dispatcher.py
+            # encapsulates the routing logic (src_slug check, OTB exclusion).
             # See: https://github.com/ramses-rf/ramses_cc/issues/843
-            if msg.code in (Code._1260, Code._10A0, Code._1F41) and src_dev:
-                src_slug = getattr(src_dev, "_SLUG", "")
-                if msg.code == Code._1260:
-                    is_dhw_src = src_slug in ("DHW", "CTL")
-                else:  # 10A0 / 1F41 are owned by the Controller
-                    is_dhw_src = src_slug == "CTL"
-                if is_dhw_src:
-                    tcs = getattr(src_dev, "tcs", None)
-                    dhw = getattr(tcs, "dhw", None) if tcs is not None else None
-                    if dhw is not None:
-                        try:
-                            self._update_dhw_state(dhw, p, msg)
-                            self._update_temperature_state(dhw, p, msg)
-                        except Exception as err:
-                            _LOGGER.error(
-                                "CQRS extraction failed for DHW %s: %s",
-                                dhw.id,
-                                err,
-                            )
+            dhw = _get_dhw_zone_from_msg(msg, src_dev)
+            if dhw is not None:
+                try:
+                    self._update_dhw_state(dhw, p, msg)
+                    self._update_temperature_state(dhw, p, msg)
+                except Exception as err:
+                    _LOGGER.error(
+                        "CQRS extraction failed for DHW %s: %s",
+                        dhw.id,
+                        err,
+                    )
 
         # --- CQRS Reactor Hooks ---
         # Automate the legacy Actuator discovery query (3EF1) in response to 3EF0 (I)

--- a/src/ramses_rf/pipeline/ingestion.py
+++ b/src/ramses_rf/pipeline/ingestion.py
@@ -339,6 +339,12 @@ class StateProjector:
                 if zone:
                     try:
                         self._update_zone_state(zone, p, msg)
+                        # 2309/2349 also carry a setpoint that the Zone's
+                        # `setpoint` property reads from temp_state.  Without
+                        # this, the zone climate entity's target_temperature
+                        # stays None (issue 843).
+                        if msg.code in (Code._2309, Code._2349):
+                            self._update_temperature_state(zone, p, msg)
                     except Exception as err:
                         _LOGGER.error(
                             "CQRS extraction failed for zone %s: %s",
@@ -804,7 +810,14 @@ class StateProjector:
             if hasattr(target, "apply_state_update"):
                 target.apply_state_update(event)
 
-        if msg.code in (Code._30C9, Code._1260, Code._0002, Code._12C0):
+        if msg.code in (
+            Code._30C9,
+            Code._1260,
+            Code._0002,
+            Code._12C0,
+            Code._2309,
+            Code._2349,
+        ):
             updates: dict[str, Any] = {}
             if SZ_TEMPERATURE in p:
                 # Legacy Parity: Physical sensors only track their own local sensor readings.
@@ -1007,13 +1020,33 @@ class StateProjector:
             target.apply_state_update(event)
 
     def _update_zone_state(self, target: Any, p: dict[str, Any], msg: Message) -> None:
-        """Translate zone configuration opcodes into ZoneState."""
-        if msg.code != Code._0004:
-            return
+        """Translate zone configuration opcodes into ZoneState.
 
+        Handles:
+        - 0004 (zone_name): updates zone_state.name
+        - 2349 (zone_mode): updates zone_state.mode, setpoint, until
+        - 2309 (setpoint): updates zone_state.setpoint
+        """
         updates: dict[str, Any] = {}
-        if SZ_NAME in p:
-            updates[SZ_NAME] = str(p[SZ_NAME])
+
+        if msg.code == Code._0004:
+            if SZ_NAME in p:
+                updates[SZ_NAME] = str(p[SZ_NAME])
+
+        elif msg.code == Code._2349:
+            if SZ_MODE in p:
+                updates[SZ_MODE] = p[SZ_MODE]
+            if SZ_SETPOINT in p:
+                updates[SZ_SETPOINT] = p[SZ_SETPOINT]
+            if SZ_UNTIL in p:
+                updates[SZ_UNTIL] = p[SZ_UNTIL]
+
+        elif msg.code == Code._2309:
+            if SZ_SETPOINT in p:
+                updates[SZ_SETPOINT] = p[SZ_SETPOINT]
+
+        else:
+            return
 
         if not updates:
             return
@@ -1024,7 +1057,6 @@ class StateProjector:
 
         current_state = getattr(target, "zone_state", None) or ZoneState()
         new_state = dataclasses.replace(current_state, **updates)
-        target.zone_state = new_state
 
         event = StateUpdatedEvent(
             entity_id=getattr(target, "id", "unknown"),
@@ -1034,3 +1066,5 @@ class StateProjector:
         )
         if hasattr(target, "apply_state_update"):
             target.apply_state_update(event)
+        else:
+            target.zone_state = new_state  # noqa: B010

--- a/src/ramses_rf/systems/tcs.py
+++ b/src/ramses_rf/systems/tcs.py
@@ -1203,11 +1203,12 @@ class StoredHw(SystemBase):  # 10A0, 1260, 1F41
     def _remove_dhw_zone(self) -> bool:
         """Remove the DhwZone from this system if it is empty.
 
-        A DhwZone is considered empty when it has no sensor, no hotwater
-        valve, no heating valve, and no remaining children.  This is used
-        during re-parenting (e.g. when a BDR is promoted from
-        ``hotwater_valve`` to ``appliance_control``) to clean up a
-        spurious DhwZone that was created by a lower-confidence binding.
+        A DhwZone is considered empty when it has no hotwater valve, no
+        heating valve, and no remaining children.  The sensor is not
+        checked — a 07: DHW sensor may have been auto-assigned from
+        traffic even though the system has no DHW (see issue 834 where
+        a spurious DhwZone was created by a lower-confidence 000C HTG
+        binding).
 
         :returns: ``True`` if the DhwZone was removed, ``False`` if it
             was retained because it still has children.
@@ -1217,8 +1218,7 @@ class StoredHw(SystemBase):  # 10A0, 1260, 1F41
             return False
 
         if (
-            self._dhw.sensor is None
-            and self._dhw.hotwater_valve is None
+            self._dhw.hotwater_valve is None
             and self._dhw.heating_valve is None
             and not self._dhw.childs
         ):

--- a/src/ramses_tx/dtos.py
+++ b/src/ramses_tx/dtos.py
@@ -81,9 +81,17 @@ class CommandDTO:
     num_repeats: int = 1
 
     def __str__(self) -> str:
-        """Return the string representation of the frame to be transmitted."""
+        """Return the string representation of the frame to be transmitted.
+
+        The verb is stripped and right-justified to 2 characters to match the
+        RF protocol format expected by the HGI80 (e.g. ``" W"`` not ``"W"``).
+        Without this normalisation, verbs passed as plain strings (e.g. from
+        the ramses_cc send_packet service) produce malformed frames that the
+        HGI80 silently drops — no echo, causing a 20s QoS timeout.
+        """
+        verb = f"{str(self.verb).strip():>2}"
         return (
-            f"{self.verb} --- {self.addr1} {self.addr2} {self.addr3} {self.code} "
+            f"{verb} --- {self.addr1} {self.addr2} {self.addr3} {self.code} "
             f"{int(len(self.payload) / 2):03d} {self.payload}"
         )
 

--- a/src/ramses_tx/engine.py
+++ b/src/ramses_tx/engine.py
@@ -19,9 +19,12 @@ from .const import (
     DEFAULT_NUM_REPEATS,
     DEFAULT_SEND_TIMEOUT,
     DEFAULT_WAIT_FOR_REPLY,
+    I_,
     SZ_ACTIVE_HGI,
+    W_,
     Code,
     Priority,
+    VerbT,
 )
 from .dtos import CommandDTO, PacketDTO
 from .packet import Packet
@@ -332,6 +335,12 @@ class Engine:
         from_id: str | None = None,
         seqn: str | None = None,
     ) -> CommandDTO:
+        # Normalise plain-string verbs to VerbT so that the frame is formatted
+        # correctly (e.g. "W" → " W").  The old Command._from_attrs did this;
+        # the migration to CommandDTO dropped it, causing malformed frames
+        # that the HGI80 silently drops (issue 835).
+        verb = I_ if verb == "I" else W_ if verb == "W" else verb
+
         addr1 = from_id or HGI_DEV_ADDR.id
 
         if device_id == addr1:

--- a/src/ramses_tx/packet.py
+++ b/src/ramses_tx/packet.py
@@ -154,7 +154,7 @@ class Packet(Frame):
         if dtm is None:
             dtm = dt.now()
         frame = (
-            f"{cmd.verb} --- {cmd.addr1} {cmd.addr2} {cmd.addr3} {cmd.code} "
+            f"{cmd.verb.strip():>2} --- {cmd.addr1} {cmd.addr2} {cmd.addr3} {cmd.code} "
             f"{int(len(cmd.payload) / 2):03d} {cmd.payload}"
         )
         return cls.from_port(dtm, f"... {frame}")

--- a/src/ramses_tx/protocol/fsm.py
+++ b/src/ramses_tx/protocol/fsm.py
@@ -557,7 +557,6 @@ class WantEcho(ProtocolStateBase):
         else:
             pkt__hdr = pkt_hdr
 
-        print(f"DEBUG: pkt__hdr={pkt__hdr!r} tx_header={self._sent_cmd.tx_header!r}")
         if pkt__hdr != self._sent_cmd.tx_header:
             return
 

--- a/tests/tests_rf/commands/test_tx_parity.py
+++ b/tests/tests_rf/commands/test_tx_parity.py
@@ -369,6 +369,54 @@ def test_build_set_bypass_position(snapshot: Any) -> None:
     assert dto.payload == "00FF"
 
 
+def test_build_set_program_enabled_true(snapshot: Any) -> None:
+    intent = Intent(
+        src=Address("37:171871"),
+        dst=Address("32:155617"),
+        action=Action.SET_PROGRAM_ENABLED,
+        data={"enabled": True},
+    )
+    dto = build_dto(intent)
+    assert str(dto.verb) == " W"
+    assert str(dto.code) == "22B0"
+    assert dto.payload == "0005"
+
+
+def test_build_set_program_enabled_false(snapshot: Any) -> None:
+    intent = Intent(
+        src=Address("37:171871"),
+        dst=Address("32:155617"),
+        action=Action.SET_PROGRAM_ENABLED,
+        data={"enabled": False},
+    )
+    dto = build_dto(intent)
+    assert str(dto.verb) == " W"
+    assert str(dto.code) == "22B0"
+    assert dto.payload == "0006"
+
+
+def test_build_set_program_enabled_missing_raises() -> None:
+    intent = Intent(
+        src=Address("37:171871"),
+        dst=Address("32:155617"),
+        action=Action.SET_PROGRAM_ENABLED,
+        data={},
+    )
+    with pytest.raises(ValueError, match="Missing 'enabled'"):
+        build_dto(intent)
+
+
+def test_build_set_program_enabled_wrong_type_raises() -> None:
+    intent = Intent(
+        src=Address("37:171871"),
+        dst=Address("32:155617"),
+        action=Action.SET_PROGRAM_ENABLED,
+        data={"enabled": "yes"},
+    )
+    with pytest.raises(ValueError, match="must be a bool"):
+        build_dto(intent)
+
+
 def test_build_get_fan_param(snapshot: Any) -> None:
     intent = Intent(
         src=Address("18:000730"),

--- a/tests/tests_rf/test_bdr_reparent_issue_834.py
+++ b/tests/tests_rf/test_bdr_reparent_issue_834.py
@@ -108,12 +108,17 @@ async def test_bdr_reparent_from_hotwater_valve_to_appliance_control() -> None:
 
 
 @pytest.mark.asyncio
-async def test_bdr_no_reparent_when_dhw_sensor_exists() -> None:
-    """A BDR must NOT be re-parented from hotwater_valve to
-    appliance_control when a DHW sensor exists.
+async def test_bdr_reparent_even_when_dhw_sensor_exists() -> None:
+    """A BDR must be re-parented from hotwater_valve to
+    appliance_control even when a DHW sensor exists.
 
-    If the system genuinely has DHW (sensor present), the BDR may truly be
-    the hotwater_valve, so the re-parenting must be suppressed.
+    The FC binding (appliance_control) is a higher-confidence signal than
+    the FA binding (hotwater_valve).  In issue 834, the DhwZone was
+    created spuriously from a 000C HTG binding, and a 07: DHW sensor may
+    have been auto-assigned even though the system has no DHW.  The
+    sensor is not a reliable indicator that the system genuinely has
+    DHW, so re-parenting must proceed and the spurious DhwZone must be
+    removed.
     """
     known_list = {
         CTL_ID: {"class": "CTL"},
@@ -146,15 +151,19 @@ async def test_bdr_no_reparent_when_dhw_sensor_exists() -> None:
         assert tcs.dhw.hotwater_valve is not None
         assert tcs.dhw.hotwater_valve.id == BDR_ID
 
-        # 4. Attempt to bind the same BDR as appliance_control (FC)
-        # This should NOT re-parent because a DHW sensor exists
+        # 4. Bind the same BDR as appliance_control (FC)
+        # This MUST re-parent because the FC binding is higher-confidence
+        # than the FA binding, even though a DHW sensor is present.
         with contextlib.suppress(Exception):
             gwy.device_registry.get_device(BDR_ID, parent=tcs, child_id=FC)
 
-        # 5. Verify the BDR is still hotwater_valve (not re-parented)
-        assert tcs.dhw is not None
-        assert tcs.dhw.hotwater_valve is not None
-        assert tcs.dhw.hotwater_valve.id == BDR_ID
+        # 5. Verify the BDR was re-parented to appliance_control
+        assert tcs.appliance_control is not None
+        assert tcs.appliance_control.id == BDR_ID
+        # The spurious DhwZone must be removed (no hotwater_valve, no
+        # heating_valve, no childs — the sensor alone is not enough to
+        # keep it alive).
+        assert tcs.dhw is None or tcs.dhw.hotwater_valve is None
     finally:
         await gwy.stop()
 


### PR DESCRIPTION
## Summary

This PR bundles 4 independent fixes that all sit on top of PRs 869 + 879 (merged):

### 1. discovery.py rx_header + packet.py verb normalization
- `discovery.py`: `HeaderT(str(cmd))` produced `"CommandDTO(...)"` instead of the rx_header string, causing every `cmd_key` to be identical and discovery QoS to break. Use `cmd.rx_header` instead.
- `packet.py`: `Packet._from_cmd` used `f"{cmd.verb}"` which left single-char verbs like `"W"` without the leading space that ramses_rf expects (`" W"`). Use `f"{cmd.verb.strip():>2}"` to right-align in a 2-char field.

### 2. cc 834 — BDR re-parenting from DhwZone
- `_maybe_reparent_bdr`: remove the early return when `old_parent.sensor` is not None. The FC binding (`appliance_control`) is a higher-confidence signal than the FA binding (`hotwater_valve`). In issue 834, the DhwZone was created spuriously from a 000C HTG binding, and a 07: DHW sensor may have been auto-assigned even though the system has no DHW.
- `_remove_dhw_zone`: stop checking `self._dhw.sensor` — a sensor may have been auto-assigned from traffic even though the system has no DHW.

### 3. cc 843/855 — zone climate state hydration
- Hydrates `zone_state.mode/setpoint` from 2349/2309 packets via the CQRS ingestion pipeline. Without this, zone climate entities show `unknown` state and `preset_mode` is null.
- `parsers/heating.py`: add `SZ_ZONE_IDX` to parser_2349/parser_2309 results
- `pipeline/ingestion.py`: extend `_update_zone_state` for Code._2349/_2309, add those codes to `_update_temperature_state`, call `_update_temperature_state` on zones in CQRS routing
- `ramses_tx/typing.py`: add `zone_idx` to `_2349` TypedDict

### 4. cc 835 — verb normalization in CommandDTO/Engine.create_cmd
- The Command architecture migration (commit 2a86a4833) dropped the verb normalisation that the old `Command._from_attrs` did. Without this, passing `verb="W"` (without leading space) — as the ramses_cc `send_packet` service allows — produces a malformed frame that the HGI80 silently drops, causing a 20s QoS timeout.
- `dtos.py`: `CommandDTO.__str__` now strips and right-justifies the verb to 2 chars
- `engine.py`: `Engine.create_cmd` converts `"I"`/`"W"` to `I_`/`W_` (VerbT)
- `fsm.py`: removed leftover debug `print()`

### 5. cc 854 — RND/DT2/DTS/HCW/TR0 slug aliases
- The discovery scan engine labels 34: devices (T87RF2033) as `RND`, but `_CLASS_BY_SLUG` had no entry for `RND` (the `Thermostat` class uses `_SLUG = THM`). This caused ramses_cc to log a warning every 5 minutes.
- `devices/__init__.py`: added `_SLUG_ALIASES` mapping orphan DevType slugs to their parent device classes (RND/DT2/DTS/HCW → THM, TR0 → TRV)

#### Test plan
- [x] ramses_rf test suite: 1413 passed, 39 skipped
- [x] ramses_cc ha_sim_test R36 recipe passes (zone climate state hydration)
- [x] CI on this PR

see also https://github.com/ramses-rf/ramses_cc/issues/855