### PR TITLE
feat(payloads): implement HVAC and OpenTherm payload dataclasses (PR 4/6)

### DIFF
--- a/src/ramses_rf/payloads/__init__.py
+++ b/src/ramses_rf/payloads/__init__.py
@@ -15,7 +15,13 @@ from .heating import (
     TemperaturePayload,
     ZoneConfigPayload,
 )
-from .hvac import FanModePayload
+from .hvac import (
+    Co2Payload,
+    FanModePayload,
+    HvacFanParamPayload,
+    RelativeHumidityPayload,
+)
+from .opentherm import OpenThermMsgPayload
 from .registry import (
     PAYLOAD_REGISTRY,
     PayloadRegistry,
@@ -26,11 +32,15 @@ from .registry import (
 __all__ = [
     "PAYLOAD_REGISTRY",
     "BindingPayload",
+    "Co2Payload",
     "DhwTemperaturePayload",
     "FanModePayload",
     "HeatDemandPayload",
+    "HvacFanParamPayload",
+    "OpenThermMsgPayload",
     "PayloadBase",
     "PayloadRegistry",
+    "RelativeHumidityPayload",
     "ScheduleSwitchpointPayload",
     "SystemSyncPayload",
     "TemperaturePayload",

--- a/src/ramses_rf/payloads/hvac.py
+++ b/src/ramses_rf/payloads/hvac.py
@@ -4,8 +4,9 @@ This module contains strongly-typed dataclass representations for HVAC / ventila
 packet payloads.
 """
 
+import struct
 from dataclasses import dataclass
-from typing import Self
+from typing import ClassVar, Self
 
 from .base import PayloadBase
 from .registry import register_payload
@@ -64,3 +65,186 @@ class FanModePayload(PayloadBase):
         if self.mode_max is not None:
             return bytes([self.header, self.mode_idx, self.mode_max])
         return bytes([self.header, self.mode_idx])
+
+
+@register_payload("2411")
+@dataclass(frozen=True, slots=True)
+class HvacFanParamPayload(PayloadBase):
+    """Command 2411 HVAC fan parameter payload.
+
+    Command 2411 payload binary layout (Big-Endian):
+      Offset  Format  Len  Description                    Sample Hex
+      --------------------------------------------------------------
+      +0      >B      1B   Leading zero byte            : 00
+      +1       H      2B   Parameter ID                 : 00 0A
+      +3       B      1B   Padding byte                 : 00
+      +4       B      1B   Data type ID                 : 10
+      +5       i      4B   Current value (int32)        : 00 00 00 05
+      +9       i      4B   Minimum value (int32)        : 00 00 00 00
+      +13      i      4B   Maximum value (int32)        : 00 00 00 64
+      +17      i      4B   Precision scalar (int32)     : 00 00 00 01
+      +21     2s      2B   Trailer bytes                : 00 01
+      --------------------------------------------------------------
+      Field-spaced hex : 00 000A 00 10 00000005 00000000 00000064 00000001 0001
+      Payload hex      : 00000A0010000000050000000000000064000000010001
+
+    :param param_id: Parameter ID uint16.
+    :type param_id: int
+    :param data_type: Data type ID byte.
+    :type data_type: int
+    :param value_scaled: Current scaled int32 value.
+    :type value_scaled: int
+    :param min_val_scaled: Minimum scaled int32 value.
+    :type min_val_scaled: int
+    :param max_val_scaled: Maximum scaled int32 value.
+    :type max_val_scaled: int
+    :param precision_scaled: Precision scalar int32 value.
+    :type precision_scaled: int
+    :param trailer_bytes: 2-byte trailer raw bytes.
+    :type trailer_bytes: bytes
+    """
+
+    _STRUCT_FMT: ClassVar[str] = ">BHBBiiii2s"
+
+    param_id: int
+    data_type: int
+    value_scaled: int
+    min_val_scaled: int
+    max_val_scaled: int
+    precision_scaled: int
+    trailer_bytes: bytes
+
+    @classmethod
+    def from_bytes(cls, raw_data: bytes) -> Self:
+        """Unpack HVAC fan parameter binary payload.
+
+        :param raw_data: Raw binary byte string.
+        :type raw_data: bytes
+        :returns: Unpacked HvacFanParamPayload instance.
+        :rtype: Self
+        """
+        (
+            _,
+            param_id,
+            _,
+            data_type,
+            val,
+            min_val,
+            max_val,
+            precision,
+            trailer,
+        ) = struct.unpack(cls._STRUCT_FMT, raw_data)
+        return cls(
+            param_id=param_id,
+            data_type=data_type,
+            value_scaled=val,
+            min_val_scaled=min_val,
+            max_val_scaled=max_val,
+            precision_scaled=precision,
+            trailer_bytes=trailer,
+        )
+
+    def to_bytes(self) -> bytes:
+        """Pack HVAC fan parameter data into binary payload.
+
+        :returns: Packed binary payload bytes.
+        :rtype: bytes
+        """
+        return struct.pack(
+            self._STRUCT_FMT,
+            0x00,
+            self.param_id,
+            0x00,
+            self.data_type,
+            self.value_scaled,
+            self.min_val_scaled,
+            self.max_val_scaled,
+            self.precision_scaled,
+            self.trailer_bytes,
+        )
+
+
+@register_payload("1298")
+@dataclass(frozen=True, slots=True)
+class Co2Payload(PayloadBase):
+    """CO2 sensor reading payload (Opcode 1298).
+
+    2-byte CO2 binary layout (Big-Endian):
+      Offset  Format  Len  Description                    Sample Hex
+      --------------------------------------------------------------
+      +0       H      2B   CO2 level in PPM (uint16)    : 02 D0 (720 PPM)
+      --------------------------------------------------------------
+      Field-spaced hex : 02D0
+      Payload hex      : 02D0
+
+    :param co2_ppm: CO2 concentration level in PPM (parts per million).
+    :type co2_ppm: int
+    """
+
+    co2_ppm: int
+
+    @classmethod
+    def from_bytes(cls, raw_data: bytes) -> Self:
+        """Unpack 2-byte CO2 sensor reading payload.
+
+        :param raw_data: Raw binary byte string.
+        :type raw_data: bytes
+        :returns: Unpacked Co2Payload instance.
+        :rtype: Self
+        :raises ValueError: If raw_data length is less than 2 bytes.
+        """
+        if len(raw_data) < 2:
+            raise ValueError("Invalid payload length for 1298: expected 2 bytes")
+        return cls(co2_ppm=int.from_bytes(raw_data[:2], byteorder="big", signed=False))
+
+    def to_bytes(self) -> bytes:
+        """Pack CO2 sensor reading data into 2-byte binary payload.
+
+        :returns: Packed binary payload bytes.
+        :rtype: bytes
+        """
+        return self.co2_ppm.to_bytes(2, byteorder="big", signed=False)
+
+
+@register_payload("12A0")
+@dataclass(frozen=True, slots=True)
+class RelativeHumidityPayload(PayloadBase):
+    """Relative humidity payload (Opcode 12A0).
+
+    1-2 byte Relative Humidity binary layout:
+      Offset  Format  Len  Description                    Sample Hex
+      --------------------------------------------------------------
+      +0       B      1B   Humidity percentage (uint8)  : 64 (50.0%)
+      --------------------------------------------------------------
+      Field-spaced hex : 64
+      Payload hex      : 64
+
+    :param humidity_percent: Relative humidity value (0.0 - 100.0%).
+    :type humidity_percent: float
+    """
+
+    humidity_percent: float
+
+    @classmethod
+    def from_bytes(cls, raw_data: bytes) -> Self:
+        """Unpack relative humidity binary payload.
+
+        :param raw_data: Raw binary byte string.
+        :type raw_data: bytes
+        :returns: Unpacked RelativeHumidityPayload instance.
+        :rtype: Self
+        :raises ValueError: If raw_data is empty.
+        """
+        if not raw_data:
+            raise ValueError("Payload data cannot be empty")
+        raw_val = raw_data[0]
+        return cls(humidity_percent=raw_val / 2.0)
+
+    def to_bytes(self) -> bytes:
+        """Pack relative humidity data into binary payload.
+
+        :returns: Packed binary payload bytes.
+        :rtype: bytes
+        """
+        raw_val = int(round(self.humidity_percent * 2.0))
+        return bytes([raw_val])

--- a/src/ramses_rf/payloads/opentherm.py
+++ b/src/ramses_rf/payloads/opentherm.py
@@ -1,0 +1,64 @@
+"""RAMSES RF - OpenTherm bridge payload dataclasses.
+
+This module contains strongly-typed dataclass representations for OpenTherm bridge
+packet payloads.
+"""
+
+from dataclasses import dataclass
+from typing import Self
+
+from .base import PayloadBase
+from .registry import register_payload
+
+
+@register_payload("3220")
+@dataclass(frozen=True, slots=True)
+class OpenThermMsgPayload(PayloadBase):
+    """OpenTherm message payload (Opcode 3220).
+
+    2-4 byte OpenTherm frame binary layout (Big-Endian):
+      Offset  Format  Len  Description                    Sample Hex
+      --------------------------------------------------------------
+      +0       B      1B   Message ID / Data ID (uint8) : 19 (25 = Boiler temp)
+      +1       B      1B   Message Type / Flags         : 00
+      +2       2s     2B   Value bytes (uint16/float16) : 19 00 (25.0°C)
+      --------------------------------------------------------------
+      Field-spaced hex : 19 00 1900
+      Payload hex      : 19001900
+
+    :param msg_id: OpenTherm Message ID (Data ID 0-255).
+    :type msg_id: int
+    :param msg_type: OpenTherm Message Type flag byte.
+    :type msg_type: int
+    :param raw_value: Raw 2-byte OpenTherm value payload.
+    :type raw_value: bytes
+    """
+
+    msg_id: int
+    msg_type: int
+    raw_value: bytes
+
+    @classmethod
+    def from_bytes(cls, raw_data: bytes) -> Self:
+        """Unpack an OpenTherm message binary payload.
+
+        :param raw_data: Raw binary byte string.
+        :type raw_data: bytes
+        :returns: Unpacked OpenThermMsgPayload instance.
+        :rtype: Self
+        :raises ValueError: If raw_data is less than 2 bytes.
+        """
+        if len(raw_data) < 2:
+            raise ValueError(f"Invalid payload length for 3220: {len(raw_data)}")
+        msg_id = raw_data[0]
+        msg_type = raw_data[1]
+        raw_val = raw_data[2:] if len(raw_data) >= 3 else b""
+        return cls(msg_id=msg_id, msg_type=msg_type, raw_value=raw_val)
+
+    def to_bytes(self) -> bytes:
+        """Pack OpenTherm message data into a binary payload.
+
+        :returns: Packed binary payload bytes.
+        :rtype: bytes
+        """
+        return bytes([self.msg_id, self.msg_type]) + self.raw_value

--- a/tests/tests_rf/test_payload_parity.py
+++ b/tests/tests_rf/test_payload_parity.py
@@ -11,7 +11,13 @@ from ramses_rf.payloads.heating import (
     TemperaturePayload,
     ZoneConfigPayload,
 )
-from ramses_rf.payloads.hvac import FanModePayload
+from ramses_rf.payloads.hvac import (
+    Co2Payload,
+    FanModePayload,
+    HvacFanParamPayload,
+    RelativeHumidityPayload,
+)
+from ramses_rf.payloads.opentherm import OpenThermMsgPayload
 from ramses_tx.dtos import PacketDTO
 
 
@@ -78,8 +84,8 @@ def test_schedule_switchpoint_payload_0404_parity() -> None:
     # Assert
     assert payload.zone_idx == 1
     assert payload.day_of_week == 1
-    assert payload.time_of_day_mins == 360  # 0168 hex -> 360 mins = 06:00
-    assert payload.setpoint_value == 2000  # 07D0 hex -> 2000
+    assert payload.time_of_day_mins == 360
+    assert payload.setpoint_value == 2000
     assert reencoded == raw_hex
     assert as_dict == {
         "zone_idx": 1,
@@ -182,6 +188,86 @@ def test_fan_mode_payload_22f1_parity() -> None:
     assert payload.mode_max == 4
     assert reencoded == raw_hex
     assert as_dict == {"header": 0, "mode_idx": 2, "mode_max": 4}
+
+
+def test_hvac_fan_param_payload_2411_parity() -> None:
+    # Arrange
+    raw_hex = "00000A0010000000050000000000000064000000010001"
+    raw_bytes = bytes.fromhex(raw_hex)
+
+    # Act
+    payload = HvacFanParamPayload.from_bytes(raw_bytes)
+    reencoded = payload.to_bytes().hex().upper()
+    as_dict = payload_to_dict(payload)
+
+    # Assert
+    assert payload.param_id == 10
+    assert payload.data_type == 16
+    assert payload.value_scaled == 5
+    assert payload.min_val_scaled == 0
+    assert payload.max_val_scaled == 100
+    assert payload.precision_scaled == 1
+    assert payload.trailer_bytes == b"\x00\x01"
+    assert reencoded == raw_hex
+    assert as_dict == {
+        "param_id": 10,
+        "data_type": 16,
+        "value_scaled": 5,
+        "min_val_scaled": 0,
+        "max_val_scaled": 100,
+        "precision_scaled": 1,
+        "trailer_bytes": b"\x00\x01",
+    }
+
+
+def test_co2_payload_1298_parity() -> None:
+    # Arrange
+    raw_hex = "02D0"
+    raw_bytes = bytes.fromhex(raw_hex)
+
+    # Act
+    payload = Co2Payload.from_bytes(raw_bytes)
+    reencoded = payload.to_bytes().hex().upper()
+    as_dict = payload_to_dict(payload)
+
+    # Assert
+    assert payload.co2_ppm == 720
+    assert reencoded == raw_hex
+    assert as_dict == {"co2_ppm": 720}
+
+
+def test_relative_humidity_payload_12a0_parity() -> None:
+    # Arrange
+    raw_hex = "64"
+    raw_bytes = bytes.fromhex(raw_hex)
+
+    # Act
+    payload = RelativeHumidityPayload.from_bytes(raw_bytes)
+    reencoded = payload.to_bytes().hex().upper()
+    as_dict = payload_to_dict(payload)
+
+    # Assert
+    assert payload.humidity_percent == 50.0
+    assert reencoded == raw_hex
+    assert as_dict == {"humidity_percent": 50.0}
+
+
+def test_opentherm_msg_payload_3220_parity() -> None:
+    # Arrange
+    raw_hex = "19001900"
+    raw_bytes = bytes.fromhex(raw_hex)
+
+    # Act
+    payload = OpenThermMsgPayload.from_bytes(raw_bytes)
+    reencoded = payload.to_bytes().hex().upper()
+    as_dict = payload_to_dict(payload)
+
+    # Assert
+    assert payload.msg_id == 25
+    assert payload.msg_type == 0
+    assert payload.raw_value == b"\x19\x00"
+    assert reencoded == raw_hex
+    assert as_dict == {"msg_id": 25, "msg_type": 0, "raw_value": b"\x19\x00"}
 
 
 def test_pipeline_shadow_parity_execution() -> None:


### PR DESCRIPTION
### ⚠️ STACKED PR: Depends on ramses-rf/ramses_rf#1004 (and ramses-rf/ramses_rf#1003, ramses-rf/ramses_rf#1002)

This PR implements **PR 4 (HVAC & OpenTherm Payloads)** of the Phase 6 Unified Dataclass Payload Layer proposal, as outlined in ramses-rf/ramses_rf#1001, ramses-rf/ramses_rf#639, and ramses-rf/ramses_rf#837.

### The Problem:
HVAC fan parameters, CO2/humidity sensor frames, and OpenTherm bridge packets currently rely on legacy string-space decoders.

### The Fix:
- Implement strongly-typed payload dataclasses in `src/ramses_rf/payloads/hvac.py`:
  - `HvacFanParamPayload` (`2411`): 22-byte HVAC fan parameters payload using `struct.pack`/`unpack` (`_STRUCT_FMT: ClassVar[str] = ">BHBBiiii2s"`).
  - `Co2Payload` (`1298`): 2-byte CO2 sensor reading payload (`co2_ppm: int`).
  - `RelativeHumidityPayload` (`12A0`): 1-byte relative humidity payload (`humidity_percent: float`).
- Create `src/ramses_rf/payloads/opentherm.py`:
  - `OpenThermMsgPayload` (`3220`): 2-4 byte OpenTherm frame message payload.
- Include IETF/Wireshark Byte-Offset Field Map (BOFM) tables inside class-level docstrings so layouts render in IDE tooltips (`help(Class)`).
- Export all PR 4 payload classes in `src/ramses_rf/payloads/__init__.py`.
- Expand parity unit test suite in `tests/tests_rf/test_payload_parity.py`.

### Testing Performed:
- `pytest`: 20/20 tests passed (`.venv/bin/pytest tests/tests_rf/test_payload_base.py tests/tests_rf/test_payload_parity.py`).
- `mypy`: 100% strict type safety (`.venv/bin/mypy --strict src/ramses_rf/payloads`).
- `ruff`: 100% docstring and formatting compliance (`.venv/bin/ruff check --select D src/ramses_rf/payloads`).
- `pre-commit`: All 17 checks passed (`.venv/bin/prek run -a`).

### AI Assistance Disclosure:
This contribution was developed with the assistance of Google Gemini 3.6 Flash for code generation and documentation. All logic and implementations were reviewed and verified by the author.