### PR TITLE
fix: persist `is_authoritative_domain` on DiscoveredDevice (issue 931)

### DIFF
--- a/src/ramses_rf/discovery_scan.py
+++ b/src/ramses_rf/discovery_scan.py
@@ -192,6 +192,11 @@ class DiscoveredDevice:
     bound_to: str | None = None  # parent device ID (CTL for TRV, FAN for REM)
     zone_idx: str | None = None  # zone index if known from payload
     domain_id: str | None = None  # domain ID if known (FC=appliance_control)
+    # True if domain_id was set from an authoritative 000C binding table
+    # entry; False if from a 3B00/3EF0 fallback hint.  Consumers (ramses_cc)
+    # use this to distinguish confident classification from hedged hints.
+    # Issue 931.
+    is_authoritative_domain: bool = False
     rssi: float | None = None  # running average
     confidence: str = "low"  # high, medium, low
     is_battery: bool = False  # seen sending battery info
@@ -524,6 +529,9 @@ class DiscoveryScan:
                     src_count=1 if is_src else 0,
                     dst_count=0 if is_src else 1,
                     domain_id=domain_id if domain_id and is_src else None,
+                    is_authoritative_domain=(
+                        is_authoritative_domain and bool(domain_id) and is_src
+                    ),
                 )
                 self._devices[dev_id] = dev
                 self._dirty = True
@@ -579,6 +587,7 @@ class DiscoveryScan:
                     )
                 ):
                     dev.domain_id = domain_id
+                    dev.is_authoritative_domain = is_authoritative_domain
                     dev.confidence = "high"
                     self._dirty = True
 
@@ -651,6 +660,7 @@ class DiscoveryScan:
                 )
             ):
                 dev.domain_id = domain_id
+                dev.is_authoritative_domain = is_authoritative_domain
                 dev.confidence = "high"
             # HVAC topology inference: a FAN (32:) sending a directed packet
             # (I or RP) to this device confirms the binding — the FAN is the
@@ -732,6 +742,7 @@ class DiscoveryScan:
             )
         ):
             dev.domain_id = domain_id
+            dev.is_authoritative_domain = is_authoritative_domain
             dev.confidence = "high"
             changed = True
 


### PR DESCRIPTION
## Summary

- Persist `is_authoritative_domain` on the `DiscoveredDevice` dataclass. The scan engine tracked this as a local variable in `_process_packet` but never persisted it, so consumers (`ramses_cc`) could see `domain_id` but could not distinguish an authoritative `000C`-sourced domain from a `3B00`/`3EF0` fallback hint.
- Set the field alongside `domain_id` in all four code paths (known-device new/existing, new-device, existing-device).

This is the `ramses_rf` half of the issue 931 fix. The `ramses_cc` half (https://github.com/ramses-rf/ramses_cc/pull/944) uses this flag to gate BDR auto-placement and render hedged vs confident domain comments.

## Context

Issue 931: a DHW relay BDR (`13:042605`) was never associated as `stored_hotwater.hotwater_valve` because `ramses_cc` keyed on the wrong `"1100" in scan_codes` heuristic. The authoritative `domain_id` (FC/FA/F9) was tracked by the scan engine but never surfaced across the bridge — the `is_authoritative_domain` flag was lost entirely.

## Test plan

- [x] ramses_rf tests: 1690 passed, 4 skipped
- [x] ruff clean
- [x] mypy --strict clean
- [x] ha_sim_test regression recipe (to be added separately)