### PR TITLE
feat(payloads): implement remaining heating and DHW payload dataclasses (PR 5/9)

### DIFF
--- a/src/ramses_rf/payloads/__init__.py
+++ b/src/ramses_rf/payloads/__init__.py
@@ -6,14 +6,19 @@ packet payloads.
 
 from .adapters import payload_to_dict
 from .base import PayloadBase
+from .dhw import DhwConfigPayload, DhwModePayload, DhwStatePayload
 from .heating import (
     BindingPayload,
+    BoilerRelayDemandPayload,
     DhwTemperaturePayload,
     HeatDemandPayload,
+    OutdoorTempPayload,
     ScheduleSwitchpointPayload,
+    SetPointInfoPayload,
     SystemSyncPayload,
     TemperaturePayload,
     ZoneConfigPayload,
+    ZoneSetpointPayload,
 )
 from .hvac import (
     Co2Payload,
@@ -32,19 +37,26 @@ from .registry import (
 __all__ = [
     "PAYLOAD_REGISTRY",
     "BindingPayload",
+    "BoilerRelayDemandPayload",
     "Co2Payload",
+    "DhwConfigPayload",
+    "DhwModePayload",
+    "DhwStatePayload",
     "DhwTemperaturePayload",
     "FanModePayload",
     "HeatDemandPayload",
     "HvacFanParamPayload",
     "OpenThermMsgPayload",
+    "OutdoorTempPayload",
     "PayloadBase",
     "PayloadRegistry",
     "RelativeHumidityPayload",
     "ScheduleSwitchpointPayload",
+    "SetPointInfoPayload",
     "SystemSyncPayload",
     "TemperaturePayload",
     "ZoneConfigPayload",
+    "ZoneSetpointPayload",
     "get_payload_class",
     "payload_to_dict",
     "register_payload",

--- a/src/ramses_rf/payloads/dhw.py
+++ b/src/ramses_rf/payloads/dhw.py
@@ -1,0 +1,158 @@
+"""RAMSES RF - Domestic Hot Water (DHW) payload dataclasses.
+
+This module contains strongly-typed dataclass representations for Domestic Hot Water
+packet payloads.
+"""
+
+from dataclasses import dataclass
+from typing import Self
+
+from .base import PayloadBase
+from .registry import register_payload
+
+
+@register_payload("1260")
+@dataclass(frozen=True, slots=True)
+class DhwModePayload(PayloadBase):
+    """DHW mode and override payload (Opcode 1260).
+
+    3-byte DHW Mode binary layout:
+      Offset  Format  Len  Description                    Sample Hex
+      --------------------------------------------------------------
+      +0       B      1B   DHW Index (uint8)            : 00
+      +1       B      1B   DHW Mode / Override Flag     : 01
+      +2       B      1B   DHW State / Enabled          : 01
+      --------------------------------------------------------------
+      Field-spaced hex : 00 01 01
+      Payload hex      : 000101
+
+    :param dhw_idx: DHW index byte.
+    :type dhw_idx: int
+    :param mode: Mode or override flag byte.
+    :type mode: int
+    :param state: DHW state byte (enabled/disabled).
+    :type state: int
+    """
+
+    dhw_idx: int
+    mode: int
+    state: int
+
+    @classmethod
+    def from_bytes(cls, raw_data: bytes) -> Self:
+        """Unpack DHW mode binary payload.
+
+        :param raw_data: Raw binary byte string.
+        :type raw_data: bytes
+        :returns: Unpacked DhwModePayload instance.
+        :rtype: Self
+        :raises ValueError: If raw_data length is less than 3 bytes.
+        """
+        if len(raw_data) < 3:
+            raise ValueError(f"Invalid payload length for 1260: {len(raw_data)}")
+        return cls(dhw_idx=raw_data[0], mode=raw_data[1], state=raw_data[2])
+
+    def to_bytes(self) -> bytes:
+        """Pack DHW mode data into binary payload.
+
+        :returns: Packed binary payload bytes.
+        :rtype: bytes
+        """
+        return bytes([self.dhw_idx, self.mode, self.state])
+
+
+@register_payload("12F0")
+@dataclass(frozen=True, slots=True)
+class DhwConfigPayload(PayloadBase):
+    """DHW configuration payload (Opcode 12F0).
+
+    3-byte DHW Config binary layout:
+      Offset  Format  Len  Description                    Sample Hex
+      --------------------------------------------------------------
+      +0       B      1B   DHW Index (uint8)            : 00
+      +1       h      2B   Target Setpoint (int16*100)  : 13 88 (50.00°C)
+      --------------------------------------------------------------
+      Field-spaced hex : 00 1388
+      Payload hex      : 001388
+
+    :param dhw_idx: DHW index byte.
+    :type dhw_idx: int
+    :param setpoint_temp: Target DHW setpoint temperature in °C.
+    :type setpoint_temp: float
+    """
+
+    dhw_idx: int
+    setpoint_temp: float
+
+    @classmethod
+    def from_bytes(cls, raw_data: bytes) -> Self:
+        """Unpack DHW config binary payload.
+
+        :param raw_data: Raw binary byte string.
+        :type raw_data: bytes
+        :returns: Unpacked DhwConfigPayload instance.
+        :rtype: Self
+        :raises ValueError: If raw_data length is less than 3 bytes.
+        """
+        if len(raw_data) < 3:
+            raise ValueError(f"Invalid payload length for 12F0: {len(raw_data)}")
+        idx = raw_data[0]
+        setpoint_raw = int.from_bytes(raw_data[1:3], byteorder="big", signed=True)
+        return cls(dhw_idx=idx, setpoint_temp=setpoint_raw / 100.0)
+
+    def to_bytes(self) -> bytes:
+        """Pack DHW config data into binary payload.
+
+        :returns: Packed binary payload bytes.
+        :rtype: bytes
+        """
+        setpoint_raw = int(round(self.setpoint_temp * 100.0))
+        return bytes([self.dhw_idx]) + setpoint_raw.to_bytes(
+            2, byteorder="big", signed=True
+        )
+
+
+@register_payload("1F41")
+@dataclass(frozen=True, slots=True)
+class DhwStatePayload(PayloadBase):
+    """DHW state payload (Opcode 1F41).
+
+    2-byte DHW State binary layout:
+      Offset  Format  Len  Description                    Sample Hex
+      --------------------------------------------------------------
+      +0       B      1B   DHW Index (uint8)            : 00
+      +1       B      1B   DHW Active Flag (0=Off, 1=On): 01
+      --------------------------------------------------------------
+      Field-spaced hex : 00 01
+      Payload hex      : 0001
+
+    :param dhw_idx: DHW index byte.
+    :type dhw_idx: int
+    :param active_flag: DHW active status flag byte.
+    :type active_flag: int
+    """
+
+    dhw_idx: int
+    active_flag: int
+
+    @classmethod
+    def from_bytes(cls, raw_data: bytes) -> Self:
+        """Unpack DHW state binary payload.
+
+        :param raw_data: Raw binary byte string.
+        :type raw_data: bytes
+        :returns: Unpacked DhwStatePayload instance.
+        :rtype: Self
+        :raises ValueError: If raw_data length is less than 2 bytes.
+        """
+        if len(raw_data) < 2:
+            raise ValueError(f"Invalid payload length for 1F41: {len(raw_data)}")
+        return cls(dhw_idx=raw_data[0], active_flag=raw_data[1])
+
+    def to_bytes(self) -> bytes:
+        """Pack DHW state data into binary payload.
+
+        :returns: Packed binary payload bytes.
+        :rtype: bytes
+        """
+        return bytes([self.dhw_idx, self.active_flag])

--- a/src/ramses_rf/payloads/heating.py
+++ b/src/ramses_rf/payloads/heating.py
@@ -417,3 +417,195 @@ class ZoneConfigPayload(PayloadBase):
             min_raw,
             max_raw,
         )
+
+
+@register_payload("0004")
+@dataclass(frozen=True, slots=True)
+class ZoneSetpointPayload(PayloadBase):
+    """Zone target setpoint payload (Opcode 0004).
+
+    3-byte Zone Setpoint binary layout:
+      Offset  Format  Len  Description                    Sample Hex
+      --------------------------------------------------------------
+      +0       B      1B   Zone Index (uint8)           : 01
+      +1       h      2B   Target Setpoint (int16*100)  : 07 D0 (20.00°C)
+      --------------------------------------------------------------
+      Field-spaced hex : 01 07D0
+      Payload hex      : 0107D0
+
+    :param zone_idx: Zone index byte.
+    :type zone_idx: int
+    :param setpoint_temp: Target temperature in °C.
+    :type setpoint_temp: float
+    """
+
+    zone_idx: int
+    setpoint_temp: float
+
+    @classmethod
+    def from_bytes(cls, raw_data: bytes) -> Self:
+        """Unpack zone setpoint binary payload.
+
+        :param raw_data: Raw binary byte string.
+        :type raw_data: bytes
+        :returns: Unpacked ZoneSetpointPayload instance.
+        :rtype: Self
+        :raises ValueError: If raw_data length is less than 3 bytes.
+        """
+        if len(raw_data) < 3:
+            raise ValueError(f"Invalid payload length for 0004: {len(raw_data)}")
+        idx = raw_data[0]
+        sp_raw = int.from_bytes(raw_data[1:3], byteorder="big", signed=True)
+        return cls(zone_idx=idx, setpoint_temp=sp_raw / 100.0)
+
+    def to_bytes(self) -> bytes:
+        """Pack zone setpoint data into binary payload.
+
+        :returns: Packed binary payload bytes.
+        :rtype: bytes
+        """
+        sp_raw = int(round(self.setpoint_temp * 100.0))
+        return bytes([self.zone_idx]) + sp_raw.to_bytes(2, byteorder="big", signed=True)
+
+
+@register_payload("12C0")
+@dataclass(frozen=True, slots=True)
+class OutdoorTempPayload(PayloadBase):
+    """Outdoor temperature reading payload (Opcode 12C0).
+
+    2-byte Outdoor Temp binary layout (Big-Endian):
+      Offset  Format  Len  Description                    Sample Hex
+      --------------------------------------------------------------
+      +0       h      2B   Outdoor Temperature (int16*100): 05 DC (15.00°C)
+      --------------------------------------------------------------
+      Field-spaced hex : 05DC
+      Payload hex      : 05DC
+
+    :param temperature: Outdoor temperature reading in °C.
+    :type temperature: float
+    """
+
+    temperature: float
+
+    @classmethod
+    def from_bytes(cls, raw_data: bytes) -> Self:
+        """Unpack outdoor temperature binary payload.
+
+        :param raw_data: Raw binary byte string.
+        :type raw_data: bytes
+        :returns: Unpacked OutdoorTempPayload instance.
+        :rtype: Self
+        :raises ValueError: If raw_data length is less than 2 bytes.
+        """
+        if len(raw_data) < 2:
+            raise ValueError(f"Invalid payload length for 12C0: {len(raw_data)}")
+        temp_raw = int.from_bytes(raw_data[:2], byteorder="big", signed=True)
+        return cls(temperature=temp_raw / 100.0)
+
+    def to_bytes(self) -> bytes:
+        """Pack outdoor temperature data into binary payload.
+
+        :returns: Packed binary payload bytes.
+        :rtype: bytes
+        """
+        temp_raw = int(round(self.temperature * 100.0))
+        return temp_raw.to_bytes(2, byteorder="big", signed=True)
+
+
+@register_payload("2309")
+@dataclass(frozen=True, slots=True)
+class SetPointInfoPayload(PayloadBase):
+    """Set-point info payload (Opcode 2309).
+
+    3-byte Set-point Info binary layout:
+      Offset  Format  Len  Description                    Sample Hex
+      --------------------------------------------------------------
+      +0       B      1B   Zone Index (uint8)           : 00
+      +1       h      2B   Setpoint Temp (int16*100)    : 08 34 (21.00°C)
+      --------------------------------------------------------------
+      Field-spaced hex : 00 0834
+      Payload hex      : 000834
+
+    :param zone_idx: Zone index byte.
+    :type zone_idx: int
+    :param setpoint_temp: Setpoint temperature in °C.
+    :type setpoint_temp: float
+    """
+
+    zone_idx: int
+    setpoint_temp: float
+
+    @classmethod
+    def from_bytes(cls, raw_data: bytes) -> Self:
+        """Unpack setpoint info binary payload.
+
+        :param raw_data: Raw binary byte string.
+        :type raw_data: bytes
+        :returns: Unpacked SetPointInfoPayload instance.
+        :rtype: Self
+        :raises ValueError: If raw_data length is less than 3 bytes.
+        """
+        if len(raw_data) < 3:
+            raise ValueError(f"Invalid payload length for 2309: {len(raw_data)}")
+        idx = raw_data[0]
+        sp_raw = int.from_bytes(raw_data[1:3], byteorder="big", signed=True)
+        return cls(zone_idx=idx, setpoint_temp=sp_raw / 100.0)
+
+    def to_bytes(self) -> bytes:
+        """Pack setpoint info data into binary payload.
+
+        :returns: Packed binary payload bytes.
+        :rtype: bytes
+        """
+        sp_raw = int(round(self.setpoint_temp * 100.0))
+        return bytes([self.zone_idx]) + sp_raw.to_bytes(2, byteorder="big", signed=True)
+
+
+@register_payload("3200")
+@dataclass(frozen=True, slots=True)
+class BoilerRelayDemandPayload(PayloadBase):
+    """Boiler relay heat demand payload (Opcode 3200).
+
+    3-byte Boiler Relay Demand binary layout:
+      Offset  Format  Len  Description                    Sample Hex
+      --------------------------------------------------------------
+      +0       B      1B   Relay Domain / Index (uint8) : 00
+      +1       B      1B   Heat Demand Percentage       : C8 (200)
+      +2       B      1B   Relay Flags                  : 00
+      --------------------------------------------------------------
+      Field-spaced hex : 00 C8 00
+      Payload hex      : 00C800
+
+    :param domain: Relay domain byte.
+    :type domain: int
+    :param demand_percent: Demand percentage value (0-200).
+    :type demand_percent: int
+    :param flags: Relay flags byte.
+    :type flags: int
+    """
+
+    domain: int
+    demand_percent: int
+    flags: int
+
+    @classmethod
+    def from_bytes(cls, raw_data: bytes) -> Self:
+        """Unpack boiler relay demand binary payload.
+
+        :param raw_data: Raw binary byte string.
+        :type raw_data: bytes
+        :returns: Unpacked BoilerRelayDemandPayload instance.
+        :rtype: Self
+        :raises ValueError: If raw_data length is less than 3 bytes.
+        """
+        if len(raw_data) < 3:
+            raise ValueError(f"Invalid payload length for 3200: {len(raw_data)}")
+        return cls(domain=raw_data[0], demand_percent=raw_data[1], flags=raw_data[2])
+
+    def to_bytes(self) -> bytes:
+        """Pack boiler relay demand data into binary payload.
+
+        :returns: Packed binary payload bytes.
+        :rtype: bytes
+        """
+        return bytes([self.domain, self.demand_percent, self.flags])

--- a/tests/tests_rf/test_payload_parity.py
+++ b/tests/tests_rf/test_payload_parity.py
@@ -2,14 +2,19 @@ from datetime import datetime as dt
 
 from ramses_rf.parsers.decoder import decode_packet
 from ramses_rf.payloads.adapters import payload_to_dict
+from ramses_rf.payloads.dhw import DhwConfigPayload, DhwModePayload, DhwStatePayload
 from ramses_rf.payloads.heating import (
     BindingPayload,
+    BoilerRelayDemandPayload,
     DhwTemperaturePayload,
     HeatDemandPayload,
+    OutdoorTempPayload,
     ScheduleSwitchpointPayload,
+    SetPointInfoPayload,
     SystemSyncPayload,
     TemperaturePayload,
     ZoneConfigPayload,
+    ZoneSetpointPayload,
 )
 from ramses_rf.payloads.hvac import (
     Co2Payload,
@@ -268,6 +273,126 @@ def test_opentherm_msg_payload_3220_parity() -> None:
     assert payload.raw_value == b"\x19\x00"
     assert reencoded == raw_hex
     assert as_dict == {"msg_id": 25, "msg_type": 0, "raw_value": b"\x19\x00"}
+
+
+def test_dhw_mode_payload_1260_parity() -> None:
+    # Arrange
+    raw_hex = "000101"
+    raw_bytes = bytes.fromhex(raw_hex)
+
+    # Act
+    payload = DhwModePayload.from_bytes(raw_bytes)
+    reencoded = payload.to_bytes().hex().upper()
+    as_dict = payload_to_dict(payload)
+
+    # Assert
+    assert payload.dhw_idx == 0
+    assert payload.mode == 1
+    assert payload.state == 1
+    assert reencoded == raw_hex
+    assert as_dict == {"dhw_idx": 0, "mode": 1, "state": 1}
+
+
+def test_dhw_config_payload_12f0_parity() -> None:
+    # Arrange
+    raw_hex = "001388"
+    raw_bytes = bytes.fromhex(raw_hex)
+
+    # Act
+    payload = DhwConfigPayload.from_bytes(raw_bytes)
+    reencoded = payload.to_bytes().hex().upper()
+    as_dict = payload_to_dict(payload)
+
+    # Assert
+    assert payload.dhw_idx == 0
+    assert payload.setpoint_temp == 50.0
+    assert reencoded == raw_hex
+    assert as_dict == {"dhw_idx": 0, "setpoint_temp": 50.0}
+
+
+def test_dhw_state_payload_1f41_parity() -> None:
+    # Arrange
+    raw_hex = "0001"
+    raw_bytes = bytes.fromhex(raw_hex)
+
+    # Act
+    payload = DhwStatePayload.from_bytes(raw_bytes)
+    reencoded = payload.to_bytes().hex().upper()
+    as_dict = payload_to_dict(payload)
+
+    # Assert
+    assert payload.dhw_idx == 0
+    assert payload.active_flag == 1
+    assert reencoded == raw_hex
+    assert as_dict == {"dhw_idx": 0, "active_flag": 1}
+
+
+def test_zone_setpoint_payload_0004_parity() -> None:
+    # Arrange
+    raw_hex = "0107D0"
+    raw_bytes = bytes.fromhex(raw_hex)
+
+    # Act
+    payload = ZoneSetpointPayload.from_bytes(raw_bytes)
+    reencoded = payload.to_bytes().hex().upper()
+    as_dict = payload_to_dict(payload)
+
+    # Assert
+    assert payload.zone_idx == 1
+    assert payload.setpoint_temp == 20.0
+    assert reencoded == raw_hex
+    assert as_dict == {"zone_idx": 1, "setpoint_temp": 20.0}
+
+
+def test_outdoor_temp_payload_12c0_parity() -> None:
+    # Arrange
+    raw_hex = "05DC"
+    raw_bytes = bytes.fromhex(raw_hex)
+
+    # Act
+    payload = OutdoorTempPayload.from_bytes(raw_bytes)
+    reencoded = payload.to_bytes().hex().upper()
+    as_dict = payload_to_dict(payload)
+
+    # Assert
+    assert payload.temperature == 15.0
+    assert reencoded == raw_hex
+    assert as_dict == {"temperature": 15.0}
+
+
+def test_setpoint_info_payload_2309_parity() -> None:
+    # Arrange
+    raw_hex = "000834"
+    raw_bytes = bytes.fromhex(raw_hex)
+
+    # Act
+    payload = SetPointInfoPayload.from_bytes(raw_bytes)
+    reencoded = payload.to_bytes().hex().upper()
+    as_dict = payload_to_dict(payload)
+
+    # Assert
+    assert payload.zone_idx == 0
+    assert payload.setpoint_temp == 21.0
+    assert reencoded == raw_hex
+    assert as_dict == {"zone_idx": 0, "setpoint_temp": 21.0}
+
+
+def test_boiler_relay_demand_payload_3200_parity() -> None:
+    # Arrange
+    raw_hex = "00C800"
+    raw_bytes = bytes.fromhex(raw_hex)
+
+    # Act
+    payload = BoilerRelayDemandPayload.from_bytes(raw_bytes)
+    reencoded = payload.to_bytes().hex().upper()
+    as_dict = payload_to_dict(payload)
+
+    # Assert
+    assert payload.domain == 0
+    assert payload.demand_percent == 200
+    assert payload.flags == 0
+    assert reencoded == raw_hex
+    assert as_dict == {"domain": 0, "demand_percent": 200, "flags": 0}
 
 
 def test_pipeline_shadow_parity_execution() -> None:


### PR DESCRIPTION
### ⚠️ STACKED PR: Depends on ramses-rf/ramses_rf#1005 (and ramses-rf/ramses_rf#1004, ramses-rf/ramses_rf#1003, ramses-rf/ramses_rf#1002)

This PR implements **PR 5 (Remaining Heating & DHW Payloads)** of the Phase 6 Unified Dataclass Payload Layer proposal, as outlined in ramses-rf/ramses_rf#1001, ramses-rf/ramses_rf#639, and ramses-rf/ramses_rf#837.

### The Problem:
CH / DHW modes, overrides, and setpoints currently rely on legacy string-space decoders.

### The Fix:
- Create `src/ramses_rf/payloads/dhw.py`:
  - `DhwModePayload` (`1260`): 3-byte DHW mode & override payload.
  - `DhwConfigPayload` (`12F0`): 3-byte DHW target setpoint configuration payload.
  - `DhwStatePayload` (`1F41`): 2-byte DHW active state payload.
- Expand `src/ramses_rf/payloads/heating.py`:
  - `ZoneSetpointPayload` (`0004`): 3-byte zone target setpoint payload.
  - `OutdoorTempPayload` (`12C0`): 2-byte outdoor temperature payload.
  - `SetPointInfoPayload` (`2309`): 3-byte setpoint info payload.
  - `BoilerRelayDemandPayload` (`3200`): 3-byte boiler relay demand payload.
- Include IETF/Wireshark Byte-Offset Field Map (BOFM) tables inside class-level docstrings so layouts render in IDE tooltips (`help(Class)`).
- Export all PR 5 payload classes in `src/ramses_rf/payloads/__init__.py`.
- Expand parity unit test suite in `tests/tests_rf/test_payload_parity.py`.

### Testing Performed:
- `pytest`: 27/27 tests passed (`.venv/bin/pytest tests/tests_rf/test_payload_base.py tests/tests_rf/test_payload_parity.py`).
- `mypy`: 100% strict type safety (`.venv/bin/mypy --strict src/ramses_rf/payloads`).
- `ruff`: 100% docstring and formatting compliance (`.venv/bin/ruff check --select D src/ramses_rf/payloads`).
- `pre-commit`: All 17 checks passed (`.venv/bin/prek run -a`).

### AI Assistance Disclosure:
This contribution was developed with the assistance of Google Gemini 3.6 Flash for code generation and documentation. All logic and implementations were reviewed and verified by the author.