### PR TITLE
fix(schema): correct `22D0` W regex, HGI known_list filter, and `3EF0` I from THM

### DIFF
--- a/src/ramses_rf/devices/dev_filter.py
+++ b/src/ramses_rf/devices/dev_filter.py
@@ -48,7 +48,7 @@ class DeviceFilter:
         :rtype: None
         :raises DeviceNotFoundError: If the device is unwanted, strictly not known, or excluded.
         """
-        if dev_id in self._unwanted:
+        if dev_id in self._unwanted and dev_id != self._hgi_id_provider():
             raise DeviceNotFoundError(
                 f"Can't create {dev_id}: it is unwanted or invalid"
             )

--- a/src/ramses_rf/gateway.py
+++ b/src/ramses_rf/gateway.py
@@ -153,7 +153,9 @@ class Gateway(GatewayLifecycle, GatewayInterface):
             exclude=[DeviceIdT(k) for k in self._gwy_config.block_list],
             unwanted=self._engine._unwanted,
             enforce_known_list=self._gwy_config.engine.enforce_known_list,
-            hgi_id_provider=lambda: getattr(self.hgi, "id", None),
+            hgi_id_provider=lambda: (
+                getattr(self.hgi, "id", None) or self._gwy_config.hgi_id
+            ),
         )
 
         self._device_registry: DeviceRegistryInterface = DeviceRegistry(

--- a/src/ramses_rf/protocol/ramses.py
+++ b/src/ramses_rf/protocol/ramses.py
@@ -402,7 +402,7 @@ CODES_SCHEMA: dict[Code, CodeSchemaEntry] = {  # rf_unknown
     Code._22D0: {  # unknown_22d0, Spider thermostat, HVAC system switch?
         "name": "message_22d0",
         " I": r"^(00|03)[0-9]{6}$",
-        " W": r"^03[0-9]{4}1E14030020$",
+        " W": r"^[0-9A-F]{4}001E14030020$",
     },
     Code._22D9: {  # boiler_setpoint
         "name": "boiler_setpoint",
@@ -896,7 +896,7 @@ _DEV_KLASSES_HEAT: dict[str, dict[Code, dict[VerbT, Any]]] = {
         },  # .W --- 30:253184 34:010943 --:------ 313F 009 006000070E0...
         Code._3220: {RP: {}},  # RND (using OT)
         Code._3B00: {I_: {}},
-        Code._3EF0: {RQ: {}},  # when bound direct to a 13:
+        Code._3EF0: {I_: {}, RQ: {}},  # when bound direct to a 13:
         Code._3EF1: {RQ: {}},  # when bound direct to a 13:
     },
     DevType.UFC: {  # e.g. HCE80/HCC80: Underfloor Heating Controller

--- a/tests/tests/parsers/code_22d0.log
+++ b/tests/tests/parsers/code_22d0.log
@@ -8,3 +8,6 @@
 
 # evohome from cesar.florin HCC80 (UFC) controlled via round thermostat talking to a BDR91 relay
 2025-09-09T18:54:03.354496 061  I --- 02:033545 --:------ 02:033545 22D0 004 00000002          # {'zone_idx': '00', 'idx': '00', '_flags': [0, 0, 0, 0, 0, 0, 0, 0], 'cool_mode': False, 'heat_mode': False, 'is_active': False, '_unknown': '0002'}
+
+# issue 864: idx=00, flags=14 — the old W regex (^03[0-9]{4}...) rejected this
+2025-08-08T21:05:35.000000 064  W --- 21:057310 18:002965 --:------ 22D0 008 0014001E14030020  # {'idx': '00', '_flags': [0, 0, 0, 1, 0, 1, 0, 0], 'cool_mode': False, 'heat_mode': True, 'is_active': True, '_unknown': '001E14030020'}

--- a/tests/tests/test_ramses_schema.py
+++ b/tests/tests/test_ramses_schema.py
@@ -11,11 +11,12 @@ from ramses_rf.protocol.ramses import (
     CODE_IDX_ARE_COMPLEX,
     CODE_IDX_ARE_NONE,
     CODE_IDX_ARE_SIMPLE,
+    CODES_BY_DEV_SLUG,
     CODES_SCHEMA,
     HVAC_KLASS_BY_VC_PAIR,
     RQ_NO_PAYLOAD,
 )
-from ramses_tx.const import Code
+from ramses_tx.const import I_, Code
 
 
 def test_code_counts() -> None:
@@ -113,3 +114,18 @@ RQ_IDX_UNKNOWN = [
     for k, v in CODES_SCHEMA.items()
     if k not in RQ_NO_PAYLOAD + RQ_IDX_ONLY and RQ in v
 ]
+
+
+def test_thm_can_broadcast_3ef0_i() -> None:
+    """A THM bound direct to a BDR relay can broadcast 3EF0 with verb I.
+
+    Regression guard for issue 864: a thermostat (THM) sending a 3EF0
+    I_ broadcast (boiler relay state) was rejected with
+    PacketInvalid("Unexpected verb/code for src (THM) to Tx") because
+    CODES_BY_DEV_SLUG only listed RQ for THM/3EF0.
+
+    :returns: None
+    """
+    thm_codes = CODES_BY_DEV_SLUG[DevType.THM]
+    assert Code._3EF0 in thm_codes
+    assert I_ in thm_codes[Code._3EF0]

--- a/tests/tests_rf/device/test_registry.py
+++ b/tests/tests_rf/device/test_registry.py
@@ -162,6 +162,59 @@ def test_registry_enforces_filter_lists() -> None:
         registry.get_device(blocked_id)
 
 
+def test_filter_hgi_exempt_from_unwanted() -> None:
+    """The gateway's own ID must not be permanently blocked by _unwanted.
+
+    Regression guard for issue 864: when enforce_known_list is True and
+    the HGI device object has not yet been created, hgi_id_provider
+    returned None, causing the gateway's own ID to be rejected and
+    added to _unwanted.  The filter must exempt the HGI ID from the
+    _unwanted permanent block so it can be created later.
+
+    :returns: None
+    """
+    hgi_id = cast(DeviceIdT, "18:000730")
+
+    # Simulate the race: HGI ID is already in _unwanted (e.g. from an
+    # earlier rejection before the config.hgi_id was set), but the
+    # provider now returns the correct ID.
+    device_filter = DeviceFilter(
+        include=[hgi_id],
+        exclude=[],
+        unwanted=[hgi_id],
+        enforce_known_list=True,
+        hgi_id_provider=lambda: hgi_id,
+    )
+
+    # Must NOT raise — the HGI ID is exempted from the _unwanted check
+    device_filter.check_filter_lists(hgi_id)
+
+
+def test_filter_hgi_id_provider_fallback() -> None:
+    """hgi_id_provider should allow the HGI ID via config fallback.
+
+    When self.hgi is None (device not yet created), the provider
+    falls back to config.hgi_id.  The filter must accept the HGI ID
+    even when enforce_known_list is True and the ID is not in the
+    include list.
+
+    :returns: None
+    """
+    hgi_id = cast(DeviceIdT, "18:000730")
+
+    # HGI ID is not in include list, but provider returns it
+    device_filter = DeviceFilter(
+        include=[],
+        exclude=[],
+        unwanted=[],
+        enforce_known_list=True,
+        hgi_id_provider=lambda: hgi_id,
+    )
+
+    # Must NOT raise — the HGI ID is exempted via the provider
+    device_filter.check_filter_lists(hgi_id)
+
+
 @pytest.mark.asyncio
 async def test_fan_promotion_race_condition() -> None:
     """Test that early PROMOTE_CLASS events correctly apply via the SSOT.


### PR DESCRIPTION
## Summary

Fixes three regressions reported in https://github.com/ramses-rf/ramses_cc/issues/928:

1. **22D0 W_ payload schema mismatch** — the W_ regex `^03[0-9]{4}1E14030020$` hardcoded `idx=03` and was shifted 2 chars (missing the `00` prefix of the constant suffix). Valid payloads such as `0014001E14030020` (idx=00, flags=14) were rejected with `PacketPayloadInvalid`. Corrected to `^[0-9A-F]{4}001E14030020$` to match the parser's expected `[idx][flags]001E14030020` layout. Existing test payloads (`0314001E14030020`, `0304001E14030020`) continue to match.

2. **DeviceNotFoundError for the gateway's own ID (18:000730)** — when `enforce_known_list: true`, `hgi_id_provider` returned `None` before the HGI device object was created (e.g. before the transport detected the active HGI), so the filter rejected the gateway's own ID and permanently added it to `_unwanted`. Fixed by:
   - Falling back to `config.hgi_id` (available before the device object exists) in the provider lambda.
   - Exempting the gateway ID from the `_unwanted` permanent block in `DeviceFilter.check_filter_lists`.

3. **PacketInvalid for 3EF0 I_ from a THM source** — `CODES_BY_DEV_SLUG[THM][_3EF0]` only allowed `RQ`, but a thermostat bound directly to a BDR relay can broadcast its state with `I_`. Added `I_` to the allowed verbs.

#### Test plan
- [x] `ruff check` passes
- [x] `ruff format` passes
- [x] `mypy --strict` passes (3 modified files)
- [x] `pytest` — 1634 passed, 4 skipped, 0 failures
- [x] `prek run -a` — all hooks pass