### PR TITLE
feat(payloads): implement heating and schedule payload dataclasses (PR 3/6)

### DIFF
--- a/src/ramses_rf/payloads/__init__.py
+++ b/src/ramses_rf/payloads/__init__.py
@@ -6,7 +6,15 @@ packet payloads.
 
 from .adapters import payload_to_dict
 from .base import PayloadBase
-from .heating import HeatDemandPayload, TemperaturePayload
+from .heating import (
+    BindingPayload,
+    DhwTemperaturePayload,
+    HeatDemandPayload,
+    ScheduleSwitchpointPayload,
+    SystemSyncPayload,
+    TemperaturePayload,
+    ZoneConfigPayload,
+)
 from .hvac import FanModePayload
 from .registry import (
     PAYLOAD_REGISTRY,
@@ -17,11 +25,16 @@ from .registry import (
 
 __all__ = [
     "PAYLOAD_REGISTRY",
+    "BindingPayload",
+    "DhwTemperaturePayload",
     "FanModePayload",
     "HeatDemandPayload",
     "PayloadBase",
     "PayloadRegistry",
+    "ScheduleSwitchpointPayload",
+    "SystemSyncPayload",
     "TemperaturePayload",
+    "ZoneConfigPayload",
     "get_payload_class",
     "payload_to_dict",
     "register_payload",

--- a/src/ramses_rf/payloads/heating.py
+++ b/src/ramses_rf/payloads/heating.py
@@ -4,8 +4,9 @@ This module contains strongly-typed dataclass representations for CH / Evohome
 packet payloads.
 """
 
+import struct
 from dataclasses import dataclass
-from typing import Self
+from typing import ClassVar, Self
 
 from .base import PayloadBase
 from .registry import register_payload
@@ -124,3 +125,295 @@ class TemperaturePayload(PayloadBase):
         if self.zone_idx is not None:
             return bytes([self.zone_idx]) + temp_bytes
         return temp_bytes
+
+
+@register_payload("0404")
+@dataclass(frozen=True, slots=True)
+class ScheduleSwitchpointPayload(PayloadBase):
+    """Schedule switchpoint payload (Opcode 0404).
+
+    20-byte Schedule Switchpoint binary layout (Little-Endian):
+      Offset  Format  Len  Description                    Sample Hex
+      --------------------------------------------------------------
+      +0       4x     4B   Padding / Header bytes       : 00 00 00 00
+      +4       B      1B   Zone/Domain index (uint8)    : 01
+      +5       3x     3B   Padding bytes                : 00 00 00
+      +8       B      1B   Day of week (uint8, 1-7)     : 01
+      +9       3x     3B   Padding bytes                : 00 00 00
+      +12      H      2B   Time of day (uint16 mins)    : 68 01
+      +14      2x     2B   Padding bytes                : 00 00
+      +16      H      2B   Setpoint value / state (u16) : D0 07
+      +18      H      2B   Reserved / Trailer bytes     : 00 00
+      --------------------------------------------------------------
+      Field-spaced hex : 00000000 01 000000 01 000000 6801 0000 D007 0000
+      Payload hex      : 00000000010000000100000068010000D0070000
+
+    :param zone_idx: Zone/domain index byte.
+    :type zone_idx: int
+    :param day_of_week: Day of week integer (1-7).
+    :type day_of_week: int
+    :param time_of_day_mins: Time of day in minutes.
+    :type time_of_day_mins: int
+    :param setpoint_value: Setpoint value or state raw uint16.
+    :type setpoint_value: int
+    """
+
+    _STRUCT_FMT: ClassVar[str] = "<xxxxBxxxBxxxHxxHH"
+
+    zone_idx: int
+    day_of_week: int
+    time_of_day_mins: int
+    setpoint_value: int
+
+    @classmethod
+    def from_bytes(cls, raw_data: bytes) -> Self:
+        """Unpack a compressed 20-byte RAMSES binary schedule switchpoint.
+
+        :param raw_data: 20-byte schedule binary block.
+        :type raw_data: bytes
+        :returns: Unpacked ScheduleSwitchpointPayload instance.
+        :rtype: Self
+        """
+        idx, dow, tod, val, _ = struct.unpack(cls._STRUCT_FMT, raw_data)
+        return cls(
+            zone_idx=idx,
+            day_of_week=dow,
+            time_of_day_mins=tod,
+            setpoint_value=val,
+        )
+
+    def to_bytes(self) -> bytes:
+        """Pack schedule switchpoint information into bytes.
+
+        :returns: Packed 20-byte binary payload bytes.
+        :rtype: bytes
+        """
+        return struct.pack(
+            self._STRUCT_FMT,
+            self.zone_idx,
+            self.day_of_week,
+            self.time_of_day_mins,
+            self.setpoint_value,
+            0,  # Reserved / trailer 2-byte field (0x0000)
+        )
+
+
+@register_payload("10A0")
+@dataclass(frozen=True, slots=True)
+class DhwTemperaturePayload(PayloadBase):
+    """DHW Temperature payload (Opcode 10A0).
+
+    2-3 byte DHW Temp binary layout (Big-Endian):
+      Offset  Format  Len  Description                    Sample Hex
+      --------------------------------------------------------------
+      +0       B      1B   DHW Index (optional uint8)   : 00
+      +1       h      2B   Temperature (int16, degC*100): 0E D8 (38.00°C)
+      --------------------------------------------------------------
+      Field-spaced hex : 00 0ED8
+      Payload hex      : 000ED8
+
+    :param dhw_idx: Optional DHW index byte, or None.
+    :type dhw_idx: int | None
+    :param temperature: DHW temperature in °C, False if disabled, or None.
+    :type temperature: float | bool | None
+    """
+
+    dhw_idx: int | None
+    temperature: float | bool | None
+
+    @classmethod
+    def from_bytes(cls, raw_data: bytes) -> Self:
+        """Unpack DHW temperature binary payload.
+
+        :param raw_data: Raw binary byte string.
+        :type raw_data: bytes
+        :returns: Unpacked DhwTemperaturePayload instance.
+        :rtype: Self
+        :raises ValueError: If raw_data length is invalid.
+        """
+        if len(raw_data) == 2:
+            idx = None
+            temp_bytes = raw_data
+        elif len(raw_data) >= 3:
+            idx = raw_data[0]
+            temp_bytes = raw_data[1:3]
+        else:
+            raise ValueError(f"Invalid payload length for 10A0: {len(raw_data)}")
+
+        temp_raw = int.from_bytes(temp_bytes, byteorder="big", signed=True)
+        if temp_raw in (0x31FF, 0x7FFF):
+            temp_val: float | bool | None = None
+        elif temp_raw == 0x7EFF:
+            temp_val = False
+        else:
+            temp_val = temp_raw / 100.0
+
+        return cls(dhw_idx=idx, temperature=temp_val)
+
+    def to_bytes(self) -> bytes:
+        """Pack DHW temperature data into binary payload.
+
+        :returns: Packed binary payload bytes.
+        :rtype: bytes
+        """
+        if self.temperature is None:
+            temp_raw = 0x7FFF
+        elif self.temperature is False:
+            temp_raw = 0x7EFF
+        else:
+            temp_raw = int(round(self.temperature * 100.0))
+
+        temp_bytes = temp_raw.to_bytes(2, byteorder="big", signed=True)
+        if self.dhw_idx is not None:
+            return bytes([self.dhw_idx]) + temp_bytes
+        return temp_bytes
+
+
+@register_payload("1030")
+@dataclass(frozen=True, slots=True)
+class SystemSyncPayload(PayloadBase):
+    """System Sync payload (Opcode 1030).
+
+    1-byte System Sync binary layout:
+      Offset  Format  Len  Description                    Sample Hex
+      --------------------------------------------------------------
+      +0       B      1B   Sync Flag / Counter (uint8)  : 00
+      --------------------------------------------------------------
+      Field-spaced hex : 00
+      Payload hex      : 00
+
+    :param sync_flag: System synchronization counter or status byte.
+    :type sync_flag: int
+    """
+
+    sync_flag: int
+
+    @classmethod
+    def from_bytes(cls, raw_data: bytes) -> Self:
+        """Unpack system sync binary payload.
+
+        :param raw_data: Raw binary byte string.
+        :type raw_data: bytes
+        :returns: Unpacked SystemSyncPayload instance.
+        :rtype: Self
+        :raises ValueError: If raw_data is empty.
+        """
+        if not raw_data:
+            raise ValueError("Payload data cannot be empty")
+        return cls(sync_flag=raw_data[0])
+
+    def to_bytes(self) -> bytes:
+        """Pack system sync data into a 1-byte binary payload.
+
+        :returns: Packed 1-byte binary payload.
+        :rtype: bytes
+        """
+        return bytes([self.sync_flag])
+
+
+@register_payload("1FC9")
+@dataclass(frozen=True, slots=True)
+class BindingPayload(PayloadBase):
+    """Binding payload (Opcode 1FC9).
+
+    Encapsulates binding offer / confirmation metadata between devices.
+
+    :param binding_type: Binding type or domain byte.
+    :type binding_type: int
+    :param binding_data: Binding payload raw byte data.
+    :type binding_data: bytes
+    """
+
+    binding_type: int
+    binding_data: bytes
+
+    @classmethod
+    def from_bytes(cls, raw_data: bytes) -> Self:
+        """Unpack binding binary payload.
+
+        :param raw_data: Raw binary byte string.
+        :type raw_data: bytes
+        :returns: Unpacked BindingPayload instance.
+        :rtype: Self
+        :raises ValueError: If raw_data is empty.
+        """
+        if not raw_data:
+            raise ValueError("Payload data cannot be empty")
+        b_type = raw_data[0]
+        b_data = raw_data[1:]
+        return cls(binding_type=b_type, binding_data=b_data)
+
+    def to_bytes(self) -> bytes:
+        """Pack binding data into binary payload.
+
+        :returns: Packed binary payload bytes.
+        :rtype: bytes
+        """
+        return bytes([self.binding_type]) + self.binding_data
+
+
+@register_payload("000A")
+@dataclass(frozen=True, slots=True)
+class ZoneConfigPayload(PayloadBase):
+    """Zone configuration payload (Opcode 000A).
+
+    6-byte Zone Config binary layout (Big-Endian):
+      Offset  Format  Len  Description                    Sample Hex
+      --------------------------------------------------------------
+      +0       B      1B   Zone Index (uint8)           : 00
+      +1       B      1B   Zone Type / Flags            : 00
+      +2       h      2B   Min Temp (int16, degC*100)   : 01 F4 (5.00°C)
+      +4       h      2B   Max Temp (int16, degC*100)   : 0D B8 (35.00°C)
+      --------------------------------------------------------------
+      Field-spaced hex : 00 00 01F4 0DB8
+      Payload hex      : 000001F40DB8
+
+    :param zone_idx: Zone index integer.
+    :type zone_idx: int
+    :param zone_flags: Zone flags byte.
+    :type zone_flags: int
+    :param min_temp: Minimum zone temperature setting in °C.
+    :type min_temp: float
+    :param max_temp: Maximum zone temperature setting in °C.
+    :type max_temp: float
+    """
+
+    _STRUCT_FMT: ClassVar[str] = ">BBhh"
+
+    zone_idx: int
+    zone_flags: int
+    min_temp: float
+    max_temp: float
+
+    @classmethod
+    def from_bytes(cls, raw_data: bytes) -> Self:
+        """Unpack zone config binary payload.
+
+        :param raw_data: Raw binary byte string.
+        :type raw_data: bytes
+        :returns: Unpacked ZoneConfigPayload instance.
+        :rtype: Self
+        """
+        idx, flags, min_raw, max_raw = struct.unpack(cls._STRUCT_FMT, raw_data)
+        return cls(
+            zone_idx=idx,
+            zone_flags=flags,
+            min_temp=min_raw / 100.0,
+            max_temp=max_raw / 100.0,
+        )
+
+    def to_bytes(self) -> bytes:
+        """Pack zone config data into binary payload.
+
+        :returns: Packed binary payload bytes.
+        :rtype: bytes
+        """
+        min_raw = int(round(self.min_temp * 100.0))
+        max_raw = int(round(self.max_temp * 100.0))
+        return struct.pack(
+            self._STRUCT_FMT,
+            self.zone_idx,
+            self.zone_flags,
+            min_raw,
+            max_raw,
+        )

--- a/tests/tests_rf/test_payload_parity.py
+++ b/tests/tests_rf/test_payload_parity.py
@@ -2,7 +2,15 @@ from datetime import datetime as dt
 
 from ramses_rf.parsers.decoder import decode_packet
 from ramses_rf.payloads.adapters import payload_to_dict
-from ramses_rf.payloads.heating import HeatDemandPayload, TemperaturePayload
+from ramses_rf.payloads.heating import (
+    BindingPayload,
+    DhwTemperaturePayload,
+    HeatDemandPayload,
+    ScheduleSwitchpointPayload,
+    SystemSyncPayload,
+    TemperaturePayload,
+    ZoneConfigPayload,
+)
 from ramses_rf.payloads.hvac import FanModePayload
 from ramses_tx.dtos import PacketDTO
 
@@ -55,6 +63,107 @@ def test_temperature_payload_30c9_zone_parity() -> None:
     assert payload.temperature == 20.0
     assert reencoded == raw_hex
     assert as_dict == {"zone_idx": 1, "temperature": 20.0}
+
+
+def test_schedule_switchpoint_payload_0404_parity() -> None:
+    # Arrange
+    raw_hex = "00000000010000000100000068010000D0070000"
+    raw_bytes = bytes.fromhex(raw_hex)
+
+    # Act
+    payload = ScheduleSwitchpointPayload.from_bytes(raw_bytes)
+    reencoded = payload.to_bytes().hex().upper()
+    as_dict = payload_to_dict(payload)
+
+    # Assert
+    assert payload.zone_idx == 1
+    assert payload.day_of_week == 1
+    assert payload.time_of_day_mins == 360  # 0168 hex -> 360 mins = 06:00
+    assert payload.setpoint_value == 2000  # 07D0 hex -> 2000
+    assert reencoded == raw_hex
+    assert as_dict == {
+        "zone_idx": 1,
+        "day_of_week": 1,
+        "time_of_day_mins": 360,
+        "setpoint_value": 2000,
+    }
+
+
+def test_dhw_temperature_payload_10a0_parity() -> None:
+    # Arrange
+    raw_hex = "000ED8"
+    raw_bytes = bytes.fromhex(raw_hex)
+
+    # Act
+    payload = DhwTemperaturePayload.from_bytes(raw_bytes)
+    reencoded = payload.to_bytes().hex().upper()
+    as_dict = payload_to_dict(payload)
+
+    # Assert
+    assert payload.dhw_idx == 0
+    assert payload.temperature == 38.0
+    assert reencoded == raw_hex
+    assert as_dict == {"dhw_idx": 0, "temperature": 38.0}
+
+
+def test_system_sync_payload_1030_parity() -> None:
+    # Arrange
+    raw_hex = "00"
+    raw_bytes = bytes.fromhex(raw_hex)
+
+    # Act
+    payload = SystemSyncPayload.from_bytes(raw_bytes)
+    reencoded = payload.to_bytes().hex().upper()
+    as_dict = payload_to_dict(payload)
+
+    # Assert
+    assert payload.sync_flag == 0
+    assert reencoded == raw_hex
+    assert as_dict == {"sync_flag": 0}
+
+
+def test_binding_payload_1fc9_parity() -> None:
+    # Arrange
+    raw_hex = "000102030405"
+    raw_bytes = bytes.fromhex(raw_hex)
+
+    # Act
+    payload = BindingPayload.from_bytes(raw_bytes)
+    reencoded = payload.to_bytes().hex().upper()
+    as_dict = payload_to_dict(payload)
+
+    # Assert
+    assert payload.binding_type == 0
+    assert payload.binding_data == b"\x01\x02\x03\x04\x05"
+    assert reencoded == raw_hex
+    assert as_dict == {
+        "binding_type": 0,
+        "binding_data": b"\x01\x02\x03\x04\x05",
+    }
+
+
+def test_zone_config_payload_000a_parity() -> None:
+    # Arrange
+    raw_hex = "000001F40DB8"
+    raw_bytes = bytes.fromhex(raw_hex)
+
+    # Act
+    payload = ZoneConfigPayload.from_bytes(raw_bytes)
+    reencoded = payload.to_bytes().hex().upper()
+    as_dict = payload_to_dict(payload)
+
+    # Assert
+    assert payload.zone_idx == 0
+    assert payload.zone_flags == 0
+    assert payload.min_temp == 5.0
+    assert payload.max_temp == 35.12
+    assert reencoded == raw_hex
+    assert as_dict == {
+        "zone_idx": 0,
+        "zone_flags": 0,
+        "min_temp": 5.0,
+        "max_temp": 35.12,
+    }
 
 
 def test_fan_mode_payload_22f1_parity() -> None:


### PR DESCRIPTION
### ⚠️ STACKED PR: Depends on ramses-rf/ramses_rf#1003 (and ramses-rf/ramses_rf#1002)

This PR implements **PR 3 (Heating & Schedule Payloads)** of the Phase 6 Unified Dataclass Payload Layer proposal, as outlined in ramses-rf/ramses_rf#1001, ramses-rf/ramses_rf#639, and ramses-rf/ramses_rf#837.

### The Problem:
CH / Evohome heating payloads and schedule switchpoints rely on string-based Regex decoding and untyped dictionary representations.

### The Fix:
- Implement strongly-typed payload dataclasses in `src/ramses_rf/payloads/heating.py`:
  - `ScheduleSwitchpointPayload` (`0404`): 20-byte schedule switchpoints using `struct.pack`/`unpack` (`_STRUCT_FMT: ClassVar[str] = "<xxxxBxxxBxxxHxxHH"`).
  - `DhwTemperaturePayload` (`10A0`): DHW temperature reading payload.
  - `SystemSyncPayload` (`1030`): 1-byte system synchronization heartbeat payload.
  - `BindingPayload` (`1FC9`): Binding offer/confirmation metadata payload.
  - `ZoneConfigPayload` (`000A`): 6-byte zone configuration payload (`_STRUCT_FMT: ClassVar[str] = ">BBhh"`).
- Include IETF/Wireshark Byte-Offset Field Map (BOFM) tables inside class-level docstrings so layouts render in IDE tooltips (`help(Class)`).
- Export all PR 3 payload classes in `src/ramses_rf/payloads/__init__.py`.
- Expand parity unit test suite in `tests/tests_rf/test_payload_parity.py`.

### Testing Performed:
- `pytest`: 16/16 tests passed (`.venv/bin/pytest tests/tests_rf/test_payload_base.py tests/tests_rf/test_payload_parity.py`).
- `mypy`: 100% strict type safety (`.venv/bin/mypy --strict src/ramses_rf/payloads`).
- `ruff`: 100% docstring and formatting compliance (`.venv/bin/ruff check --select D src/ramses_rf/payloads`).
- `pre-commit`: All 17 checks passed (`.venv/bin/prek run -a`).

### AI Assistance Disclosure:
This contribution was developed with the assistance of Google Gemini 3.6 Flash for code generation and documentation. All logic and implementations were reviewed and verified by the author.