### PR TITLE
feat(payloads): implement core PayloadBase ABC, registry, and adapters (PR 1/6)

### DIFF
--- a/src/ramses_rf/payloads/__init__.py
+++ b/src/ramses_rf/payloads/__init__.py
@@ -1,0 +1,23 @@
+"""RAMSES RF - Dataclass Payload Layer package.
+
+This package provides the unified strongly-typed dataclass layer for RAMSES-II
+packet payloads.
+"""
+
+from .adapters import payload_to_dict
+from .base import PayloadBase
+from .registry import (
+    PAYLOAD_REGISTRY,
+    PayloadRegistry,
+    get_payload_class,
+    register_payload,
+)
+
+__all__ = [
+    "PAYLOAD_REGISTRY",
+    "PayloadBase",
+    "PayloadRegistry",
+    "get_payload_class",
+    "payload_to_dict",
+    "register_payload",
+]

--- a/src/ramses_rf/payloads/adapters.py
+++ b/src/ramses_rf/payloads/adapters.py
@@ -1,0 +1,24 @@
+"""RAMSES RF - Dataclass to Legacy Dictionary Adapter.
+
+This module provides serialization utilities to convert typed PayloadBase instances
+into legacy dictionary formats for parity testing and backward compatibility.
+"""
+
+from dataclasses import asdict, is_dataclass
+from typing import Any
+
+from .base import PayloadBase
+
+
+def payload_to_dict(payload: PayloadBase) -> dict[str, Any]:
+    """Convert a PayloadBase instance into a dictionary structure.
+
+    :param payload: The payload dataclass instance to convert.
+    :type payload: PayloadBase
+    :returns: Dictionary representation of the payload attributes.
+    :rtype: dict[str, Any]
+    :raises TypeError: If the input is not a dataclass instance.
+    """
+    if not is_dataclass(payload):
+        raise TypeError(f"Expected dataclass instance, got {type(payload).__name__}")
+    return asdict(payload)

--- a/src/ramses_rf/payloads/base.py
+++ b/src/ramses_rf/payloads/base.py
@@ -1,0 +1,39 @@
+"""RAMSES RF - Dataclass Payload Layer base interface.
+
+This module defines the abstract base class and protocol contract for all RAMSES
+packet payload dataclasses.
+"""
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+from typing import Self
+
+
+@dataclass(frozen=True, slots=True)
+class PayloadBase(ABC):
+    """Abstract base class for RAMSES packet payload dataclasses.
+
+    All payload classes must inherit from this class, specify slots and frozen,
+    and implement binary decoding (from_bytes) and encoding (to_bytes) methods.
+    """
+
+    @classmethod
+    @abstractmethod
+    def from_bytes(cls, raw_data: bytes) -> Self:
+        """Unpack raw binary payload bytes into a typed dataclass instance.
+
+        :param raw_data: Raw byte string representation of the payload.
+        :type raw_data: bytes
+        :returns: A typed payload dataclass instance.
+        :rtype: Self
+        """
+        ...
+
+    @abstractmethod
+    def to_bytes(self) -> bytes:
+        """Pack payload attributes into a raw byte string layout for transmission.
+
+        :returns: Packed raw byte string representation of the payload.
+        :rtype: bytes
+        """
+        ...

--- a/src/ramses_rf/payloads/registry.py
+++ b/src/ramses_rf/payloads/registry.py
@@ -3,6 +3,8 @@
 This module maintains the O(1) opcode-to-payload-class lookup registry.
 """
 
+from __future__ import annotations
+
 from collections.abc import Callable
 from typing import TYPE_CHECKING
 

--- a/src/ramses_rf/payloads/registry.py
+++ b/src/ramses_rf/payloads/registry.py
@@ -1,0 +1,92 @@
+"""RAMSES RF - Dataclass Payload Registry.
+
+This module maintains the O(1) opcode-to-payload-class lookup registry.
+"""
+
+from collections.abc import Callable
+from typing import TYPE_CHECKING
+
+from ramses_tx.const import Code
+
+if TYPE_CHECKING:
+    from .base import PayloadBase
+
+
+class PayloadRegistry:
+    """Registry managing mapping between RAMSES opcodes and PayloadBase classes."""
+
+    def __init__(self) -> None:
+        """Initialize an empty payload registry."""
+        self._registry: dict[str, type[PayloadBase]] = {}
+
+    def register(
+        self, code: Code | str
+    ) -> Callable[[type[PayloadBase]], type[PayloadBase]]:
+        """Register a PayloadBase class for a RAMSES opcode.
+
+        :param code: The Code enum or 4-character hex code string.
+        :type code: Code | str
+        :returns: Decorator function registering target payload class.
+        :rtype: Callable[[type[PayloadBase]], type[PayloadBase]]
+        """
+        key = code.value if isinstance(code, Code) else str(code).upper()
+
+        def decorator(cls: type[PayloadBase]) -> type[PayloadBase]:
+            self._registry[key] = cls
+            return cls
+
+        return decorator
+
+    def get(self, code: Code | str) -> type[PayloadBase] | None:
+        """Retrieve registered PayloadBase class for an opcode.
+
+        :param code: The Code enum or 4-character hex code string.
+        :type code: Code | str
+        :returns: Registered payload dataclass, or None if not found.
+        :rtype: type[PayloadBase] | None
+        """
+        key = code.value if isinstance(code, Code) else str(code).upper()
+        return self._registry.get(key)
+
+    def clear(self) -> None:
+        """Clear all registered payload classes."""
+        self._registry.clear()
+
+    def __contains__(self, code: Code | str) -> bool:
+        """Check if an opcode is registered.
+
+        :param code: The Code enum or 4-character hex code string.
+        :type code: Code | str
+        :returns: True if opcode is registered, False otherwise.
+        :rtype: bool
+        """
+        key = code.value if isinstance(code, Code) else str(code).upper()
+        return key in self._registry
+
+
+# Global default registry instance
+PAYLOAD_REGISTRY = PayloadRegistry()
+
+
+def register_payload(
+    code: Code | str,
+) -> Callable[[type[PayloadBase]], type[PayloadBase]]:
+    """Register a payload dataclass with the global registry.
+
+    :param code: The Code enum or 4-character hex code string.
+    :type code: Code | str
+    :returns: Decorator function registering the payload class.
+    :rtype: Callable[[type[PayloadBase]], type[PayloadBase]]
+    """
+    return PAYLOAD_REGISTRY.register(code)
+
+
+def get_payload_class(code: Code | str) -> type[PayloadBase] | None:
+    """Retrieve a registered payload dataclass from the global registry.
+
+    :param code: The Code enum or 4-character hex code string.
+    :type code: Code | str
+    :returns: The registered payload class or None.
+    :rtype: type[PayloadBase] | None
+    """
+    return PAYLOAD_REGISTRY.get(code)

--- a/tests/tests_rf/test_payload_base.py
+++ b/tests/tests_rf/test_payload_base.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from typing import Self
+from typing import Self, cast
 
 import pytest
 
@@ -98,4 +98,4 @@ def test_payload_to_dict_adapter() -> None:
 def test_payload_to_dict_invalid_type() -> None:
     # Arrange & Act & Assert
     with pytest.raises(TypeError, match="Expected dataclass instance"):
-        payload_to_dict("not_a_dataclass")  # type: ignore[arg-type]
+        payload_to_dict(cast(PayloadBase, "not_a_dataclass"))

--- a/tests/tests_rf/test_payload_base.py
+++ b/tests/tests_rf/test_payload_base.py
@@ -1,0 +1,101 @@
+from dataclasses import dataclass
+from typing import Self
+
+import pytest
+
+from ramses_rf.payloads.adapters import payload_to_dict
+from ramses_rf.payloads.base import PayloadBase
+from ramses_rf.payloads.registry import (
+    PayloadRegistry,
+    get_payload_class,
+    register_payload,
+)
+from ramses_tx.const import Code
+
+
+@dataclass(frozen=True, slots=True)
+class DummyPayload(PayloadBase):
+    val: int
+
+    @classmethod
+    def from_bytes(cls, raw_data: bytes) -> Self:
+        return cls(val=int.from_bytes(raw_data, byteorder="little"))
+
+    def to_bytes(self) -> bytes:
+        return self.val.to_bytes(1, byteorder="little")
+
+
+def test_payload_base_serialization() -> None:
+    # Arrange
+    raw_input = b"\x05"
+
+    # Act
+    payload = DummyPayload.from_bytes(raw_input)
+    encoded = payload.to_bytes()
+
+    # Assert
+    assert payload.val == 5
+    assert encoded == raw_input
+
+
+def test_payload_registry_registration() -> None:
+    # Arrange
+    registry = PayloadRegistry()
+
+    # Act
+    registry.register(Code._3150)(DummyPayload)
+
+    # Assert
+    assert Code._3150 in registry
+    assert "3150" in registry
+    assert registry.get(Code._3150) is DummyPayload
+    assert registry.get("3150") is DummyPayload
+    assert registry.get("9999") is None
+
+
+def test_global_payload_registry_decorator() -> None:
+    # Arrange & Act
+    @register_payload("1234")
+    @dataclass(frozen=True, slots=True)
+    class SamplePayload(PayloadBase):
+        data: int
+
+        @classmethod
+        def from_bytes(cls, raw_data: bytes) -> Self:
+            return cls(data=0)
+
+        def to_bytes(self) -> bytes:
+            return b"\x00"
+
+    # Assert
+    assert get_payload_class("1234") is SamplePayload
+
+
+def test_payload_registry_clear() -> None:
+    # Arrange
+    registry = PayloadRegistry()
+    registry.register("ABCD")(DummyPayload)
+
+    # Act
+    registry.clear()
+
+    # Assert
+    assert "ABCD" not in registry
+    assert registry.get("ABCD") is None
+
+
+def test_payload_to_dict_adapter() -> None:
+    # Arrange
+    payload = DummyPayload(val=42)
+
+    # Act
+    result = payload_to_dict(payload)
+
+    # Assert
+    assert result == {"val": 42}
+
+
+def test_payload_to_dict_invalid_type() -> None:
+    # Arrange & Act & Assert
+    with pytest.raises(TypeError, match="Expected dataclass instance"):
+        payload_to_dict("not_a_dataclass")  # type: ignore[arg-type]


### PR DESCRIPTION
This PR implements **PR 1 (Core Infrastructure & Protocol Contracts)** of the Phase 6 Unified Dataclass Payload Layer proposal, as outlined in ramses-rf/ramses_rf#1001, ramses-rf/ramses_rf#639, and ramses-rf/ramses_rf#837.

### The Problem:
`ramses_rf` payload parsing relies on legacy string-slicing and regex dictionary parsers, missing uniform binary interfaces and type safety.

### The Fix:
- Implement abstract base class `PayloadBase` decorated with `@dataclass(frozen=True, slots=True)` defining `@classmethod from_bytes(cls, raw_data: bytes)` and `to_bytes(self) -> bytes` contracts in `src/ramses_rf/payloads/base.py`.
- Implement `PayloadRegistry` in `src/ramses_rf/payloads/registry.py` for O(1) registration and lookup mapping `Code` enums or hex string opcodes to payload classes, with helper functions `register_payload()` and `get_payload_class()`.
- Implement `payload_to_dict()` adapter in `src/ramses_rf/payloads/adapters.py` for converting typed dataclasses into dictionaries during parity testing.
- Export public API in `src/ramses_rf/payloads/__init__.py`.
- Add unit test suite in `tests/tests_rf/test_payload_base.py`.

### Testing Performed:
- `pytest`: 6/6 tests passed (`.venv/bin/pytest tests/tests_rf/test_payload_base.py`).
- `mypy`: 100% strict type safety (`.venv/bin/mypy --strict src/ramses_rf/payloads`).
- `ruff`: 100% docstring and formatting compliance (`.venv/bin/ruff check --select D src/ramses_rf/payloads`).
- `pre-commit`: All 17 checks passed (`.venv/bin/prek run -a`).

### AI Assistance Disclosure:
This contribution was developed with the assistance of Google Gemini 3.6 Flash for code generation and documentation. All logic and implementations were reviewed and verified by the author.