### PR TITLE
fix: exempt HGI_DEV_ADDR placeholder from known_list/unwanted filters

### DIFF
--- a/src/ramses_rf/devices/dev_filter.py
+++ b/src/ramses_rf/devices/dev_filter.py
@@ -6,6 +6,7 @@ from collections.abc import Callable
 
 from ramses_rf.exceptions import DeviceNotFoundError
 from ramses_rf.typing import DeviceIdT
+from ramses_tx.address import HGI_DEV_ADDR
 from ramses_tx.schemas import SZ_BLOCK_LIST, SZ_KNOWN_LIST
 
 
@@ -48,13 +49,23 @@ class DeviceFilter:
         :rtype: None
         :raises DeviceNotFoundError: If the device is unwanted, strictly not known, or excluded.
         """
-        if dev_id in self._unwanted:
+        # HGI_DEV_ADDR (18:000730) is the shared on-air placeholder that a
+        # real HGI80 transmits under (instead of its own real device ID).
+        # It must bypass the _unwanted permanent block and the
+        # enforce_known_list check, otherwise every self-originated RQ/W is
+        # rejected with a DeviceNotFoundError warning pair (issue 1015).
+        # The block_list check below is intentionally NOT exempted — the
+        # protocol-level filter (_is_wanted_addrs in ramses_tx) keeps
+        # HGI_DEV_ADDR subject to the block_list.
+        if dev_id in self._unwanted and dev_id != HGI_DEV_ADDR.id:
             raise DeviceNotFoundError(
                 f"Can't create {dev_id}: it is unwanted or invalid"
             )
 
         if self._enforce_known_list and (
-            dev_id not in self._include and dev_id != self._hgi_id_provider()
+            dev_id not in self._include
+            and dev_id != self._hgi_id_provider()
+            and dev_id != HGI_DEV_ADDR.id
         ):
             self._unwanted.append(dev_id)
             raise DeviceNotFoundError(

--- a/tests/tests_rf/device/test_registry.py
+++ b/tests/tests_rf/device/test_registry.py
@@ -17,6 +17,7 @@ from ramses_rf.enums import TopologyAction
 from ramses_rf.exceptions import DeviceNotFoundError, SchemaInconsistentError
 from ramses_rf.models import DeviceTraits, TopologyChangedEvent
 from ramses_rf.typing import DeviceIdT
+from ramses_tx.address import HGI_DEV_ADDR
 
 if TYPE_CHECKING:
     from ramses_rf.devices.dev_base import Device
@@ -215,3 +216,101 @@ async def test_fan_promotion_race_condition() -> None:
 
     # 3. The returned device must act as the promoted class
     assert getattr(dev, "_SLUG", None) == "ventilator"
+
+
+def test_filter_placeholder_exempt_from_enforce_known_list() -> None:
+    """HGI_DEV_ADDR (18:000730) must bypass enforce_known_list.
+
+    Regression guard for issue 1015: when the active gateway is a real
+    HGI80, it transmits under the shared placeholder address 18:000730
+    (not its own real device ID).  GatewayConfig.__post_init__ derives
+    config.hgi_id from the known_list, which is the *real* ID (e.g.
+    18:123456), so hgi_id_provider() returns the real ID — not the
+    placeholder the HGI80 actually transmits as.
+
+    check_filter_lists("18:000730") therefore failed both the
+    enforce_known_list check (18:000730 != 18:123456 and not in
+    include) and, after the first rejection, the _unwanted permanent
+    block — logging a DeviceNotFoundError warning pair on every
+    self-originated RQ/W.
+
+    The placeholder must be exempt from both checks (but NOT from the
+    block_list, which the protocol-level filter intentionally keeps
+    enforced for HGI_DEV_ADDR).
+
+    :returns: None
+    """
+    real_hgi_id = cast(DeviceIdT, "18:123456")
+    placeholder_id = HGI_DEV_ADDR.id  # 18:000730
+
+    # Simulate the HGI80 scenario: provider returns the real ID (from
+    # config.hgi_id, derived from known_list by __post_init__), the
+    # placeholder is NOT in the include list, enforce_known_list is True.
+    device_filter = DeviceFilter(
+        include=[real_hgi_id],
+        exclude=[],
+        unwanted=[],
+        enforce_known_list=True,
+        hgi_id_provider=lambda: real_hgi_id,
+    )
+
+    # Must NOT raise — the placeholder is exempt from enforce_known_list
+    device_filter.check_filter_lists(placeholder_id)
+
+    # Must NOT have been added to _unwanted (which would cause repeating
+    # rejections on every subsequent packet via the faster _unwanted branch)
+    assert placeholder_id not in device_filter._unwanted
+
+
+def test_filter_placeholder_exempt_from_unwanted() -> None:
+    """HGI_DEV_ADDR must bypass the _unwanted permanent block.
+
+    Companion to test_filter_placeholder_exempt_from_enforce_known_list:
+    even if 18:000730 somehow ends up in _unwanted (e.g. from a race
+    during startup before config.hgi_id was set), the filter must not
+    permanently reject it — otherwise the active HGI80 can never be
+    created in the registry.
+
+    :returns: None
+    """
+    placeholder_id = HGI_DEV_ADDR.id
+
+    # placeholder already in _unwanted, provider returns a *different*
+    # real HGI ID (the HGI80 scenario)
+    real_hgi_id = cast(DeviceIdT, "18:123456")
+    device_filter = DeviceFilter(
+        include=[],
+        exclude=[],
+        unwanted=[placeholder_id],
+        enforce_known_list=True,
+        hgi_id_provider=lambda: real_hgi_id,
+    )
+
+    # Must NOT raise — the placeholder is exempt from the _unwanted check
+    device_filter.check_filter_lists(placeholder_id)
+
+
+def test_filter_placeholder_still_subject_to_block_list() -> None:
+    """HGI_DEV_ADDR must remain subject to the block_list.
+
+    The protocol-level filter (_is_wanted_addrs in ramses_tx) explicitly
+    keeps HGI_DEV_ADDR subject to the block_list, and the device-registry
+    filter must match that policy — the placeholder exemption covers
+    enforce_known_list and _unwanted only, not the block_list.
+
+    :returns: None
+    """
+    placeholder_id = HGI_DEV_ADDR.id
+    real_hgi_id = cast(DeviceIdT, "18:123456")
+
+    device_filter = DeviceFilter(
+        include=[placeholder_id],
+        exclude=[placeholder_id],
+        unwanted=[],
+        enforce_known_list=True,
+        hgi_id_provider=lambda: real_hgi_id,
+    )
+
+    # MUST raise — the block_list check is not exempted for the placeholder
+    with pytest.raises(DeviceNotFoundError, match="blocked device_id"):
+        device_filter.check_filter_lists(placeholder_id)


### PR DESCRIPTION
## Summary

Fixes https://github.com/ramses-rf/ramses_rf/issues/1015

A real HGI80 transmits under the shared placeholder address `18:000730` (`HGI_DEV_ADDR`) rather than its own real device ID. `GatewayConfig.__post_init__` derives `config.hgi_id` from the known_list (the real ID, e.g. `18:123456`), so `hgi_id_provider()` returns the real ID — not the placeholder the HGI80 actually transmits as.

`check_filter_lists("18:000730")` therefore failed both:
- the `enforce_known_list` check (`18:000730 != 18:123456` and not in `include`), and
- after the first rejection, the `_unwanted` permanent block

— logging a `DeviceNotFoundError` warning pair on **every** self-originated RQ/W when `enforce_known_list: true` is set against real HGI80 hardware.

### The fix

Exempt `HGI_DEV_ADDR.id` (`18:000730`) from both the `_unwanted` check and the `enforce_known_list` check in `DeviceFilter.check_filter_lists()`, but **not** from the `block_list` check — matching the protocol-level filter's policy in `ramses_tx` (`_is_wanted_addrs`), which intentionally keeps `HGI_DEV_ADDR` subject to the `block_list`.

This is the active-HGI80 counterpart to the foreign-HGI fix in PR 867 (issue 822): same mechanism, but failing for the active gateway's own placeholder address instead of a foreign HGI's real address.

### Why option 1 (filter exemption) over option 2 (skip in `instantiate_devices`)

The foreign-HGI skip in `instantiate_devices` is about *not creating* a device — correct for a foreign HGI, but wrong for the active HGI80's own `18:000730`, which **should** become the `HgiGateway` in the registry. Skipping creation would leave `gwy.hgi` permanently `None`. The filter exemption is also strictly more complete: it covers both `src` and `dst` paths (the active HGI80 can appear as `dst` in RPs from the controller), and it fixes the `_unwanted` permanent-block path that causes the *repeating* spam.

### Changes

- **`src/ramses_rf/devices/dev_filter.py`**: add `and dev_id != HGI_DEV_ADDR.id` to the `_unwanted` and `enforce_known_list` checks (not the `block_list` check).
- **`tests/tests_rf/device/test_registry.py`**: three regression tests covering the placeholder exemption from `enforce_known_list`, from `_unwanted`, and confirming the `block_list` still applies.

#### Test plan
- [x] `pytest tests/tests_rf/device/test_registry.py` — 8 passed
- [x] `pytest tests/tests_rf/` — 848 passed, 4 skipped
- [x] `pytest tests/` — 1637 passed, 4 skipped
- [x] ruff + mypy --strict + pre-commit hooks pass