### PR TITLE
fix: hydrate zone_state.name from schema _name (issue 919)

### DIFF
--- a/src/ramses_rf/config.py
+++ b/src/ramses_rf/config.py
@@ -171,6 +171,11 @@ _TRAIT_KEY_MAP: Final[dict[str, str]] = {
     "_is_battery": SZ_IS_BATTERY,
 }
 
+# _-prefixed keys that are preserved as-is (not stripped/mapped) because
+# ramses_rf schemas accept them directly (e.g. SCH_TCS_ZONES_ZON accepts
+# _name for zone name hydration — ramses-rf/ramses_cc#919).
+_TRAIT_PRESERVE_KEYS: Final[frozenset[str]] = frozenset({"_name"})
+
 
 def strip_and_map_traits(traits: dict[str, Any]) -> dict[str, Any]:
     """Strip ramses_cc-only ``_``-prefixed keys and map known ones to native traits.
@@ -206,7 +211,7 @@ def strip_and_map_traits(traits: dict[str, Any]) -> dict[str, Any]:
             else:
                 result[key] = value
             continue
-        # _-prefixed key: map or strip
+        # _-prefixed key: map, preserve, or strip
         native_key = _TRAIT_KEY_MAP.get(key)
         if native_key is not None and native_key not in result:
             # Recurse into mapped value if it's a dict
@@ -214,6 +219,12 @@ def strip_and_map_traits(traits: dict[str, Any]) -> dict[str, Any]:
                 result[native_key] = strip_and_map_traits(value)
             else:
                 result[native_key] = value
+        elif key in _TRAIT_PRESERVE_KEYS:
+            # Preserve as-is (ramses_rf schemas accept these _-prefixed keys)
+            if isinstance(value, dict):
+                result[key] = strip_and_map_traits(value)
+            else:
+                result[key] = value
         # else: strip (drop the key)
     return result
 

--- a/src/ramses_rf/devices/heat_controllers.py
+++ b/src/ramses_rf/devices/heat_controllers.py
@@ -59,6 +59,14 @@ class Controller(DeviceHeat):  # CTL (01):
             # DO NOT MOVE to module level.
             from ramses_rf.systems import Evohome, system_factory
 
+            # TODO: This code path is probably obsolete — load_tcs() calls
+            # ctl.tcs._update_schema(**schema) directly, bypassing this
+            # method.  The only callers (_handle_create_controller,
+            # JIT creation in dev_registry) invoke _make_tcs_controller()
+            # without schema kwargs.  Needs a check to confirm whether any
+            # code path passes zone schema through here.  If not, this
+            # method can be simplified to just the create/update logic
+            # without the schema processing.
             schema = shrink(SCH_TCS(schema))
 
             if not self.tcs:

--- a/src/ramses_rf/systems/tcs.py
+++ b/src/ramses_rf/systems/tcs.py
@@ -306,7 +306,9 @@ class MultiZone(SystemBase):  # 0005 (+/- 000C?)
         :returns: The created or retrieved heating zone.
         :rtype: Zone
         """
-        schema = shrink(SCH_TCS_ZONES_ZON(schema))
+        # Use keep_hints=True so _name survives shrink() and reaches
+        # Zone._update_schema for hydration (ramses-rf/ramses_cc#919).
+        schema = shrink(SCH_TCS_ZONES_ZON(schema), keep_hints=True)
 
         zon: Zone = self.zone_by_idx.get(zone_idx)  # type: ignore[assignment]
         if zon is None:  # not found in tcs, create it
@@ -803,7 +805,12 @@ class System(StoredHw, Datetime, Logbook, SystemBase):
         """
 
         _schema: dict[str, Any]
-        schema = shrink(SCH_TCS(schema))
+        # Use keep_hints=True so that _name in zone entries survives
+        # shrink() and reaches Zone._update_schema for hydration
+        # (ramses-rf/ramses_cc#919: zone names lost after 24h).
+        # SCH_TCS validation ensures only allowed _ keys (i.e. _name)
+        # are present, so keep_hints is safe here.
+        schema = shrink(SCH_TCS(schema), keep_hints=True)
 
         if schema.get(SZ_SYSTEM) and (
             dev_id := schema[SZ_SYSTEM].get(SZ_APPLIANCE_CONTROL)

--- a/src/ramses_rf/systems/zones.py
+++ b/src/ramses_rf/systems/zones.py
@@ -506,7 +506,25 @@ class Zone(ZoneSchedule):
 
         # if schema.get(SZ_CLASS) == ZON_ROLE_MAP[ZON_ROLE.ACT]:
         #     schema.pop(SZ_CLASS)
-        schema = shrink(SCH_TCS_ZONES_ZON(schema))
+        validated = SCH_TCS_ZONES_ZON(schema)
+
+        # Hydrate zone_state.name from the schema's _name before shrink()
+        # strips it (ramses-rf/ramses_cc#919: zone names lost after 24h
+        # when the MessageStore prunes 0004 packets — the schema is the
+        # only persistent source of the name).
+        schema_name = validated.get(f"_{SZ_NAME}")
+        _LOGGER.debug(
+            "Zone %s _update_schema: _name=%r, zone_state.name=%r",
+            self.id,
+            schema_name,
+            self.zone_state.name,
+        )
+        if schema_name and self.zone_state.name is None:
+            self.zone_state = dataclasses.replace(
+                self.zone_state, name=str(schema_name)
+            )
+
+        schema = shrink(validated)
 
         if klass := schema.get(SZ_CLASS):
             set_zone_type(ZON_ROLE_MAP[klass])

--- a/tests/tests_rf/test_config.py
+++ b/tests/tests_rf/test_config.py
@@ -35,11 +35,17 @@ class TestStripAndMapTraits:
         assert result["class"] == "FAN"
 
     def test_strip_disabled_name_owner(self) -> None:
-        """_disabled, _name, _owner are stripped (ramses_cc-only)."""
+        """_disabled, _owner are stripped (ramses_cc-only).
+
+        _name is preserved (not stripped) because ramses_rf's
+        SCH_TCS_ZONES_ZON accepts it for zone name hydration
+        (ramses-rf/ramses_cc#919: zone names lost after 24h).
+        """
         traits = {"_disabled": True, "_name": "My REM", "_owner": "me", "alias": "test"}
         result = strip_and_map_traits(traits)
         assert "_disabled" not in result
-        assert "_name" not in result
+        assert "_name" in result  # preserved for zone name hydration (issue 919)
+        assert result["_name"] == "My REM"
         assert "_owner" not in result
         assert result["alias"] == "test"
 
@@ -107,14 +113,19 @@ class TestStripAndMapTraits:
         assert result["alias"] == "My Fan"
 
     def test_recursive_nested_dict_strips_underscore(self) -> None:
-        """_name inside a nested dict (e.g. a zone) is stripped."""
+        """_name inside a nested dict (e.g. a zone) is preserved.
+
+        _name is preserved (not stripped) because ramses_rf's
+        SCH_TCS_ZONES_ZON accepts it for zone name hydration
+        (ramses-rf/ramses_cc#919: zone names lost after 24h).
+        """
         traits = {
             "class": "TCS",
             "zones": {"01": {"_name": "Living Room", "setpoint": 20.0}},
         }
         result = strip_and_map_traits(traits)
-        assert result["zones"]["01"] == {"setpoint": 20.0}
-        assert "_name" not in result["zones"]["01"]
+        assert result["zones"]["01"]["setpoint"] == 20.0
+        assert result["zones"]["01"]["_name"] == "Living Room"  # preserved (issue 919)
 
     def test_recursive_nested_dict_maps_underscore(self) -> None:
         """_bound inside a nested dict is mapped to bound."""
@@ -127,7 +138,10 @@ class TestStripAndMapTraits:
         assert "_bound" not in result["zones"]["01"]
 
     def test_recursive_deeply_nested(self) -> None:
-        """Recursion works at arbitrary depth."""
+        """Recursion works at arbitrary depth.
+
+        _name is preserved (issue 919), _disabled is stripped.
+        """
         traits = {
             "class": "TCS",
             "zones": {
@@ -135,7 +149,7 @@ class TestStripAndMapTraits:
             },
         }
         result = strip_and_map_traits(traits)
-        assert "_name" not in result["zones"]["01"]
+        assert result["zones"]["01"]["_name"] == "Zone 1"  # preserved (issue 919)
         assert "_disabled" not in result["zones"]["01"]["sub"]
         assert result["zones"]["01"]["sub"] == {"ok": 1}
 


### PR DESCRIPTION
## Summary

Zone names were lost after ~12h because the MessageStore prunes 0004 packets older than 24h, and `Zone.name()` was the only property doing retroactive MessageStore hydration — with no fallback to the schema.

The schema's `_name` trait (persisted to `.storage/ramses_cc`) is the correct SSOT for zone names. This fix ensures `_name` survives the schema processing pipeline:

1. **`strip_and_map_traits` (config.py)**: preserve `_name` via `_TRAIT_PRESERVE_KEYS` instead of stripping it
2. **`TCS._update_schema` (tcs.py)**: use `shrink(keep_hints=True)` so `_name` in zone entries survives to `get_htg_zone`
3. **`get_htg_zone` (tcs.py)**: use `shrink(keep_hints=True)` so `_name` survives to `Zone._update_schema`
4. **`Zone._update_schema` (zones.py)**: hydrate `zone_state.name` from the validated `_name` before `shrink` strips it

`SCH_TCS` validation ensures only allowed `_` keys (i.e. `_name`) survive, so `keep_hints=True` is safe — no other `_` keys leak through.

Also adds TODO comment on `Controller._make_tcs_controller` noting it appears to be dead code (`load_tcs` bypasses it, all callers invoke without schema kwargs).

### Findings on the 24h prune

- `Zone.name()` is the **only** property in ramses_rf that does retroactive MessageStore hydration (`message_store.get(code=Code._0004, src=self._z_id)`)
- The MessageStore prunes messages older than 24h (`td(days=1)` in `store.py:housekeeping`)
- No other zone properties (config, mode, setpoint, etc.) fall back to the MessageStore — they all read from `zone_state` which is hydrated from packets as they arrive
- So the 24h prune only affects `Zone.name()`, and the schema-based hydration is the correct fix (the schema is the persistent SSOT, not the MessageStore)

#### Test plan
- [x] All 1634 ramses_rf unit tests pass
- [x] R63 regression recipe passes (zone name survives container restart = simulated prune)
- [x] R22 recipe passes (scan-engine-ready wait)
- [x] Full ha_sim_test suite passes

see https://github.com/ramses-rf/ramses_cc/issues/919