### PR TITLE
fix(polling): restore per-zone 0004 polling for CTL

### DIFF
--- a/src/ramses_rf/pipeline/polling.py
+++ b/src/ramses_rf/pipeline/polling.py
@@ -26,6 +26,7 @@ if TYPE_CHECKING:
 _LOGGER = logging.getLogger(__name__)
 
 INTERVAL_HOURLY: Final[int] = 3600  # 1 hour in seconds
+INTERVAL_EVERY_6_HOURS: Final[int] = 21600  # 6 hours in seconds
 INTERVAL_EVERY_12_HOURS: Final[int] = 43200  # 12 hours in seconds
 INTERVAL_DAILY: Final[int] = 86400  # 24 hours in seconds
 
@@ -39,6 +40,12 @@ DEFAULT_POLLING_SCHEDULES: Final[dict[str, dict[str, int | None]]] = {
         "1F41": INTERVAL_HOURLY,  # DHW System Mode / Operating State
         "2E04": INTERVAL_DAILY,  # Evohome System Mode
         "313F": INTERVAL_EVERY_12_HOURS,  # System Time & Date Sync
+        # 0004 (zone name) is polled per-zone, not per-device — see
+        # update_device_tasks for the zone-level expansion.  The interval
+        # here is a marker; actual tasks are keyed by (device_id, "0004",
+        # zone_idx).  Issue 947: zone names lost after cache clear because
+        # the CTL does not broadcast 0004 unless queried.
+        "0004": INTERVAL_EVERY_6_HOURS,  # Zone Name (per-zone, expanded below)
     },
     # Boiler Relay / Switch
     DevType.BDR: {
@@ -110,6 +117,8 @@ class PollingTask:
     :type last_polled: dt | None
     :param failures: Count of consecutive polling failures.
     :type failures: int
+    :param payload: Optional payload suffix (e.g., zone_idx for 0004).
+    :type payload: str | None
     """
 
     device_id: DeviceIdT
@@ -118,6 +127,7 @@ class PollingTask:
     next_due: dt
     last_polled: dt | None = None
     failures: int = 0
+    payload: str | None = None
 
 
 class PollingManager:
@@ -148,7 +158,9 @@ class PollingManager:
         self.shadow_mode: bool = shadow_mode
         self._cycle_interval: float = cycle_interval
 
-        self._tasks: dict[tuple[DeviceIdT, str], PollingTask] = {}
+        # Keys are (device_id, code) for device-level tasks, or
+        # (device_id, code, zone_idx) for zone-level tasks (e.g., 0004).
+        self._tasks: dict[tuple[str, ...], PollingTask] = {}
         self._poller_task: asyncio.Task[None] | None = None
         self._running: bool = False
 
@@ -199,30 +211,63 @@ class PollingManager:
             if interval is not None and interval > 0
         }
 
-    def update_device_tasks(self, device: DeviceBase) -> set[tuple[DeviceIdT, str]]:
+    def update_device_tasks(self, device: DeviceBase) -> set[tuple[str, ...]]:
         """Update or register scheduled polling tasks for a device entity.
+
+        For CTL devices with zones, the ``0004`` (zone name) code is
+        expanded into one task per zone, keyed by
+        ``(device_id, "0004", zone_idx)``.  This restores the per-zone
+        zone-name polling that was lost when the legacy DiscoveryService
+        was removed (issue 947 / ramses-rf/ramses_cc#947).
 
         :param device: The device entity to register or refresh.
         :type device: DeviceBase
-        :returns: Set of active task keys (device_id, code) for the device.
-        :rtype: set[tuple[DeviceIdT, str]]
+        :returns: Set of active task keys for the device.
+        :rtype: set[tuple[str, ...]]
         """
         schedule = self.resolve_schedule_for_device(device)
         now = dt.now(UTC)
-        active_keys: set[tuple[DeviceIdT, str]] = set()
+        active_keys: set[tuple[str, ...]] = set()
+
+        # Collect zone indices for per-zone code expansion (0004).
+        # CTL devices have a .tcs attribute with .zones list.
+        zone_idxs: list[str] = []
+        if "0004" in schedule:
+            tcs = getattr(device, "tcs", None)
+            if tcs is not None:
+                zones = getattr(tcs, "zones", [])
+                zone_idxs = [z.idx for z in zones if hasattr(z, "idx")]
 
         for code, interval in schedule.items():
-            key = (device.id, code)
-            active_keys.add(key)
-            if key not in self._tasks:
-                self._tasks[key] = PollingTask(
-                    device_id=device.id,
-                    code=code,
-                    interval=interval,
-                    next_due=now + td(seconds=interval),
-                )
+            if code == "0004" and zone_idxs:
+                # Expand into per-zone tasks
+                for zone_idx in zone_idxs:
+                    zkey = (device.id, code, zone_idx)
+                    active_keys.add(zkey)
+                    payload = f"{zone_idx}00"
+                    if zkey not in self._tasks:
+                        self._tasks[zkey] = PollingTask(
+                            device_id=device.id,
+                            code=code,
+                            interval=interval,
+                            next_due=now + td(seconds=interval),
+                            payload=payload,
+                        )
+                    else:
+                        self._tasks[zkey].interval = interval
+                        self._tasks[zkey].payload = payload
             else:
-                self._tasks[key].interval = interval
+                dkey = (device.id, code)
+                active_keys.add(dkey)
+                if dkey not in self._tasks:
+                    self._tasks[dkey] = PollingTask(
+                        device_id=device.id,
+                        code=code,
+                        interval=interval,
+                        next_due=now + td(seconds=interval),
+                    )
+                else:
+                    self._tasks[dkey].interval = interval
 
         return active_keys
 
@@ -294,7 +339,7 @@ class PollingManager:
             return 0
 
         # Refresh tasks for all devices currently in registry and prune stale tasks
-        active_keys: set[tuple[DeviceIdT, str]] = set()
+        active_keys: set[tuple[str, ...]] = set()
         for dev in list(self._gwy.device_registry.devices):
             active_keys.update(self.update_device_tasks(dev))
 
@@ -315,10 +360,11 @@ class PollingManager:
             processed_count += 1
             if self.shadow_mode:
                 _LOGGER.debug(
-                    "[SHADOW POLLING] Device %s command %s due (interval=%ss)",
+                    "[SHADOW POLLING] Device %s command %s due (interval=%ss, payload=%s)",
                     task.device_id,
                     task.code,
                     task.interval,
+                    task.payload or "00",
                 )
                 task.last_polled = now
                 task.next_due = now + td(seconds=task.interval)
@@ -326,7 +372,9 @@ class PollingManager:
                 _LOGGER.info("Polling device %s command %s", task.device_id, task.code)
                 task.last_polled = now
                 task.next_due = now + td(seconds=task.interval)
-                cmd_dto = build_rq_cmd(task.device_id, task.code)
+                cmd_dto = build_rq_cmd(
+                    task.device_id, task.code, payload=task.payload or "00"
+                )
                 try:
                     await self._gwy.async_send_cmd(cmd_dto)
                 except (RamsesException, TimeoutError) as err:

--- a/tests/tests_rf/test_polling_parity.py
+++ b/tests/tests_rf/test_polling_parity.py
@@ -267,6 +267,128 @@ async def test_polling_manager_live_dispatch_cutover(
     assert sent_dto.addr2 == "01:111111"
 
 
+def test_polling_manager_ctl_without_tcs_creates_device_level_0004(
+    mock_gateway: MagicMock,
+) -> None:
+    """CTL without a TCS (no zones) gets a single device-level 0004 task.
+
+    The MockDevice has no .tcs attribute, so 0004 is not expanded into
+    per-zone tasks.  This verifies the fallback path.
+    """
+    # ARRANGE
+    poller = PollingManager(mock_gateway, shadow_mode=True)
+    ctl_dev = MockDevice(mock_gateway, "01:111111", slug="CTL")
+
+    # ACT
+    active_keys = poller.update_device_tasks(ctl_dev)
+
+    # ASSERT
+    # 5 device-level tasks: 10E0, 1F41, 2E04, 313F, 0004
+    assert len(active_keys) == 5
+    assert ("01:111111", "0004") in active_keys
+    # No zone-level keys (3-tuples)
+    assert all(len(k) == 2 for k in active_keys)
+
+
+def test_polling_manager_ctl_with_zones_expands_0004_per_zone(
+    mock_gateway: MagicMock,
+) -> None:
+    """CTL with a TCS and zones gets per-zone 0004 polling tasks.
+
+    This restores the per-zone zone-name polling that was lost when the
+    legacy DiscoveryService was removed (issue 947 /
+    ramses-rf/ramses_cc#947).  Each zone gets its own 0004 task with
+    the zone_idx in the payload.
+    """
+    # ARRANGE
+    poller = PollingManager(mock_gateway, shadow_mode=True)
+    ctl_dev = MockDevice(mock_gateway, "01:111111", slug="CTL")
+
+    # Mock a TCS with zones
+    zone_03 = MagicMock()
+    zone_03.idx = "03"
+    zone_07 = MagicMock()
+    zone_07.idx = "07"
+    mock_tcs = MagicMock()
+    mock_tcs.zones = [zone_03, zone_07]
+    ctl_dev.tcs = mock_tcs
+
+    # ACT
+    active_keys = poller.update_device_tasks(ctl_dev)
+
+    # ASSERT
+    # 4 device-level tasks (10E0, 1F41, 2E04, 313F) + 2 zone-level 0004 tasks
+    device_level = {k for k in active_keys if len(k) == 2}
+    zone_level = {k for k in active_keys if len(k) == 3}
+    assert len(device_level) == 4
+    assert len(zone_level) == 2
+
+    # Zone-level keys are (device_id, "0004", zone_idx)
+    assert ("01:111111", "0004", "03") in zone_level
+    assert ("01:111111", "0004", "07") in zone_level
+
+    # Verify the 0004 tasks have the correct payload (zone_idx + "00")
+    task_03 = poller._tasks[("01:111111", "0004", "03")]
+    assert task_03.payload == "0300"
+    assert task_03.code == "0004"
+
+    task_07 = poller._tasks[("01:111111", "0004", "07")]
+    assert task_07.payload == "0700"
+    assert task_07.code == "0004"
+
+    # Device-level tasks have no payload (default "00" in build_rq_cmd)
+    task_10e0 = poller._tasks[("01:111111", "10E0")]
+    assert task_10e0.payload is None
+
+
+@pytest.mark.asyncio
+async def test_polling_manager_0004_zone_uses_payload_in_cmd(
+    mock_gateway: MagicMock,
+) -> None:
+    """When polling 0004 for a zone, the RQ payload includes the zone_idx.
+
+    The old DiscoveryService sent GET_ZONE_NAME with the zone_idx in the
+    payload.  The PollingManager must do the same — payload "00" would
+    only query zone 00, not the target zone.
+    """
+    # ARRANGE
+    poller = PollingManager(mock_gateway, shadow_mode=False)
+    ctl_dev = MockDevice(mock_gateway, "01:111111", slug="CTL")
+
+    # Mock a TCS with one zone
+    zone_05 = MagicMock()
+    zone_05.idx = "05"
+    mock_tcs = MagicMock()
+    mock_tcs.zones = [zone_05]
+    ctl_dev.tcs = mock_tcs
+
+    mock_gateway.device_registry.devices = [ctl_dev]
+    poller.update_device_tasks(ctl_dev)
+
+    # Fast-forward all tasks to trigger due commands
+    past = dt.now(UTC) - td(seconds=10)
+    for task in poller.get_scheduled_cmds():
+        task.next_due = past
+
+    # ACT
+    await poller.poll_due_commands()
+
+    # ASSERT: find the 0004 call and check its payload
+    sent_codes = [
+        call.args[0].code for call in mock_gateway.async_send_cmd.call_args_list
+    ]
+    assert "0004" in sent_codes
+
+    # Find the 0004 call and verify payload contains zone_idx
+    for call in mock_gateway.async_send_cmd.call_args_list:
+        dto: CommandDTO = call.args[0]
+        if dto.code == "0004":
+            assert dto.payload == "0500", (
+                f"Expected 0004 payload '0500' for zone 05, got '{dto.payload}'"
+            )
+            break
+
+
 @pytest.mark.asyncio
 async def test_polling_schema_traits_parsing() -> None:
     # ARRANGE


### PR DESCRIPTION
## Summary

- Restores per-zone 0004 (zone_name) polling that was lost when the legacy DiscoveryService was replaced by the PollingManager in commit dba5bf7d
- Adds 0004 to `DEFAULT_POLLING_SCHEDULES` for CTL (6-hour interval)
- Expands 0004 into per-zone tasks in `update_device_tasks`, keyed by `(device_id, "0004", zone_idx)` with the zone_idx in the RQ payload (the old code polled per-zone using `self.idx`; the PollingManager is device-level, so it needs explicit per-zone expansion)
- Adds optional `payload` field to `PollingTask` for per-zone RQ payloads
- Changes `_tasks` dict key to `tuple[str, ...]` to support 3-tuple keys

The CTL does not broadcast 0004 spontaneously, so without active polling zone names go missing after cache clear. This was a regression, not a missing feature — the old `Zone._setup_discovery_cmds` actively polled `Action.GET_ZONE_NAME` every 6 hours per zone.

Refs: https://github.com/ramses-rf/ramses_cc/issues/947

#### Test plan

- [x] `pytest tests/tests_rf/test_polling_parity.py tests/tests_rf/test_polling_api.py` — 27 passed
- [x] `ruff check` + `ruff format` — clean
- [x] `mypy --strict` on `polling.py` — clean
- [x] 3 new unit tests: CTL without zones gets device-level 0004, CTL with zones gets per-zone 0004 with correct payloads, 0004 RQ payload includes zone_idx
- [x] ha_sim_test R76 recipe verifies end-to-end: 0004 injection populates device registry name, CTL schedule includes 0004