### PR TITLE
docs(ai-policy): add AI_POLICY.md and align contributing guidelines with Home Assistant policy

### DIFF
--- a/AI_POLICY.md
+++ b/AI_POLICY.md
@@ -1,0 +1,61 @@
+# AI Policy for ramses_rf
+
+We support using AI (e.g. LLMs) as assistance tools when contributing
+to `ramses_rf`. However, human contributors are solely responsible for
+any contributions submitted, and maintainers are responsible for what
+is merged and released. We maintain high standards for all
+contributions.
+
+Maintainers dedicate their time and expertise to reviewing pull
+requests and issues. Submitting AI-generated content that you have not
+personally reviewed, tested, and thoroughly understood wastes maintainer
+time and will not be accepted.
+
+## 1. Autonomous Agents
+
+**We do not allow autonomous agents to contribute to ramses_rf.**
+Any pull requests, issues, or comments created autonomously without
+direct human oversight and verification will be closed immediately,
+and automated comments may be marked as spam. This includes automated
+tools that bypass standard issue or pull request templates.
+
+## 2. Communication on Issues, Pull Requests, and Code Reviews
+
+AI tools may be used to assist with writing, but tools must not post
+unreviewed content on your behalf. Keep responses concise and focused.
+Unreviewed AI output in comments or reviews may be hidden.
+
+* **Explain in Your Own Words**: When opening a pull request or issue,
+  you must be able to explain all proposed changes in your own words.
+  This includes the pull request description and answers to maintainer
+  questions. If AI is used to help draft a PR description, you must
+  review it for technical accuracy.
+* **No AI Answers to Maintainers**: Do not use AI to generate answers to
+  questions or feedback from maintainers. You must understand and
+  explain your own work. The substance of your responses must be your
+  own.
+
+## 3. Non-Native English Speakers
+
+AI tools are genuinely helpful when communicating as a non-native English
+speaker. Using AI to improve the grammar, spelling, or clarity of text
+you have written yourself is welcomed. If using AI for translation,
+ensure it accurately reflects your intent. You may optionally include
+your original non-English text inside a `<details>` block.
+
+## 4. Code and Documentation Contributions
+
+AI can be a helpful aid when writing code and documentation. However,
+a human in the loop must understand and verify all work produced by AI.
+
+All contributions must be reviewed, tested, and understood by the
+contributor before submission. You must be able to explain every line
+of code and design decision in your pull request. PRs that appear to be
+unreviewed AI output will be closed without review.
+
+## 5. Enforcement
+
+Contributions that fail to adhere to this policy will be closed.
+Repeated violations may result in being blocked from contributing to
+`ramses_rf`. If you believe your contribution was closed in error,
+please reach out to a maintainer to discuss.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,6 +39,15 @@ Changes that are cosmetic in nature and do not add anything substantial to the s
 
 * Please read [The Ramses RF Dev Wiki](https://github.com/ramses-rf/ramses_rf/wiki).
 
+## AI & LLM Policy
+
+All contributors (human and AI-assisted) must strictly comply with our [AI Policy](AI_POLICY.md).
+
+* **Human Accountability**: AI tools are supported as assistance tools, but human contributors maintain 100% responsibility for all submitted code, documentation, issues, and pull requests.
+* **Autonomous Agents Prohibited**: Pull requests, issues, or comments created autonomously without human review will be closed immediately.
+* **No AI Answers to Maintainers**: Contributors must understand and be able to explain their changes in their own words. AI must **never** be used to generate answers to maintainer review questions.
+* **AI Instructions**: AI coding agents operating on this repository must follow the instructions in [LLM_INSTRUCTIONS.md](LLM_INSTRUCTIONS.md).
+
 ---
 
 ## Coding & Development Standards

--- a/LLM_INSTRUCTIONS.md
+++ b/LLM_INSTRUCTIONS.md
@@ -6,6 +6,9 @@ For all general coding, typing, docstring, and architectural standards, you **mu
 
 ## 1. Identity, Tone & Behavior
 
+* **AI Policy Compliance**: Strictly adhere to the project [AI Policy](AI_POLICY.md). You are an assistant tool; human contributors maintain sole responsibility for all submitted code, documentation, comments, issues, and PRs.
+* **No Autonomous Submissions**: Never create pull requests, issues, or comments autonomously. All submissions must be human-verified.
+* **No Generating Answers to Maintainers**: Never generate automated responses to maintainer review questions on PRs or issues. All answers must come from the human contributor's own understanding.
 * **Professional Tone**: Keep feedback, PR titles, and PR descriptions professional, objective, and concise. Avoid marketing-style hype or aggressive terminology (e.g. avoid words like "lobotomy", "purge", "nuke", "eradicate").
 * **No Advertising**: Never add signatures like "co-authored by Devin" or promote AI tools in commits, comments, code, or PR descriptions.
 * **Wait for Approval**: Do not automatically commit or push code unless explicitly instructed by the user.


### PR DESCRIPTION
### The Problem:
`ramses_rf` needed its AI and LLM policy aligned with Home Assistant's Open Home Foundation AI Policy as requested in ramses-rf/ramses_rf#887.

### The Fix:
- Added `AI_POLICY.md` at root adapting Open Home Foundation standards (human contributor accountability, ban on autonomous agents, rules against AI-generated answers to maintainer review questions, non-native English grammar assistance, and enforcement).
- Updated `CONTRIBUTING.md` with an **AI & LLM Policy** section referencing `AI_POLICY.md`.
- Updated `LLM_INSTRUCTIONS.md` to reference `AI_POLICY.md` and add explicit guardrails against autonomous PR generation and AI-generated maintainer Q&A responses.

Ref: ramses-rf/ramses_rf#887

### Testing Performed:
Ran `.venv/bin/prek run -a` to verify formatting, spell check, and line ending compliance.

### AI Assistance Disclosure:
This contribution was developed with the assistance of Google Gemini 3.6 Flash for documentation formatting. All text and guidelines were reviewed and verified by the author.