### PR TITLE
refactor(dto): resolve Phase 5 API boundary gaps and implement ActuatorCycleDTO

### DIFF
--- a/src/ramses_rf/devices/dev_base.py
+++ b/src/ramses_rf/devices/dev_base.py
@@ -243,25 +243,53 @@ class DeviceBase(Entity):
             return self._gwy.polling_manager.resolve_schedule_for_device(self)
         return self._polling_interval
 
-    def set_polling_interval(self, code: str, interval: int) -> None:
+    def set_polling_interval(self, interval: int | None) -> None:
+        """Set or update the overall polling interval override for this device.
+
+        :param interval: The polling interval in seconds, or None to reset to default.
+        :type interval: int | None
+        :raises ValueError: If interval is negative or if setting a battery device below 300s.
+        """
+        if interval is not None and interval < 0:
+            raise ValueError(f"Polling interval cannot be negative: {interval}")
+        if self.is_battery and interval is not None and 0 < interval < 300:
+            raise ValueError(
+                f"Battery-powered device {self.id} polling interval cannot be set below 300s (got {interval}s)"
+            )
+
+        if interval is None:
+            self._polling_interval = None
+        else:
+            eff_schedule = self.effective_polling_interval or {}
+            codes = list(eff_schedule.keys()) or ["10E0"]
+            self._polling_interval = {code: interval for code in codes}
+
+        if getattr(self._gwy, "polling_manager", None):
+            self._gwy.polling_manager.update_device_tasks(self)
+
+    def set_command_polling_interval(self, code: str, interval: int | None) -> None:
         """Set or update the polling interval for a specific packet code.
 
         :param code: The hex code string for the packet type.
         :type code: str
-        :param interval: The polling interval in seconds (0 to disable).
-        :type interval: int
+        :param interval: The polling interval in seconds (None or 0 to reset).
+        :type interval: int | None
         :raises ValueError: If interval is negative or if setting a battery device below 300s.
         """
-        if interval < 0:
+        if interval is not None and interval < 0:
             raise ValueError(f"Polling interval cannot be negative: {interval}")
-        if self.is_battery and 0 < interval < 300:
+        if self.is_battery and interval is not None and 0 < interval < 300:
             raise ValueError(
                 f"Battery-powered device {self.id} polling interval cannot be set below 300s (got {interval}s)"
             )
 
         if self._polling_interval is None:
             self._polling_interval = {}
-        self._polling_interval[code] = interval
+
+        if interval is None:
+            self._polling_interval.pop(code, None)
+        else:
+            self._polling_interval[code] = interval
 
         if getattr(self._gwy, "polling_manager", None):
             self._gwy.polling_manager.update_device_tasks(self)

--- a/src/ramses_rf/devices/heat_actuators.py
+++ b/src/ramses_rf/devices/heat_actuators.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from typing import Any, Final
 
 from ramses_rf.const import DOMAIN_TYPE_MAP, DevType
-from ramses_rf.models import ActuatorStateDTO, DeviceTraits
+from ramses_rf.models import ActuatorCycleDTO, ActuatorStateDTO, DeviceTraits
 from ramses_tx import Priority
 from ramses_tx.const import SZ_HEAT_DEMAND, SZ_PRIORITY, SZ_RELAY_DEMAND, Code
 from ramses_tx.typing import PayDictT
@@ -32,26 +32,22 @@ class Actuator(DeviceHeat):  # 3EF0, 3EF1 (for 10:/13:)
     ACTUATOR_STATE: Final = "actuator_state"
     MODULATION_LEVEL: Final = "modulation_level"  # percentage (0.0-1.0)
 
-    async def actuator_cycle(self) -> dict[str, Any] | None:  # 3EF1
-        """Return the actuator cycle state.
+    async def actuator_cycle(self) -> ActuatorCycleDTO | None:  # 3EF1
+        """Return the actuator cycle state as a CQRS DTO.
 
-        # TODO: Refactor for #714 (CQRS API Boundaries).
-        # This is a legacy shim to maintain backward compatibility with ramses_cc.
+        :returns: ActuatorCycleDTO or None.
+        :rtype: ActuatorCycleDTO | None
         """
         state = getattr(self, "act_state", None)
         if not state:
             return None
 
-        raw_dict = {
-            "actuator_countdown": state.actuator_countdown,
-            "cycle_countdown": state.cycle_countdown,
-            "actuator_enabled": state.actuator_enabled,
-            "modulation_level": state.modulation_level,
-        }
-
-        # Dynamically strip None values to mimic legacy optional keys
-        clean_dict = {k: v for k, v in raw_dict.items() if v is not None}
-        return clean_dict if clean_dict else None
+        return ActuatorCycleDTO(
+            actuator_countdown=state.actuator_countdown,
+            cycle_countdown=state.cycle_countdown,
+            actuator_enabled=state.actuator_enabled,
+            modulation_level=state.modulation_level,
+        )
 
     async def actuator_state(self) -> ActuatorStateDTO | None:  # 3EF0
         """Return the actuator modulation state as a CQRS DTO.

--- a/src/ramses_rf/models/__init__.py
+++ b/src/ramses_rf/models/__init__.py
@@ -2,7 +2,13 @@
 
 from __future__ import annotations
 
-from .dto import ActuatorStateDTO, ThermalDemandDTO, UfhCircuitDemandDTO
+from .dto import (
+    ActuatorCycleDTO,
+    ActuatorStateDTO,
+    ThermalDemandDTO,
+    UfhCircuitDemandDTO,
+    ZoneScheduleDTO,
+)
 from .state_base import DeviceTraits, StateUpdatedEvent, TopologyChangedEvent, _now_utc
 from .state_climate import (
     ActuatorState,
@@ -21,6 +27,7 @@ from .state_opentherm import OpenThermState
 from .state_schedules import DailySchedule, ScheduleState, SwitchPoint
 
 __all__ = [
+    "ActuatorCycleDTO",
     "ActuatorState",
     "ActuatorStateDTO",
     "DailySchedule",
@@ -42,6 +49,7 @@ __all__ = [
     "TrvState",
     "UfhCircuitDemandDTO",
     "UfhState",
+    "ZoneScheduleDTO",
     "ZoneState",
     "_now_utc",
 ]

--- a/src/ramses_rf/models/dto.py
+++ b/src/ramses_rf/models/dto.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from datetime import datetime as dt
+from typing import Any
 
 from ramses_rf.enums import ThermalMode
 
@@ -134,3 +135,37 @@ class ActuatorStateDTO:
     dhw_active: bool | None = None
     flame_active: bool | None = None
     last_updated: dt | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class ActuatorCycleDTO:
+    """DTO for heating actuator cycle parameters (command 3EF1).
+
+    :param actuator_countdown: Remaining actuator run countdown.
+    :type actuator_countdown: int | None
+    :param cycle_countdown: Remaining cycle countdown.
+    :type cycle_countdown: int | None
+    :param actuator_enabled: True if actuator state output is enabled.
+    :type actuator_enabled: bool | None
+    :param modulation_level: Active modulation level (0.0 to 1.0).
+    :type modulation_level: float | None
+    """
+
+    actuator_countdown: int | None = None
+    cycle_countdown: int | None = None
+    actuator_enabled: bool | None = None
+    modulation_level: float | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class ZoneScheduleDTO:
+    """CQRS DTO wrapping zone or system weekly schedule payload.
+
+    :param zone_idx: Zone index string (e.g. '00', 'HW').
+    :type zone_idx: str
+    :param schedule: Weekly schedule list of daily switchpoint dicts.
+    :type schedule: list[dict[str, Any]]
+    """
+
+    zone_idx: str
+    schedule: list[dict[str, Any]]

--- a/tests/tests_rf/test_dto_models.py
+++ b/tests/tests_rf/test_dto_models.py
@@ -1,0 +1,127 @@
+"""Unit tests for RAMSES RF CQRS Data Transfer Objects (DTOs)."""
+
+from datetime import UTC, datetime as dt
+
+from ramses_rf.enums import ThermalMode
+from ramses_rf.models import (
+    ActuatorCycleDTO,
+    ActuatorStateDTO,
+    ThermalDemandDTO,
+    UfhCircuitDemandDTO,
+    ZoneScheduleDTO,
+)
+
+
+def test_thermal_demand_dto_heat_mode() -> None:
+    # Arrange
+    mode = ThermalMode.HEAT
+    magnitude = 0.75
+
+    # Act
+    dto = ThermalDemandDTO(thermal_demand=magnitude, mode=mode, ufx_idx="01")
+
+    # Assert
+    assert dto.thermal_demand == 0.75
+    assert dto.mode == ThermalMode.HEAT
+    assert dto.heating_demand == 0.75
+    assert dto.cooling_demand == 0.0
+    assert dto.heat_demand == 0.75
+    assert dto.ufx_idx == "01"
+
+
+def test_thermal_demand_dto_cool_mode() -> None:
+    # Arrange
+    mode = ThermalMode.COOL
+    magnitude = 0.50
+
+    # Act
+    dto = ThermalDemandDTO(thermal_demand=magnitude, mode=mode, ufx_idx="02")
+
+    # Assert
+    assert dto.thermal_demand == 0.50
+    assert dto.mode == ThermalMode.COOL
+    assert dto.heating_demand == 0.0
+    assert dto.cooling_demand == 0.50
+    assert dto.heat_demand == 0.0
+
+
+def test_thermal_demand_dto_none_magnitude() -> None:
+    # Arrange
+    magnitude = None
+
+    # Act
+    dto = ThermalDemandDTO(thermal_demand=magnitude, mode=ThermalMode.HEAT)
+
+    # Assert
+    assert dto.thermal_demand is None
+    assert dto.heating_demand is None
+    assert dto.cooling_demand is None
+
+
+def test_ufh_circuit_demand_dto() -> None:
+    # Arrange
+    idx = "00"
+    demand = 0.85
+
+    # Act
+    dto = UfhCircuitDemandDTO(ufx_idx=idx, thermal_demand=demand)
+
+    # Assert
+    assert dto.ufx_idx == "00"
+    assert dto.thermal_demand == 0.85
+    assert dto.heating_demand == 0.85
+    assert dto.cooling_demand == 0.0
+
+
+def test_actuator_state_dto() -> None:
+    # Arrange
+    now = dt.now(UTC)
+
+    # Act
+    dto = ActuatorStateDTO(
+        modulation_level=0.45,
+        actuator_enabled=True,
+        ch_active=True,
+        flame_active=True,
+        last_updated=now,
+    )
+
+    # Assert
+    assert dto.modulation_level == 0.45
+    assert dto.actuator_enabled is True
+    assert dto.ch_active is True
+    assert dto.flame_active is True
+    assert dto.last_updated == now
+
+
+def test_actuator_cycle_dto() -> None:
+    # Arrange
+    actuator_cd = 120
+    cycle_cd = 300
+
+    # Act
+    dto = ActuatorCycleDTO(
+        actuator_countdown=actuator_cd,
+        cycle_countdown=cycle_cd,
+        actuator_enabled=True,
+        modulation_level=0.30,
+    )
+
+    # Assert
+    assert dto.actuator_countdown == 120
+    assert dto.cycle_countdown == 300
+    assert dto.actuator_enabled is True
+    assert dto.modulation_level == 0.30
+
+
+def test_zone_schedule_dto() -> None:
+    # Arrange
+    zone_idx = "01"
+    raw_schedule = [{"day_of_week": 0, "switchpoints": []}]
+
+    # Act
+    dto = ZoneScheduleDTO(zone_idx=zone_idx, schedule=raw_schedule)
+
+    # Assert
+    assert dto.zone_idx == "01"
+    assert dto.schedule == raw_schedule

--- a/tests/tests_rf/test_polling_api.py
+++ b/tests/tests_rf/test_polling_api.py
@@ -1,0 +1,94 @@
+"""Unit tests for RAMSES RF Polling API and PollingManager."""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from ramses_rf.address import Address
+from ramses_rf.devices.dev_base import DeviceBase
+from ramses_rf.pipeline.polling import DEFAULT_POLLING_SCHEDULES, PollingManager
+
+
+def test_device_set_polling_interval_device_level() -> None:
+    # Arrange
+    gwy = MagicMock()
+    dev_addr = Address("10:123456")
+    dev = DeviceBase(gwy, dev_addr)
+
+    # Act
+    dev.set_polling_interval(600)
+
+    # Assert
+    assert dev.polling_interval is not None
+    assert all(val == 600 for val in dev.polling_interval.values())
+
+
+def test_device_set_command_polling_interval() -> None:
+    # Arrange
+    gwy = MagicMock()
+    dev_addr = Address("10:123456")
+    dev = DeviceBase(gwy, dev_addr)
+
+    # Act
+    dev.set_command_polling_interval("3EF0", 900)
+
+    # Assert
+    assert dev.polling_interval == {"3EF0": 900}
+
+
+def test_device_set_polling_interval_reset() -> None:
+    # Arrange
+    gwy = MagicMock()
+    dev_addr = Address("10:123456")
+    dev = DeviceBase(gwy, dev_addr)
+    dev.set_polling_interval(600)
+
+    # Act
+    dev.set_polling_interval(None)
+
+    # Assert
+    assert dev.polling_interval is None
+
+
+def test_device_battery_safeguard_raises_exception() -> None:
+    # Arrange
+    gwy = MagicMock()
+    dev_addr = Address("04:123456")
+    dev = DeviceBase(gwy, dev_addr)
+    dev._is_battery = True
+
+    # Act & Assert
+    with pytest.raises(ValueError, match="cannot be set below 300s"):
+        dev.set_polling_interval(120)
+
+    with pytest.raises(ValueError, match="cannot be set below 300s"):
+        dev.set_command_polling_interval("10E0", 120)
+
+
+def test_polling_manager_battery_device_returns_empty_schedule() -> None:
+    # Arrange
+    gwy = MagicMock()
+    dev_addr = Address("04:123456")
+    dev = DeviceBase(gwy, dev_addr)
+    dev._is_battery = True
+
+    # Act
+    schedule = PollingManager.resolve_schedule_for_device(dev)
+
+    # Assert
+    assert schedule == {}
+
+
+def test_polling_manager_mains_device_resolves_default_schedule() -> None:
+    # Arrange
+    gwy = MagicMock()
+    dev_addr = Address("10:123456")
+    dev = DeviceBase(gwy, dev_addr)
+    dev._is_battery = False
+    dev._SLUG = "OTB"
+
+    # Act
+    schedule = PollingManager.resolve_schedule_for_device(dev)
+
+    # Assert
+    assert schedule == DEFAULT_POLLING_SCHEDULES["OTB"]


### PR DESCRIPTION
### ⚠️ STACKED PR: Depends on #997

### The Problem:
Review of Phase 5 refactoring plan ([ramses-rf/ramses_rf#992](https://github.com/ramses-rf/ramses_rf/issues/992)) identified remaining API boundary gaps in `ramses_rf`:
1. `Actuator.actuator_cycle()` returned a legacy dict rather than a CQRS DTO (`ActuatorCycleDTO`).
2. `DeviceBase.set_polling_interval` lacked explicit separation between device-level overrides and command-code overrides, creating potential parameter ambiguity for downstream consumer service actions.
3. Unit tests for DTO models, `PollingManager` schedule resolution, and battery device safeguards were lacking.

### The Fix:
1. Introduced `ActuatorCycleDTO` and `ZoneScheduleDTO` in `ramses_rf.models.dto` and refactored `Actuator.actuator_cycle()` to return `ActuatorCycleDTO | None`.
2. Implemented explicit dual methods on `DeviceBase`:
   - `set_polling_interval(interval: int | None)`: Overrides effective polling across all active commands for the device.
   - `set_command_polling_interval(code: str, interval: int | None)`: Overrides polling interval for a specific packet code.
3. Enforced battery safeguards (`ValueError` raised if setting polling `< 300s` on battery devices).
4. Added unit test modules `test_dto_models.py` and `test_polling_api.py`.

### Testing Performed:
- Ran `.venv/bin/pytest tests/tests_rf/test_dto_models.py tests/tests_rf/test_polling_api.py` (all 13 tests passed).
- Ran full test suite `.venv/bin/pytest` (1460 passed).
- Ran `.venv/bin/prek run -a` and `.venv/bin/mypy --strict` (all checks passed cleanly).

### AI Assistance Disclosure:
This contribution was developed with the assistance of Google Gemini 3.6 Flash for code generation and documentation. All logic and implementations were reviewed and verified by the author.