### PR TITLE
refactor(payloads): optimize binary byte unpacking via struct.unpack_from (PR 9.5 of #1001)

### DIFF
--- a/src/ramses_rf/payloads/dhw.py
+++ b/src/ramses_rf/payloads/dhw.py
@@ -4,6 +4,7 @@ This module contains strongly-typed dataclass representations for Domestic Hot W
 packet payloads.
 """
 
+import struct
 from dataclasses import dataclass
 from typing import Self
 
@@ -107,8 +108,8 @@ class DhwConfigPayload(PayloadBase):
         """
         if len(raw_data) < 3:
             raise ValueError(f"Invalid payload length for 12F0: {len(raw_data)}")
-        idx = raw_data[0]
-        setpoint_raw = int.from_bytes(raw_data[1:3], byteorder="big", signed=True)
+        # Unpack dhw_idx (uint8) and setpoint_raw (int16) directly from offset 0
+        idx, setpoint_raw = struct.unpack_from(">Bh", raw_data, 0)
         return cls(dhw_idx=idx, setpoint_temp=setpoint_raw / 100.0)
 
     def to_bytes(self) -> bytes:
@@ -170,10 +171,8 @@ class DhwParamsPayload(PayloadBase):
         """
         if len(raw_data) < 6:
             raise ValueError(f"Invalid payload length for 10A0: {len(raw_data)}")
-        idx = raw_data[0]
-        sp_raw = int.from_bytes(raw_data[1:3], byteorder="big", signed=True)
-        overrun = raw_data[3]
-        diff_raw = int.from_bytes(raw_data[4:6], byteorder="big", signed=True)
+        # Unpack dhw_idx, setpoint, overrun, and diff directly from offset 0
+        idx, sp_raw, overrun, diff_raw = struct.unpack_from(">BhBh", raw_data, 0)
         return cls(
             dhw_idx=idx,
             setpoint=sp_raw / 100.0,

--- a/src/ramses_rf/payloads/heating.py
+++ b/src/ramses_rf/payloads/heating.py
@@ -643,15 +643,20 @@ class ZoneConfigPayload(PayloadBase):
             object.__setattr__(self, "zone_idx", parse_idx(self.zone_idx))
 
     @classmethod
-    def _from_bytes_single(cls, raw_data: bytes) -> Self:
-        """Unpack a single 6-byte zone config binary payload.
+    def _from_bytes_single(cls, raw_data: bytes, offset: int = 0) -> Self:
+        """Unpack a single 6-byte zone config binary payload from offset.
 
-        :param raw_data: 6-byte raw binary byte string.
+        :param raw_data: Raw binary byte string.
         :type raw_data: bytes
+        :param offset: Byte offset within raw_data to unpack from.
+        :type offset: int
         :returns: Unpacked ZoneConfigPayload instance.
         :rtype: Self
         """
-        idx, flags, min_raw, max_raw = struct.unpack(cls._STRUCT_FMT, raw_data)
+        # Unpack idx, flags, min_temp, max_temp directly from offset
+        idx, flags, min_raw, max_raw = struct.unpack_from(
+            cls._STRUCT_FMT, raw_data, offset
+        )
         return cls(
             zone_idx=idx,
             zone_flags=flags,
@@ -673,11 +678,10 @@ class ZoneConfigPayload(PayloadBase):
             raise ValueError(f"Invalid payload length for 000A: {len(raw_data)}")
         if len(raw_data) > 6:
             return [
-                cls._from_bytes_single(raw_data[i : i + 6])
-                for i in range(0, len(raw_data), 6)
+                cls._from_bytes_single(raw_data, i) for i in range(0, len(raw_data), 6)
             ]
 
-        return cls._from_bytes_single(raw_data)
+        return cls._from_bytes_single(raw_data, 0)
 
     def to_bytes(self) -> bytes:
         """Pack zone config data into binary payload.
@@ -737,9 +741,9 @@ class ZoneNamePayload(PayloadBase):
             raise ValueError(
                 f"Invalid payload length for ZoneNamePayload: {len(raw_data)}"
             )
-        idx = raw_data[0]
-        name_bytes = raw_data[2:22].rstrip(b"\x00")
-        name = name_bytes.decode("ascii", errors="replace")
+        # Unpack zone_idx (uint8), skip 1 pad byte, and extract 20-byte string
+        idx, name_raw = struct.unpack_from(">Bx20s", raw_data, 0)
+        name = name_raw.rstrip(b"\x00").decode("ascii", errors="replace")
         return cls(zone_idx=idx, name=name)
 
     def to_bytes(self) -> bytes:
@@ -795,8 +799,8 @@ class ZoneSetpointPayload(PayloadBase):
             return ZoneNamePayload.from_bytes(raw_data)
         if len(raw_data) < 3:
             raise ValueError(f"Invalid payload length for 0004: {len(raw_data)}")
-        idx = raw_data[0]
-        sp_raw = int.from_bytes(raw_data[1:3], byteorder="big", signed=True)
+        # Unpack zone_idx (uint8) and setpoint_raw (int16) directly from offset 0
+        idx, sp_raw = struct.unpack_from(">Bh", raw_data, 0)
         return cls(zone_idx=idx, setpoint_temp=sp_raw / 100.0)
 
     def to_bytes(self) -> bytes:
@@ -841,7 +845,8 @@ class OutdoorTempPayload(PayloadBase):
         """
         if len(raw_data) < 2:
             raise ValueError(f"Invalid payload length for 12C0: {len(raw_data)}")
-        temp_raw = int.from_bytes(raw_data[:2], byteorder="big", signed=True)
+        # Unpack 16-bit signed outdoor temperature directly from offset 0
+        (temp_raw,) = struct.unpack_from(">h", raw_data, 0)
         return cls(temperature=temp_raw / 100.0)
 
     def to_bytes(self) -> bytes:

--- a/src/ramses_rf/payloads/hvac.py
+++ b/src/ramses_rf/payloads/hvac.py
@@ -824,7 +824,8 @@ class HvacFanParamPayload(PayloadBase):
             max_s,
             prec_s,
             trailer,
-        ) = struct.unpack(cls._STRUCT_FMT, parse_data[:23])
+            # Unpack struct layout directly from offset 0 without buffer slicing
+        ) = struct.unpack_from(cls._STRUCT_FMT, parse_data, 0)
         # PROTOCOL QUIRK: Sentinel values (e.g. 0x000000FF, 0xFFFFFFFF, -1)
         # indicate parameter N/A or unconfigured hardware setting.
         # Normalise sentinel values to None to prevent invalid parameter
@@ -894,9 +895,9 @@ class HvacAirQualityPayload(PayloadBase):
         """
         if len(raw_data) < 2:
             raise ValueError(f"Invalid payload length: {len(raw_data)}")
-        return cls(
-            air_quality_aqi=int.from_bytes(raw_data[:2], byteorder="big", signed=False)
-        )
+        # Unpack 16-bit unsigned air quality AQI directly from offset 0
+        (aqi,) = struct.unpack_from(">H", raw_data, 0)
+        return cls(air_quality_aqi=aqi)
 
     def to_bytes(self) -> bytes:
         """Pack air quality data into binary payload.
@@ -1149,13 +1150,13 @@ class SetpointBoundsPayload(PayloadBase):
         """
         if len(raw_data) < 6:
             raise ValueError(f"Invalid payload length for 22C9: {len(raw_data)}")
-        min_t = int.from_bytes(raw_data[1:3], byteorder="big", signed=True)
-        max_t = int.from_bytes(raw_data[3:5], byteorder="big", signed=True)
+        # Unpack ufh_idx, min_temp, max_temp, mode_code directly from offset 0
+        idx, min_t, max_t, mode_code = struct.unpack_from(">BhhB", raw_data, 0)
         return cls(
-            ufh_idx=raw_data[0],
+            ufh_idx=idx,
             min_temp=min_t / 100.0,
             max_temp=max_t / 100.0,
-            mode_code=raw_data[5],
+            mode_code=mode_code,
         )
 
     def to_bytes(self) -> bytes:
@@ -1216,11 +1217,10 @@ class NowNextSetpointPayload(PayloadBase):
         """
         if len(raw_data) < 7:
             raise ValueError(f"Invalid payload length for 2249: {len(raw_data)}")
-        sp_now = int.from_bytes(raw_data[1:3], byteorder="big", signed=True)
-        sp_next = int.from_bytes(raw_data[3:5], byteorder="big", signed=True)
-        mins = int.from_bytes(raw_data[5:7], byteorder="big")
+        # Unpack zone_idx, setpoint_now, setpoint_next, mins directly from offset 0
+        idx, sp_now, sp_next, mins = struct.unpack_from(">BhhH", raw_data, 0)
         return cls(
-            zone_idx=raw_data[0],
+            zone_idx=idx,
             setpoint_now=sp_now / 100.0,
             setpoint_next=sp_next / 100.0,
             minutes_remaining=mins,

--- a/src/ramses_rf/payloads/opentherm.py
+++ b/src/ramses_rf/payloads/opentherm.py
@@ -74,13 +74,14 @@ class OpenThermMsgPayload(PayloadBase):
         if len(raw_data) < 4:
             raise ValueError(f"Invalid payload length for 3220: {len(raw_data)}")
 
+        # Unpack binary fields directly from offset 0 without buffer slicing
         if len(raw_data) >= 5:
-            ot_idx, header_byte, m_id, val = struct.unpack(
-                cls._STRUCT_FMT_5B, raw_data[:5]
+            ot_idx, header_byte, m_id, val = struct.unpack_from(
+                cls._STRUCT_FMT_5B, raw_data, 0
             )
         else:
             ot_idx = 0
-            header_byte, m_id, val = struct.unpack(cls._STRUCT_FMT_4B, raw_data[:4])
+            header_byte, m_id, val = struct.unpack_from(cls._STRUCT_FMT_4B, raw_data, 0)
 
         m_type = (header_byte >> 4) & 0x07
         return cls(ot_idx=ot_idx, msg_id=m_id, msg_type=m_type, raw_value=val)

--- a/src/ramses_rf/payloads/system.py
+++ b/src/ramses_rf/payloads/system.py
@@ -4,6 +4,7 @@ This module contains strongly-typed dataclass representations for system clock,
 device binding, fault log, and gateway heartbeat packet payloads.
 """
 
+import struct
 from dataclasses import dataclass
 from typing import Self
 
@@ -161,7 +162,8 @@ class SystemChangeCounterPayload(PayloadBase):
         """
         if len(raw_data) < 3:
             raise ValueError(f"Invalid payload length for 0006: {len(raw_data)}")
-        val = int.from_bytes(raw_data[1:3], byteorder="big", signed=False)
+        # Unpack 16-bit unsigned change counter directly from byte offset 1
+        (val,) = struct.unpack_from(">H", raw_data, 1)
         return cls(change_counter=val)
 
     def to_bytes(self) -> bytes:
@@ -664,7 +666,8 @@ class SystemOutdoorTempPayload(PayloadBase):
         """
         if len(raw_data) < 2:
             raise ValueError(f"Invalid payload length for 1290: {len(raw_data)}")
-        temp_raw = int.from_bytes(raw_data[:2], byteorder="big", signed=True)
+        # Unpack 16-bit signed outdoor temperature directly from offset 0
+        (temp_raw,) = struct.unpack_from(">h", raw_data, 0)
         return cls(temperature=temp_raw / 100.0)
 
     def to_bytes(self) -> bytes:


### PR DESCRIPTION
### ⚠️ STACKED PR: Depends on ramses-rf/ramses_rf#1020 < was merged

### The Problem:
Binary payload unpackers (`from_bytes`) across `ramses_rf.payloads.*`) previously used heap-allocating byte slices (`raw_data[A:B]`) and `int.from_bytes` or pre-sliced `struct.unpack(fmt, raw_data[:N])` calls. Each slice created temporary `bytes` object allocations in Python memory during frame decoding.

### The Fix:
- Refactored binary payload unpacking across `dhw.py`, `heating.py`, `hvac.py`, `opentherm.py`, and `system.py` to use Python standard library `struct.unpack_from(fmt, raw_data, offset)` without pre-slicing buffer allocations.
- Refactored `ZoneNamePayload.from_bytes` to use `struct.unpack_from(">Bx20s", raw_data, 0)` to unpack the index header and 20-byte text payload in a single C call.
- Refactored `ZoneConfigPayload._from_bytes_single` to accept an `offset` parameter, eliminating 6-byte slice allocations during multi-zone array unpacking loops.
- Added explanatory inline comments detailing format specifiers and offset unpacking for future maintainers.

### Testing Performed:
- **Payload Parity Suite**: `.venv/bin/pytest tests/tests_rf/test_payload_parity.py` (47/47 passed).
- **Full Test Suite**: `.venv/bin/pytest tests/tests_rf/` (866/866 passed).
- **Pre-commit & Formatting**: `.venv/bin/prek run -a` passed 100%.
- **Strict Typing**: `.venv/bin/mypy --strict src/ramses_rf/payloads/` passed clean (0 issues across 260 files).

### AI Assistance Disclosure:
This contribution was developed with the assistance of Google Gemini 3.6 Flash for code generation and documentation. All logic and implementations were reviewed and verified by the author.