### PR TITLE
refactor(payloads): standardise polymorphic payload dataclasses and complete phase 6 (#1001)

### DIFF
--- a/docs/developer_guide/payload_registry_spec.md
+++ b/docs/developer_guide/payload_registry_spec.md
@@ -29,20 +29,29 @@ Under **GitHub Issue #837 (*Replace Hex-Regex with Binary Parsing*)** and **GitH
 
 ## 3. Polymorphic Factory / Master Dispatcher Specification
 
-When an opcode supports variable byte lengths or structural variants (e.g. 3-byte short vs 6-byte long formats), payload classes MUST implement the **Polymorphic Factory / Length-Dispatched Sub-Dataclass Pattern**:
+When an opcode supports variable byte lengths or structural variants (e.g. 3-byte short vs 6-byte long formats), payload classes MUST implement the **Polymorphic Master Dispatcher Pattern** established in PR #1037:
 
 ### Architectural Rules for Variant Payloads:
-1. **Master Dispatcher Class**:
-   - Decorated with `@register_payload("<OPCODE>")`.
-   - Inherits from `PayloadBase` or an abstract opcode base class.
-   - `from_bytes(cls, raw_data: bytes)` inspects `len(raw_data)` or header flags and delegates unpacking to the matching concrete sub-dataclass.
-2. **Concrete Sub-Dataclasses (Variants)**:
-   - Inherit from the abstract opcode base class or `PayloadBase`.
+1. **Master Dispatcher Class (Defined First)**:
+   - Decorated with `@register_payload("<OPCODE>")`. Exactly **one** class per opcode carries this decorator.
+   - Inherits directly from `PayloadBase` (defined in `src/ramses_rf/payloads/base.py`).
+   - Declares `VARIANTS: ClassVar[tuple[type[PayloadBase], ...]] = ()` at class level.
+   - Implements `@classmethod from_bytes(cls, raw_data: bytes)` which inspects `len(raw_data)` or header flags and delegates unpacking to the matching concrete sub-dataclass.
+   - Implements `to_bytes(self) -> bytes` raising `NotImplementedError("Use concrete variant sub-dataclass")`.
+   - Optionally defines `__new__` if dynamic direct instantiation is supported.
+2. **Concrete Sub-Dataclasses (Defined Next)**:
+   - Inherit **directly** from the Master Dispatcher class (e.g. `class DhwParams3BPayload(DhwParamsPayload):`).
    - Decorated with `@dataclass(frozen=True, slots=True)`.
+   - MUST **NEVER** be decorated with `@register_payload` (this prevents dictionary collisions in `PAYLOAD_REGISTRY`).
    - Define an explicit `_STRUCT_FMT: ClassVar[str]` constant matching their exact byte layout.
-   - Contain ONLY fields present in that specific byte structure (no dummy/optional defaults).
-   - Contain a dedicated docstring with an exact BOFM layout table for that specific variant byte length.
-3. **Grouped Source Placement & 72-Character Separators**:
+   - Implement `@classmethod from_bytes(cls, raw_data: bytes)` with an explicit length guard (`if len(raw_data) < N: raise ValueError(...)`).
+   - Implement `to_bytes(self) -> bytes` packing their fields with `struct.pack`.
+   - Contain a dedicated Sphinx docstring with an exact BOFM layout table containing valid, real-world protocol sample hex.
+   - If the Master Dispatcher defines `__new__`, sub-dataclasses MUST accept compatible optional default parameters (e.g. `duration_minutes: int | None = None`) to prevent Python's `__init__` dispatcher from raising keyword argument `TypeError`s.
+3. **Module-Level `VARIANTS` Assignment**:
+   - Immediately following the sub-dataclass definitions, assign the tuple of variant types to the Master Dispatcher:
+     `MasterDispatcher.VARIANTS = (SubVariant1, SubVariant2, ...)`
+4. **Grouped Source Placement & 72-Character Separators**:
    - In payload source modules (`dhw.py`, `heating.py`, `hvac.py`, `opentherm.py`, `system.py`), the Master Dispatcher class and all of its associated sub-dataclasses MUST be placed together as a single contiguous logical group.
    - Logical payload groups MUST be separated from adjacent payload groups using 72-character comment lines formatted as `# ` followed by 70 `-` characters:
      `# ----------------------------------------------------------------------`
@@ -57,7 +66,6 @@ When implementing payload dataclasses, the following standard imports are requir
 from __future__ import annotations
 
 import struct
-from abc import ABC
 from dataclasses import dataclass
 from typing import Any, ClassVar, Self
 
@@ -67,72 +75,104 @@ from ramses_rf.protocol.messages import register_payload
 
 ---
 
-### Example 1: Fixed / Multi-Field Payload (e.g. `HeatDemandPayload` - Opcode `3150`)
+### Example 1: Fixed / Single-Layout Payload (e.g. `TemperaturePayload` - Opcode `0002`)
 
 ```python
 # ----------------------------------------------------------------------
 
 
-@register_payload("3150")
+@register_payload("0002")
 @dataclass(frozen=True, slots=True)
-class HeatDemandPayload(PayloadBase):
-    """Heat demand payload (Opcode 3150).
+class TemperaturePayload(PayloadBase):
+    """Temperature reading payload (Opcode 0002).
 
-    2-byte Heat Demand binary layout:
+    3-byte Temperature binary layout:
       Offset  Format  Len  Description                    Sample Hex
       --------------------------------------------------------------
-      +0       B      1B   Domain / Zone Index (uint8)  : 00
-      +1       B      1B   Heat Demand uint8 (0-200)    : 64 (50%)
+      +0       B      1B   Zone Index (uint8)           : 00
+      +1       h      2B   Temperature °C (int16*100)   : 08 34 (21.00°C)
       --------------------------------------------------------------
-      Field-spaced hex : 00 64
-      Payload hex      : 0064
+      Field-spaced hex : 00 0834
+      Payload hex      : 000834
 
-    :param domain_or_zone_idx: Domain or zone index byte.
-    :type domain_or_zone_idx: int
-    :param demand_percent: Heat demand percentage (0.0 - 100.0).
-    :type demand_percent: float
+    :param zone_idx: Zone index byte.
+    :type zone_idx: int
+    :param temperature: Temperature in °C.
+    :type temperature: float | None
     """
 
-    _STRUCT_FMT_2B: ClassVar[str] = ">BB"
+    _STRUCT_FMT: ClassVar[str] = ">Bh"
 
-    domain_or_zone_idx: int
-    demand_percent: float
+    zone_idx: int
+    temperature: float | None
 
     @classmethod
     def from_bytes(cls, raw_data: bytes) -> Self:
         """Unpack raw binary bytes into payload instance."""
-        if len(raw_data) < 2:
-            raise ValueError(f"Invalid payload length for 3150: {len(raw_data)}")
-        idx, demand_raw = struct.unpack_from(cls._STRUCT_FMT_2B, raw_data, 0)
-        return cls(domain_or_zone_idx=idx, demand_percent=demand_raw / 200.0)
+        if len(raw_data) < 3:
+            raise ValueError(
+                f"Invalid payload length for TemperaturePayload: {len(raw_data)}"
+            )
+        idx, temp_raw = struct.unpack_from(cls._STRUCT_FMT, raw_data, 0)
+        temp_val = None if temp_raw in (0x7FFF, 0x31FF) else temp_raw / 100.0
+        return cls(zone_idx=idx, temperature=temp_val)
 
     def to_bytes(self) -> bytes:
         """Pack payload instance into raw binary bytes."""
-        demand_raw = min(200, max(0, int(round(self.demand_percent * 200.0))))
-        return struct.pack(self._STRUCT_FMT_2B, self.domain_or_zone_idx, demand_raw)
+        temp_raw = (
+            0x7FFF if self.temperature is None else int(round(self.temperature * 100.0))
+        )
+        return struct.pack(self._STRUCT_FMT, self.zone_idx, temp_raw)
 
     def to_dict(self) -> dict[str, Any]:
         """Convert payload to legacy dictionary representation."""
         return {
-            "domain_or_zone_idx": f"{self.domain_or_zone_idx:02X}",
-            "heat_demand": self.demand_percent,
+            "zone_idx": f"{self.zone_idx:02X}",
+            "temperature": self.temperature,
         }
 ```
 
 ---
 
-### Example 2: Polymorphic Factory / Multi-Length Payload Grouping (e.g. `DhwParamsPayload` - Opcode `10A0`)
+### Example 2: Polymorphic Master Dispatcher & Sub-Dataclasses (e.g. `DhwParamsPayload` - Opcode `10A0`)
 
 ```python
 # ----------------------------------------------------------------------
 
 
-class DhwParamsBasePayload(PayloadBase, ABC):
-    """Abstract base class for DHW parameters (Opcode 10A0)."""
+@register_payload("10A0")
+class DhwParamsPayload(PayloadBase):
+    """Master payload dispatcher for DHW parameters (Opcode 10A0)."""
+
+    VARIANTS: ClassVar[tuple[type[PayloadBase], ...]] = ()
+
+    dhw_idx: int
+    setpoint: float | None
+    overrun: int | None = None
+    differential: float | None = None
+
+    @classmethod
+    def from_bytes(cls, raw_data: bytes) -> "DhwParams3BPayload | DhwParams6BPayload":
+        """Unpack DHW parameters payload, dispatching by length."""
+        if not raw_data:
+            raise ValueError("Payload data cannot be empty")
+        if len(raw_data) >= 6:
+            return DhwParams6BPayload.from_bytes(raw_data)
+        return DhwParams3BPayload.from_bytes(raw_data)
+
+    def to_bytes(self) -> bytes:
+        """Pack payload base default method.
+
+        :returns: Packed binary payload bytes.
+        :rtype: bytes
+        :raises NotImplementedError: Master dispatcher must dispatch to
+            variant sub-dataclass.
+        """
+        raise NotImplementedError("Use concrete variant sub-dataclass")
 
 
 @dataclass(frozen=True, slots=True)
-class DhwParams3BPayload(DhwParamsBasePayload):
+class DhwParams3BPayload(DhwParamsPayload):
     """DHW 3-byte parameters layout (Opcode 10A0).
 
     3-byte DHW Parameters binary layout:
@@ -157,6 +197,7 @@ class DhwParams3BPayload(DhwParamsBasePayload):
 
     @classmethod
     def from_bytes(cls, raw_data: bytes) -> Self:
+        """Unpack 3-byte DHW parameters binary payload."""
         if len(raw_data) < 3:
             raise ValueError(
                 f"Invalid payload length for DhwParams3BPayload: {len(raw_data)}"
@@ -166,12 +207,13 @@ class DhwParams3BPayload(DhwParamsBasePayload):
         return cls(dhw_idx=idx, setpoint=sp_val)
 
     def to_bytes(self) -> bytes:
+        """Pack 3-byte DHW parameters into binary payload."""
         sp_raw = 0x7FFF if self.setpoint is None else int(round(self.setpoint * 100.0))
         return struct.pack(self._STRUCT_FMT, self.dhw_idx, sp_raw)
 
 
 @dataclass(frozen=True, slots=True)
-class DhwParams6BPayload(DhwParamsBasePayload):
+class DhwParams6BPayload(DhwParamsPayload):
     """DHW 6-byte parameters layout (Opcode 10A0).
 
     6-byte DHW Parameters binary layout:
@@ -204,6 +246,7 @@ class DhwParams6BPayload(DhwParamsBasePayload):
 
     @classmethod
     def from_bytes(cls, raw_data: bytes) -> Self:
+        """Unpack 6-byte DHW parameters binary payload."""
         if len(raw_data) < 6:
             raise ValueError(
                 f"Invalid payload length for DhwParams6BPayload: {len(raw_data)}"
@@ -220,6 +263,7 @@ class DhwParams6BPayload(DhwParamsBasePayload):
         )
 
     def to_bytes(self) -> bytes:
+        """Pack 6-byte DHW parameters into binary payload."""
         sp_raw = 0x7FFF if self.setpoint is None else int(round(self.setpoint * 100.0))
         diff_raw = int(round(self.differential * 100.0))
         return struct.pack(
@@ -227,19 +271,11 @@ class DhwParams6BPayload(DhwParamsBasePayload):
         )
 
 
-@register_payload("10A0")
-class DhwParamsPayload:
-    """Master payload dispatcher for Opcode 10A0."""
-
-    @classmethod
-    def from_bytes(cls, raw_data: bytes) -> DhwParams3BPayload | DhwParams6BPayload:
-        """Unpack DHW parameters payload, dispatching by length."""
-        if len(raw_data) >= 6:
-            return DhwParams6BPayload.from_bytes(raw_data)
-        return DhwParams3BPayload.from_bytes(raw_data)
-
-
-# ----------------------------------------------------------------------
+# Update VARIANTS property after variants are defined
+DhwParamsPayload.VARIANTS = (
+    DhwParams3BPayload,
+    DhwParams6BPayload,
+)
 ```
 
 ---
@@ -300,7 +336,9 @@ class ZoneConfigPayload(PayloadBase):
     def from_bytes(cls, raw_data: bytes) -> Self | list[Self]:
         """Unpack single or multi-zone array payload."""
         if len(raw_data) < 6 or len(raw_data) % 6 != 0:
-            raise ValueError(f"Invalid payload length for 000A: {len(raw_data)}")
+            raise ValueError(
+                f"Invalid payload length for ZoneConfigPayload: {len(raw_data)}"
+            )
         if len(raw_data) > 6:
             return [
                 cls._from_bytes_single(raw_data, i) for i in range(0, len(raw_data), 6)
@@ -308,38 +346,36 @@ class ZoneConfigPayload(PayloadBase):
         return cls._from_bytes_single(raw_data, 0)
 
     def to_bytes(self) -> bytes:
+        """Pack zone config into binary payload."""
         min_raw = 0x7FFF if self.min_temp is None else int(round(self.min_temp * 100.0))
         max_raw = 0x7FFF if self.max_temp is None else int(round(self.max_temp * 100.0))
         return struct.pack(
             self._STRUCT_FMT, self.zone_idx, self.zone_flags, min_raw, max_raw
         )
-
-
-# ----------------------------------------------------------------------
 ```
 
 ---
 
 ## 5. Mandatory Requirements Checklist
 
-1. **Class Decorators**:
-   - Master Dispatchers decoration: `@register_payload("<OPCODE>")`.
-   - All concrete payload sub-dataclasses MUST be decorated with `@dataclass(frozen=True, slots=True)`.
+1. **Class Decorators & Exclusivity**:
+   - Single-layout classes: `@register_payload("<OPCODE>")` and `@dataclass(frozen=True, slots=True)`.
+   - Multi-variant opcodes: Exactly **one** Master Dispatcher carries `@register_payload("<OPCODE>")`. Sub-dataclasses inherit from the Master Dispatcher and carry `@dataclass(frozen=True, slots=True)`. Sub-dataclasses must **never** be decorated with `@register_payload`.
 
 2. **Declarative Format String Constants**:
    - Concrete sub-dataclasses MUST declare explicit `_STRUCT_FMT: ClassVar[str]` specifiers for multi-byte layouts (Big-Endian `>` or Little-Endian `<`).
 
-3. **Method Implementation & Boundary Adapter**:
-   - `@classmethod from_bytes(cls, raw_data: bytes)`: Must unpack raw binary data.
-   - `to_bytes(self) -> bytes`: Must serialize attributes back into exact raw binary payload bytes.
-   - `to_dict(self) -> dict[str, Any]`: The `PayloadBase.to_dict()` adapter automatically calls `dataclasses.asdict()`. You MUST NOT override `to_dict()` unless the legacy downstream parity tests strictly require converting specific integer fields into zero-padded hex strings (e.g. `f"{self.zone_idx:02X}"`). In all other cases, rely on the base class adapter.
+3. **Method Implementation & Length Guards**:
+   - `@classmethod from_bytes(cls, raw_data: bytes)`: Must unpack raw binary data and include an explicit length guard (`if len(raw_data) < N: raise ValueError(...)`).
+   - `to_bytes(self) -> bytes`: Must serialize attributes back into exact raw binary payload bytes using `struct.pack`.
+   - `to_dict(self) -> dict[str, Any]`: The `PayloadBase.to_dict()` adapter automatically calls `dataclasses.asdict()`. You MUST NOT override `to_dict()` unless downstream legacy test compatibility strictly requires field key or hex formatting transforms.
 
 4. **Docstring BOFM Table & Group Comment Separators**:
-   - All concrete payload dataclasses MUST include a Sphinx docstring with a formatted **Binary Offset Format Map (BOFM)** table specifying `Offset`, `Format`, `Len`, `Description`, and `Sample Hex`.
+   - All concrete payload dataclasses MUST include a Sphinx docstring with a formatted **Binary Offset Format Map (BOFM)** table specifying `Offset`, `Format`, `Len`, `Description`, and valid protocol `Sample Hex` that round-trips cleanly.
    - Docstring lines MUST comply with PEP 8 standards (<= 72 characters).
    - Master Dispatcher classes and associated sub-dataclasses MUST be grouped together and separated using `# ` + 70 `-` characters (`# ----------------------------------------------------------------------`).
 
-   ---
+---
 
 ## 6. C Struct Format Conventions
 
@@ -360,4 +396,5 @@ class ZoneConfigPayload(PayloadBase):
 All payload dataclass implementations must pass strict code verification:
 * **Format & Linting**: `.venv/bin/prek run -a` and `.venv/bin/ruff check --select D <file.py>` (Sphinx docstring checks).
 * **Strict Type Checking**: `.venv/bin/mypy --strict src/ tests/`.
-* **Parity & Structure Suite**: `.venv/bin/pytest tests/tests_rf/test_payload_structure.py tests/tests_rf/test_payload_parity.py`.
+* **Parity & Structure Suite**: `.venv/bin/pytest tests/tests_rf/test_payload_structure.py tests/tests_rf/test_payload_parity.py tests/tests_rf/test_payload_codecs.py`.
+

--- a/src/ramses_rf/commands/builders/dhw.py
+++ b/src/ramses_rf/commands/builders/dhw.py
@@ -9,8 +9,7 @@ from ramses_rf.commands.builders.helpers import (
 from ramses_rf.commands.core import Command
 from ramses_rf.const import SZ_DHW_IDX, ZON_MODE_MAP
 from ramses_rf.enums import DevType
-from ramses_rf.payloads.dhw import DhwParamsPayload
-from ramses_rf.payloads.heating import DhwTemperaturePayload
+from ramses_rf.payloads.dhw import DhwParamsPayload, DhwTempPayload
 from ramses_tx.const import DEFAULT_NUM_REPEATS, I_, RQ, W_, Code, Priority
 from ramses_tx.dtos import CommandDTO
 from ramses_tx.helpers import hex_from_dtm
@@ -102,7 +101,7 @@ def build_put_dhw_temp(intent: Command) -> CommandDTO:
 
     # I_ requires addr0=src, addr2=dst (which are the same for put_dhw_temp)
     addr1, addr2, addr3 = resolve_addrs(intent.src, intent.src)
-    payload = DhwTemperaturePayload(dhw_idx=dhw_idx, temperature=temperature).hex()
+    payload = DhwTempPayload(dhw_idx=dhw_idx, temperature=temperature).hex()
 
     return CommandDTO(
         verb=I_,

--- a/src/ramses_rf/commands/builders/heat.py
+++ b/src/ramses_rf/commands/builders/heat.py
@@ -2,7 +2,8 @@
 
 from ramses_rf.commands.builders.helpers import resolve_addrs
 from ramses_rf.commands.core import Command
-from ramses_rf.payloads.heating import DhwTemperaturePayload, TemperaturePayload
+from ramses_rf.payloads.dhw import DhwTempPayload
+from ramses_rf.payloads.heating import TemperaturePayload
 from ramses_tx.const import DEFAULT_NUM_REPEATS, I_, Code, Priority
 from ramses_tx.dtos import CommandDTO
 
@@ -28,7 +29,7 @@ def build_put_outdoor_temp(intent: Command) -> CommandDTO:
 def build_put_dhw_temp(intent: Command) -> CommandDTO:
     """Translate a PUT_DHW_TEMP intent into a CommandDTO."""
     temperature = intent.get("temperature")
-    payload = DhwTemperaturePayload(dhw_idx=0, temperature=temperature).hex()
+    payload = DhwTempPayload(dhw_idx=0, temperature=temperature).hex()
     addr1, addr2, addr3 = resolve_addrs(intent.src, intent.dst)
 
     return CommandDTO(

--- a/src/ramses_rf/payloads/__init__.py
+++ b/src/ramses_rf/payloads/__init__.py
@@ -9,7 +9,6 @@ from .base import PayloadBase
 from .dhw import DhwConfigPayload, DhwParamsPayload, DhwStatePayload
 from .heating import (
     BindingPayload,
-    DhwTemperaturePayload,
     FlowTempPayload,
     HeatDemandPayload,
     OutdoorTempPayload,
@@ -95,7 +94,6 @@ __all__ = [
     "DhwConfigPayload",
     "DhwParamsPayload",
     "DhwStatePayload",
-    "DhwTemperaturePayload",
     "FanModePayload",
     "FlowTempPayload",
     "HeatDemandPayload",
@@ -146,7 +144,6 @@ __all__ = [
     "SystemFaultLogPayload",
     "SystemFaultPayload",
     "SystemFlagPayload",
-    "SystemLanguagePayload",
     "SystemLanguagePayload",
     "SystemLogIndexPayload",
     "SystemOpenThermBridgePayload",

--- a/src/ramses_rf/payloads/dhw.py
+++ b/src/ramses_rf/payloads/dhw.py
@@ -5,7 +5,6 @@ Domestic Hot Water packet payloads.
 """
 
 import struct
-from abc import ABC
 from dataclasses import dataclass
 from typing import Any, ClassVar, Self
 
@@ -43,8 +42,13 @@ class DhwTempPayload(PayloadBase):
 
     _STRUCT_FMT: ClassVar[str] = ">Bh"
 
-    dhw_idx: int
-    temperature: float | None
+    dhw_idx: int | str = 0
+    temperature: float | None = None
+
+    def __post_init__(self) -> None:
+        """Normalise index arguments."""
+        if isinstance(self.dhw_idx, str):
+            object.__setattr__(self, "dhw_idx", parse_idx(self.dhw_idx))
 
     @classmethod
     def from_bytes(cls, raw_data: bytes) -> Self:
@@ -68,11 +72,12 @@ class DhwTempPayload(PayloadBase):
         :returns: Packed binary payload bytes.
         :rtype: bytes
         """
+        idx = parse_idx(self.dhw_idx)
         if self.temperature is None:
             temp_raw = 0x7FFF
         else:
             temp_raw = int(round(self.temperature * 100.0))
-        return struct.pack(self._STRUCT_FMT, self.dhw_idx, temp_raw)
+        return struct.pack(self._STRUCT_FMT, idx, temp_raw)
 
     def to_dict(self) -> dict[str, Any]:
         """Convert DHW temperature payload to legacy dictionary layout.
@@ -211,12 +216,8 @@ class DhwConfigPayload(PayloadBase):
 # ----------------------------------------------------------------------
 
 
-class DhwParamsBasePayload(PayloadBase, ABC):
-    """Abstract base class for DHW parameters (Opcode 10A0)."""
-
-
 @register_payload("10A0")
-class DhwParamsPayload(DhwParamsBasePayload):
+class DhwParamsPayload(PayloadBase):
     """Master payload dispatcher for DHW parameters (Opcode 10A0).
 
     Dispatches DHW parameters binary payloads to 3-byte or 6-byte
@@ -248,6 +249,11 @@ class DhwParamsPayload(DhwParamsBasePayload):
     """
 
     VARIANTS: ClassVar[tuple[type[PayloadBase], ...]] = ()
+
+    dhw_idx: int | str
+    setpoint: float | None
+    overrun: int | None = None
+    differential: float | None = None
 
     def __new__(
         cls,
@@ -288,7 +294,7 @@ class DhwParamsPayload(DhwParamsBasePayload):
 
 
 @dataclass(frozen=True, slots=True)
-class DhwParams3BPayload(DhwParamsBasePayload):
+class DhwParams3BPayload(DhwParamsPayload):
     """DHW 3-byte parameters payload (Opcode 10A0).
 
     3-byte DHW Parameters binary layout:
@@ -304,12 +310,23 @@ class DhwParams3BPayload(DhwParamsBasePayload):
     :type dhw_idx: int
     :param setpoint: Target setpoint temperature in °C, or None.
     :type setpoint: float | None
+    :param overrun: Overrun minutes (None for 3B payload).
+    :type overrun: int | None
+    :param differential: Differential °C (None for 3B payload).
+    :type differential: float | None
     """
 
     _STRUCT_FMT: ClassVar[str] = ">Bh"
 
-    dhw_idx: int
-    setpoint: float | None
+    dhw_idx: int | str = 0
+    setpoint: float | None = None
+    overrun: int | None = None
+    differential: float | None = None
+
+    def __post_init__(self) -> None:
+        """Normalise index arguments."""
+        if isinstance(self.dhw_idx, str):
+            object.__setattr__(self, "dhw_idx", parse_idx(self.dhw_idx))
 
     @classmethod
     def from_bytes(cls, raw_data: bytes) -> Self:
@@ -324,8 +341,9 @@ class DhwParams3BPayload(DhwParamsBasePayload):
 
     def to_bytes(self) -> bytes:
         """Pack 3-byte DHW parameters into binary payload."""
+        idx = parse_idx(self.dhw_idx)
         sp_raw = 0x7FFF if self.setpoint is None else int(round(self.setpoint * 100.0))
-        return struct.pack(self._STRUCT_FMT, self.dhw_idx, sp_raw)
+        return struct.pack(self._STRUCT_FMT, idx, sp_raw)
 
     def to_dict(self) -> dict[str, Any]:
         """Convert 3-byte DHW parameters payload to legacy dictionary layout."""
@@ -333,7 +351,7 @@ class DhwParams3BPayload(DhwParamsBasePayload):
 
 
 @dataclass(frozen=True, slots=True)
-class DhwParams6BPayload(DhwParamsBasePayload):
+class DhwParams6BPayload(DhwParamsPayload):
     """DHW 6-byte parameters payload (Opcode 10A0).
 
     6-byte DHW Parameters binary layout:
@@ -359,10 +377,15 @@ class DhwParams6BPayload(DhwParamsBasePayload):
 
     _STRUCT_FMT: ClassVar[str] = ">BhBh"
 
-    dhw_idx: int
-    setpoint: float | None
-    overrun: int
-    differential: float
+    dhw_idx: int | str = 0
+    setpoint: float | None = None
+    overrun: int = 0
+    differential: float = 0.0
+
+    def __post_init__(self) -> None:
+        """Normalise index arguments."""
+        if isinstance(self.dhw_idx, str):
+            object.__setattr__(self, "dhw_idx", parse_idx(self.dhw_idx))
 
     @classmethod
     def from_bytes(cls, raw_data: bytes) -> Self:
@@ -384,11 +407,10 @@ class DhwParams6BPayload(DhwParamsBasePayload):
 
     def to_bytes(self) -> bytes:
         """Pack 6-byte DHW parameters into binary payload."""
+        idx = parse_idx(self.dhw_idx)
         sp_raw = 0x7FFF if self.setpoint is None else int(round(self.setpoint * 100.0))
         diff_raw = int(round(self.differential * 100.0))
-        return struct.pack(
-            self._STRUCT_FMT, self.dhw_idx, sp_raw, self.overrun, diff_raw
-        )
+        return struct.pack(self._STRUCT_FMT, idx, sp_raw, self.overrun, diff_raw)
 
     def to_dict(self) -> dict[str, Any]:
         """Convert 6-byte DHW parameters payload to legacy dictionary layout."""

--- a/src/ramses_rf/payloads/heating.py
+++ b/src/ramses_rf/payloads/heating.py
@@ -5,7 +5,6 @@ packet payloads.
 """
 
 import struct
-from abc import ABC
 from dataclasses import dataclass
 from datetime import datetime as dt
 from typing import Any, ClassVar, Self, cast
@@ -25,16 +24,140 @@ from ramses_tx.helpers import hex_from_dtm, hex_to_dtm, hex_to_percent
 from ramses_tx.typing import DeviceIdT
 
 from .base import PayloadBase, parse_idx
-from .dhw import DhwParamsBasePayload, DhwParamsPayload
 from .registry import register_payload
 
 # ----------------------------------------------------------------------
 
 
 @register_payload("3150")
-@dataclass(frozen=True, slots=True)
 class HeatDemandPayload(PayloadBase):
-    """Heat demand payload (Opcode 3150).
+    """Master payload dispatcher for heat demand (Opcode 3150)."""
+
+    VARIANTS: ClassVar[tuple[type[PayloadBase], ...]] = ()
+
+    domain_or_zone_idx: int | None
+    demand_percent: int
+    raw_extra: bytes | None
+
+    def __new__(
+        cls,
+        domain_or_zone_idx: int | None = None,
+        demand_percent: int = 0,
+        raw_extra: bytes | None = None,
+        _is_array_item: bool = False,
+    ) -> Any:
+        """Construct HeatDemand payload variant dynamically."""
+        if cls is not HeatDemandPayload:
+            return super().__new__(cls)
+        if domain_or_zone_idx is not None:
+            return HeatDemand2BPayload(
+                domain_or_zone_idx=domain_or_zone_idx,
+                demand_percent=demand_percent,
+                raw_extra=raw_extra,
+                _is_array_item=_is_array_item,
+            )
+        return HeatDemand1BPayload(demand_percent=demand_percent)
+
+    @classmethod
+    def from_bytes(
+        cls, raw_data: bytes
+    ) -> "HeatDemandPayload | list[HeatDemandPayload]":
+        """Unpack heat demand payload, dispatching by length."""
+        if not raw_data:
+            raise ValueError("Payload data cannot be empty")
+        if len(raw_data) >= 4 and len(raw_data) % 2 == 0:
+            return [
+                HeatDemand2BPayload(
+                    domain_or_zone_idx=idx,
+                    demand_percent=demand,
+                    _is_array_item=True,
+                )
+                for idx, demand in (
+                    struct.unpack_from(">BB", raw_data, i)
+                    for i in range(0, len(raw_data), 2)
+                )
+            ]
+        if len(raw_data) == 1:
+            return HeatDemand1BPayload.from_bytes(raw_data)
+        return HeatDemand2BPayload.from_bytes(raw_data)
+
+    def to_bytes(self) -> bytes:
+        """Pack payload base default method.
+
+        :returns: Packed binary payload bytes.
+        :rtype: bytes
+        :raises NotImplementedError: Master dispatcher must dispatch to
+            variant sub-dataclass.
+        """
+        raise NotImplementedError("Use concrete variant sub-dataclass")
+
+
+@dataclass(frozen=True, slots=True)
+class HeatDemand1BPayload(HeatDemandPayload):
+    """1-byte heat demand payload (Opcode 3150).
+
+    1-byte Heat Demand binary layout:
+      Offset  Format  Len  Description                    Sample Hex
+      --------------------------------------------------------------
+      +0       B      1B   Heat demand percentage (uint8) : C8 (200)
+      --------------------------------------------------------------
+      Field-spaced hex : C8
+      Payload hex      : C8
+
+    :param demand_percent: Heat demand value (0-200, where 200 = 100%).
+    :type demand_percent: int
+    """
+
+    _STRUCT_FMT: ClassVar[str] = ">B"
+
+    demand_percent: int
+    domain_or_zone_idx: int | None = None
+    raw_extra: bytes | None = None
+
+    @classmethod
+    def from_bytes(cls, raw_data: bytes) -> Self:
+        """Unpack 1-byte heat demand binary payload.
+
+        :param raw_data: Raw binary byte string.
+        :type raw_data: bytes
+        :returns: Unpacked HeatDemand1BPayload instance.
+        :rtype: Self
+        :raises ValueError: If raw_data length is less than 1 byte.
+        """
+        if len(raw_data) < 1:
+            raise ValueError(
+                f"Invalid payload length for HeatDemand1BPayload: {len(raw_data)}"
+            )
+        (demand,) = struct.unpack_from(cls._STRUCT_FMT, raw_data, 0)
+        return cls(demand_percent=demand)
+
+    def to_bytes(self) -> bytes:
+        """Pack 1-byte heat demand binary payload.
+
+        :returns: Packed binary payload bytes.
+        :rtype: bytes
+        """
+        return struct.pack(self._STRUCT_FMT, self.demand_percent & 0xFF)
+
+    def to_dict(self, msg: Any = None) -> dict[str, Any]:
+        """Convert 1-byte heat demand payload to legacy dictionary layout.
+
+        :param msg: Optional message context object.
+        :type msg: Any
+        :returns: Decoded heat demand dictionary.
+        :rtype: dict[str, Any]
+        """
+        if self.demand_percent == 0xF2:
+            return {"heat_demand_fault": "unavailable"}
+        val = self.demand_percent / 200.0
+        if val == 1.01:
+            val = 1.0
+        return {"heat_demand": val}
+
+
+@dataclass(frozen=True, slots=True)
+class HeatDemand2BPayload(HeatDemandPayload):
+    """2-byte heat demand payload (Opcode 3150).
 
     2-byte Heat Demand binary layout:
       Offset  Format  Len  Description                    Sample Hex
@@ -46,82 +169,53 @@ class HeatDemandPayload(PayloadBase):
       Payload hex      : 00C8
 
     :param domain_or_zone_idx: Domain or zone index byte.
-    :type domain_or_zone_idx: int | None
+    :type domain_or_zone_idx: int
     :param demand_percent: Heat demand value (0-200, where 200 = 100%).
     :type demand_percent: int
     :param raw_extra: Optional raw extra bytes.
     :type raw_extra: bytes | None
-
-    Sample Packet Logs & Protocol Notes:
-    # .I --- 04:136513 --:------ 01:158182 3150 002 01CA  # often seen CA, artefact?
-    # .I --- 02:000921 --:------ 01:191718 3150 002 0360
-    # TODO: all have a valid domain will UFC/CTL respond to an RQ,
-    # 8 for UFC
-    # .I --- 02:001107 --:------ 02:001107 22C9 024 00-0834-0A28-01-0108340A2801-0208340A2801-0308340A2801  # noqa: E501
     """
 
-    _STRUCT_FMT_2B: ClassVar[str] = ">BB"
+    _STRUCT_FMT: ClassVar[str] = ">BB"
 
-    domain_or_zone_idx: int | None
+    domain_or_zone_idx: int
     demand_percent: int
     raw_extra: bytes | None = None
     _is_array_item: bool = False
 
     @classmethod
-    def from_bytes(cls, raw_data: bytes) -> Self | list[Self]:
-        """Unpack a 1-byte, 2-byte, or multi-byte heat demand payload.
+    def from_bytes(cls, raw_data: bytes) -> Self:
+        """Unpack 2-byte heat demand binary payload.
 
         :param raw_data: Raw binary byte string.
         :type raw_data: bytes
-        :returns: Unpacked HeatDemandPayload instance or list of instances.
-        :rtype: Self | list[Self]
-        :raises ValueError: If raw_data is empty.
+        :returns: Unpacked HeatDemand2BPayload instance.
+        :rtype: Self
+        :raises ValueError: If raw_data length is less than 2 bytes.
         """
-        if not raw_data:
-            raise ValueError("Payload data cannot be empty")
-        if len(raw_data) >= 4 and len(raw_data) % 2 == 0:
-            return [
-                cls(
-                    domain_or_zone_idx=idx,
-                    demand_percent=demand,
-                    _is_array_item=True,
-                )
-                for idx, demand in (
-                    struct.unpack_from(cls._STRUCT_FMT_2B, raw_data, i)
-                    for i in range(0, len(raw_data), 2)
-                )
-            ]
-
-        if len(raw_data) == 1:
-            return cls(domain_or_zone_idx=None, demand_percent=raw_data[0])
-        idx, demand = struct.unpack_from(cls._STRUCT_FMT_2B, raw_data, 0)
+        if len(raw_data) < 2:
+            raise ValueError(
+                f"Invalid payload length for HeatDemand2BPayload: {len(raw_data)}"
+            )
+        idx, demand = struct.unpack_from(cls._STRUCT_FMT, raw_data, 0)
         extra = raw_data[2:] if len(raw_data) > 2 else None
-        return cls(
-            domain_or_zone_idx=idx,
-            demand_percent=demand,
-            raw_extra=extra,
-        )
+        return cls(domain_or_zone_idx=idx, demand_percent=demand, raw_extra=extra)
 
     def to_bytes(self) -> bytes:
-        """Pack heat demand data into a binary payload.
+        """Pack 2-byte heat demand binary payload.
 
         :returns: Packed binary payload bytes.
         :rtype: bytes
         """
-        if self.domain_or_zone_idx is not None:
-            buf = struct.pack(
-                self._STRUCT_FMT_2B,
-                self.domain_or_zone_idx,
-                self.demand_percent & 0xFF,
-            )
-        else:
-            buf = bytes([self.demand_percent & 0xFF])
+        buf = struct.pack(
+            self._STRUCT_FMT, self.domain_or_zone_idx, self.demand_percent & 0xFF
+        )
         if self.raw_extra is not None:
             buf += self.raw_extra
         return buf
 
     def to_dict(self, msg: Any = None) -> dict[str, Any]:
-        """Convert heat demand payload to legacy dictionary layout.
+        """Convert 2-byte heat demand payload to legacy dictionary layout.
 
         :param msg: Optional message context object.
         :type msg: Any
@@ -135,22 +229,28 @@ class HeatDemandPayload(PayloadBase):
             if val == 1.01:
                 val = 1.0
             res = {"heat_demand": val}
-        if self.domain_or_zone_idx is not None:
-            idx = self.domain_or_zone_idx
-            if idx >= 0xF0:
-                res["domain_id"] = "FC" if idx == 0xFC else f"{idx:02X}"
-            else:
-                is_ufc = False
-                if msg is not None and getattr(msg, "src", None) is not None:
-                    src_str = str(getattr(msg.src, "id", msg.src))
-                    if src_str.startswith("02:") or getattr(msg.src, "type", "") in (
-                        "02",
-                        "UFC",
-                    ):
-                        is_ufc = True
-                idx_name = "ufx_idx" if is_ufc else "zone_idx"
-                res[idx_name] = f"{idx:02X}"
+        idx = self.domain_or_zone_idx
+        if idx >= 0xF0:
+            res["domain_id"] = "FC" if idx == 0xFC else f"{idx:02X}"
+        else:
+            is_ufc = False
+            if msg is not None and getattr(msg, "src", None) is not None:
+                src_str = str(getattr(msg.src, "id", msg.src))
+                if src_str.startswith("02:") or getattr(msg.src, "type", "") in (
+                    "02",
+                    "UFC",
+                ):
+                    is_ufc = True
+            idx_name = "ufx_idx" if is_ufc else "zone_idx"
+            res[idx_name] = f"{idx:02X}"
         return res
+
+
+# Update VARIANTS property after variants are defined
+HeatDemandPayload.VARIANTS = (
+    HeatDemand1BPayload,
+    HeatDemand2BPayload,
+)
 
 
 # ----------------------------------------------------------------------
@@ -334,7 +434,6 @@ TemperaturePayload.VARIANTS = (
 )
 
 
-@register_payload("1030")
 @dataclass(frozen=True, slots=True)
 class ScheduleFragmentPayload(PayloadBase):
     """Schedule fragment payload (Opcode 0404, 1030 fragment).
@@ -569,170 +668,6 @@ class ScheduleSwitchpointPayload(PayloadBase):
             self.setpoint_value,
             0,  # Reserved / trailer 2-byte field (0x0000)
         )
-
-
-# ----------------------------------------------------------------------
-
-
-@register_payload("10A0")
-class DhwTemperaturePayload(PayloadBase):
-    """Master payload dispatcher and base class for Opcode 10A0."""
-
-    VARIANTS: ClassVar[tuple[type[PayloadBase], ...]] = ()
-
-    dhw_idx: int | str | None
-    temperature: float | bool | None
-
-    def __new__(
-        cls,
-        dhw_idx: int | str | None = None,
-        temperature: float | bool | None = None,
-    ) -> Any:
-        """Construct DhwTemperature payload variant dynamically from arguments."""
-        if cls is not DhwTemperaturePayload:
-            return super().__new__(cls)
-        if dhw_idx is not None:
-            return DhwTemperature3BPayload(dhw_idx=dhw_idx, temperature=temperature)
-        return DhwTemperature2BPayload(temperature=temperature)
-
-    @classmethod
-    def _parse_temp_val(cls, temp_raw: int) -> float | bool | None:
-        """Decode raw 16-bit signed integer to DHW temperature value."""
-        if temp_raw in (0x31FF, 0x7FFF, 0x639C):
-            return None
-        if temp_raw == 0x7EFF:
-            return False
-        return temp_raw / 100.0
-
-    @classmethod
-    def from_bytes(
-        cls, raw_data: bytes
-    ) -> "DhwTemperaturePayload | DhwParamsBasePayload":
-        """Unpack DHW temperature or parameters binary payload."""
-        if len(raw_data) >= 6:
-            return DhwParamsPayload.from_bytes(raw_data)
-        if len(raw_data) == 2:
-            return DhwTemperature2BPayload.from_bytes(raw_data)
-        if len(raw_data) >= 3:
-            return DhwTemperature3BPayload.from_bytes(raw_data)
-        raise ValueError(f"Invalid payload length for 10A0: {len(raw_data)}")
-
-    def to_bytes(self) -> bytes:
-        """Pack payload base default method.
-
-        :returns: Packed binary payload bytes.
-        :rtype: bytes
-        :raises NotImplementedError: Master dispatcher must dispatch to
-            variant sub-dataclass.
-        """
-        raise NotImplementedError("Use concrete variant sub-dataclass")
-
-
-@dataclass(frozen=True, slots=True)
-class DhwTemperature2BPayload(DhwTemperaturePayload):
-    """2-byte DHW temperature payload (Opcode 10A0).
-
-    2-byte DHW Temp binary layout:
-      Offset  Format  Len  Description                    Sample Hex
-      --------------------------------------------------------------
-      +0       h      2B   Temperature (int16, degC*100): 0E D8 (38.00°C)
-      --------------------------------------------------------------
-      Field-spaced hex : 0ED8
-      Payload hex      : 0ED8
-
-    :param temperature: DHW temperature in °C, False if disabled, or None.
-    :type temperature: float | bool | None
-    """
-
-    _STRUCT_FMT: ClassVar[str] = ">h"
-
-    temperature: float | bool | None
-
-    @classmethod
-    def from_bytes(cls, raw_data: bytes) -> Self:
-        """Unpack 2-byte DHW temperature binary payload."""
-        if len(raw_data) < 2:
-            raise ValueError(
-                f"Invalid payload length for DhwTemperature2BPayload: {len(raw_data)}"
-            )
-        (temp_raw,) = struct.unpack_from(cls._STRUCT_FMT, raw_data, 0)
-        return cls(temperature=cls._parse_temp_val(temp_raw))
-
-    def to_bytes(self) -> bytes:
-        """Pack 2-byte DHW temperature binary payload."""
-        if self.temperature is None:
-            temp_raw = 0x7FFF
-        elif self.temperature is False:
-            temp_raw = 0x7EFF
-        else:
-            temp_raw = int(round(self.temperature * 100.0))
-        return struct.pack(self._STRUCT_FMT, temp_raw)
-
-    def to_dict(self) -> dict[str, Any]:
-        """Convert 2-byte DHW temperature payload to legacy dictionary layout."""
-        return {"setpoint": self.temperature}
-
-
-@dataclass(frozen=True, slots=True)
-class DhwTemperature3BPayload(DhwTemperaturePayload):
-    """3-byte DHW temperature payload (Opcode 10A0).
-
-    3-byte DHW Temp binary layout:
-      Offset  Format  Len  Description                    Sample Hex
-      --------------------------------------------------------------
-      +0       B      1B   DHW Index (uint8)            : 00
-      +1       h      2B   Temperature (int16, degC*100): 0E D8 (38.00°C)
-      --------------------------------------------------------------
-      Field-spaced hex : 00 0ED8
-      Payload hex      : 000ED8
-
-    :param dhw_idx: DHW index byte.
-    :type dhw_idx: int | str
-    :param temperature: DHW temperature in °C, False if disabled, or None.
-    :type temperature: float | bool | None
-    """
-
-    _STRUCT_FMT: ClassVar[str] = ">Bh"
-
-    dhw_idx: int | str
-    temperature: float | bool | None
-
-    def __post_init__(self) -> None:
-        """Normalise index arguments."""
-        if isinstance(self.dhw_idx, str):
-            object.__setattr__(self, "dhw_idx", parse_idx(self.dhw_idx))
-
-    @classmethod
-    def from_bytes(cls, raw_data: bytes) -> Self:
-        """Unpack 3-byte DHW temperature binary payload."""
-        if len(raw_data) < 3:
-            raise ValueError(
-                f"Invalid payload length for DhwTemperature3BPayload: {len(raw_data)}"
-            )
-        idx, temp_raw = struct.unpack_from(cls._STRUCT_FMT, raw_data, 0)
-        return cls(dhw_idx=idx, temperature=cls._parse_temp_val(temp_raw))
-
-    def to_bytes(self) -> bytes:
-        """Pack 3-byte DHW temperature binary payload."""
-        if self.temperature is None:
-            temp_raw = 0x7FFF
-        elif self.temperature is False:
-            temp_raw = 0x7EFF
-        else:
-            temp_raw = int(round(self.temperature * 100.0))
-        idx = parse_idx(self.dhw_idx)
-        return struct.pack(self._STRUCT_FMT, idx, temp_raw)
-
-    def to_dict(self) -> dict[str, Any]:
-        """Convert 3-byte DHW temperature payload to legacy dictionary layout."""
-        return {"setpoint": self.temperature}
-
-
-# Update VARIANTS property after variants are defined
-DhwTemperaturePayload.VARIANTS = (
-    DhwTemperature2BPayload,
-    DhwTemperature3BPayload,
-)
 
 
 # ----------------------------------------------------------------------
@@ -1268,9 +1203,56 @@ class ZoneConfigPayload(PayloadBase):
         }
 
 
-@dataclass(frozen=True, slots=True)
+@register_payload("0004")
 class ZoneNamePayload(PayloadBase):
-    """Zone name payload (Opcode 0004 W / 0004 RP name variant).
+    """Master payload dispatcher for zone name (Opcode 0004)."""
+
+    VARIANTS: ClassVar[tuple[type[PayloadBase], ...]] = ()
+
+    zone_idx: int | str
+    name: str | None
+    setpoint_temp: float | None
+
+    def __new__(
+        cls,
+        zone_idx: int | str = 0,
+        name: str | None = None,
+        setpoint_temp: float | None = None,
+    ) -> Any:
+        """Construct ZoneName payload variant dynamically."""
+        if cls is not ZoneNamePayload:
+            return super().__new__(cls)
+        if setpoint_temp is not None:
+            return ZoneNameShort3BPayload(
+                zone_idx=zone_idx, setpoint_temp=setpoint_temp
+            )
+        return ZoneName22BPayload(zone_idx=zone_idx, name=name)
+
+    @classmethod
+    def from_bytes(
+        cls, raw_data: bytes
+    ) -> "ZoneName22BPayload | ZoneNameShort3BPayload":
+        """Unpack zone name payload, dispatching by length."""
+        if len(raw_data) >= 22:
+            return ZoneName22BPayload.from_bytes(raw_data)
+        if len(raw_data) >= 3:
+            return ZoneNameShort3BPayload.from_bytes(raw_data)
+        raise ValueError(f"Invalid payload length for 0004: {len(raw_data)}")
+
+    def to_bytes(self) -> bytes:
+        """Pack payload base default method.
+
+        :returns: Packed binary payload bytes.
+        :rtype: bytes
+        :raises NotImplementedError: Master dispatcher must dispatch to
+            variant sub-dataclass.
+        """
+        raise NotImplementedError("Use concrete variant sub-dataclass")
+
+
+@dataclass(frozen=True, slots=True)
+class ZoneName22BPayload(ZoneNamePayload):
+    """22-byte zone name payload (Opcode 0004).
 
     22-byte Zone Name binary layout:
       Offset  Format  Len  Description                    Sample Hex
@@ -1285,10 +1267,7 @@ class ZoneNamePayload(PayloadBase):
     :param zone_idx: Zone index byte.
     :type zone_idx: int | str
     :param name: ASCII Zone Name string (max 20 chars).
-    :type name: str
-
-    Domain Notes:
-    # RQ payload is zz00; limited to 12 chars in evohome UI? if "7F"*20: not a zone
+    :type name: str | None
     """
 
     _STRUCT_FMT: ClassVar[str] = ">Bx20s"
@@ -1303,19 +1282,18 @@ class ZoneNamePayload(PayloadBase):
 
     @classmethod
     def from_bytes(cls, raw_data: bytes) -> Self:
-        """Unpack zone name binary payload.
+        """Unpack 22-byte zone name binary payload.
 
         :param raw_data: Raw binary byte string.
         :type raw_data: bytes
-        :returns: Unpacked ZoneNamePayload instance.
+        :returns: Unpacked ZoneName22BPayload instance.
         :rtype: Self
         :raises ValueError: If raw_data length is less than 22 bytes.
         """
         if len(raw_data) < 22:
             raise ValueError(
-                f"Invalid payload length for ZoneNamePayload: {len(raw_data)}"
+                f"Invalid payload length for ZoneName22BPayload: {len(raw_data)}"
             )
-        # Unpack zone_idx (uint8), skip 1 pad byte, and extract 20-byte string
         idx, name_raw = struct.unpack_from(cls._STRUCT_FMT, raw_data, 0)
         if name_raw == b"\x7f" * 20:
             name = None
@@ -1324,7 +1302,7 @@ class ZoneNamePayload(PayloadBase):
         return cls(zone_idx=idx, name=name)
 
     def to_bytes(self) -> bytes:
-        """Pack zone name data into binary payload.
+        """Pack 22-byte zone name data into binary payload.
 
         :returns: Packed binary payload bytes.
         :rtype: bytes
@@ -1338,7 +1316,7 @@ class ZoneNamePayload(PayloadBase):
         return struct.pack(self._STRUCT_FMT, idx, name_bytes)
 
     def to_dict(self) -> dict[str, Any]:
-        """Convert zone name payload to legacy dictionary layout.
+        """Convert 22-byte zone name payload to legacy dictionary layout.
 
         :returns: Decoded zone name dictionary.
         :rtype: dict[str, Any]
@@ -1351,13 +1329,9 @@ class ZoneNamePayload(PayloadBase):
         return {"zone_idx": idx_str, "name": self.name}
 
 
-# ----------------------------------------------------------------------
-
-
-@register_payload("0004")
 @dataclass(frozen=True, slots=True)
-class ZoneSetpointPayload(PayloadBase):
-    """Zone target setpoint payload (Opcode 0004).
+class ZoneNameShort3BPayload(ZoneNamePayload):
+    """3-byte zone name / setpoint short variant (Opcode 0004).
 
     3-byte Zone Setpoint binary layout:
       Offset  Format  Len  Description                    Sample Hex
@@ -1374,6 +1348,8 @@ class ZoneSetpointPayload(PayloadBase):
     :type setpoint_temp: float
     """
 
+    _STRUCT_FMT: ClassVar[str] = ">Bh"
+
     zone_idx: int | str
     setpoint_temp: float
 
@@ -1383,25 +1359,24 @@ class ZoneSetpointPayload(PayloadBase):
             object.__setattr__(self, "zone_idx", parse_idx(self.zone_idx))
 
     @classmethod
-    def from_bytes(cls, raw_data: bytes) -> Self | ZoneNamePayload:
-        """Unpack zone setpoint binary payload.
+    def from_bytes(cls, raw_data: bytes) -> Self:
+        """Unpack 3-byte zone setpoint binary payload.
 
         :param raw_data: Raw binary byte string.
         :type raw_data: bytes
-        :returns: Unpacked ZoneSetpointPayload or ZoneNamePayload instance.
-        :rtype: Self | ZoneNamePayload
+        :returns: Unpacked ZoneNameShort3BPayload instance.
+        :rtype: Self
         :raises ValueError: If raw_data length is less than 3 bytes.
         """
-        if len(raw_data) >= 22:
-            return ZoneNamePayload.from_bytes(raw_data)
         if len(raw_data) < 3:
-            raise ValueError(f"Invalid payload length for 0004: {len(raw_data)}")
-        # Unpack zone_idx (uint8) and setpoint_raw (int16) directly from offset 0
-        idx, sp_raw = struct.unpack_from(">Bh", raw_data, 0)
+            raise ValueError(
+                f"Invalid payload length for ZoneNameShort3BPayload: {len(raw_data)}"
+            )
+        idx, sp_raw = struct.unpack_from(cls._STRUCT_FMT, raw_data, 0)
         return cls(zone_idx=idx, setpoint_temp=sp_raw / 100.0)
 
     def to_bytes(self) -> bytes:
-        """Pack zone setpoint data into binary payload.
+        """Pack 3-byte zone setpoint data into binary payload.
 
         :returns: Packed binary payload bytes.
         :rtype: bytes
@@ -1410,11 +1385,28 @@ class ZoneSetpointPayload(PayloadBase):
         idx = parse_idx(self.zone_idx)
         return bytes([idx]) + sp_raw.to_bytes(2, byteorder="big", signed=True)
 
+    def to_dict(self) -> dict[str, Any]:
+        """Convert 3-byte zone setpoint payload to legacy dictionary layout.
+
+        :returns: Decoded zone setpoint dictionary.
+        :rtype: dict[str, Any]
+        """
+        idx_str = (
+            f"{self.zone_idx:02X}" if isinstance(self.zone_idx, int) else self.zone_idx
+        )
+        return {"zone_idx": idx_str, "setpoint": self.setpoint_temp}
+
+
+# Update VARIANTS property after variants are defined
+ZoneNamePayload.VARIANTS = (
+    ZoneName22BPayload,
+    ZoneNameShort3BPayload,
+)
+
 
 # ----------------------------------------------------------------------
 
 
-@register_payload("2249")
 @register_payload("12C0")
 @dataclass(frozen=True, slots=True)
 class OutdoorTempPayload(PayloadBase):
@@ -1517,9 +1509,52 @@ class OutdoorTempPayload(PayloadBase):
 
 
 @register_payload("2309")
+class ZoneSetpointPayload(PayloadBase):
+    """Master payload dispatcher for zone setpoint (Opcode 2309)."""
+
+    VARIANTS: ClassVar[tuple[type[PayloadBase], ...]] = ()
+
+    zone_idx: int | str
+    setpoint_temp: float | bool | None
+
+    def __new__(
+        cls,
+        zone_idx: int | str = 0,
+        setpoint_temp: float | bool | None = None,
+    ) -> Any:
+        """Construct ZoneSetpoint payload variant dynamically."""
+        if cls is not ZoneSetpointPayload:
+            return super().__new__(cls)
+        return ZoneSetpoint3BPayload(zone_idx=zone_idx, setpoint_temp=setpoint_temp)
+
+    @classmethod
+    def from_bytes(
+        cls, raw_data: bytes
+    ) -> "ZoneSetpointPayload | list[ZoneSetpointPayload]":
+        """Unpack zone setpoint payload, dispatching single or array entries."""
+        if len(raw_data) < 3:
+            raise ValueError(f"Invalid payload length for 2309: {len(raw_data)}")
+        if len(raw_data) > 3 and len(raw_data) % 3 == 0:
+            return [
+                ZoneSetpoint3BPayload.from_bytes(raw_data[i : i + 3])
+                for i in range(0, len(raw_data), 3)
+            ]
+        return ZoneSetpoint3BPayload.from_bytes(raw_data)
+
+    def to_bytes(self) -> bytes:
+        """Pack payload base default method.
+
+        :returns: Packed binary payload bytes.
+        :rtype: bytes
+        :raises NotImplementedError: Master dispatcher must dispatch to
+            variant sub-dataclass.
+        """
+        raise NotImplementedError("Use concrete variant sub-dataclass")
+
+
 @dataclass(frozen=True, slots=True)
-class SetPointInfoPayload(PayloadBase):
-    """Set-point info payload (Opcode 2309).
+class ZoneSetpoint3BPayload(ZoneSetpointPayload):
+    """3-byte zone setpoint layout (Opcode 2309).
 
     3-byte Set-point Info binary layout:
       Offset  Format  Len  Description                    Sample Hex
@@ -1531,19 +1566,20 @@ class SetPointInfoPayload(PayloadBase):
       Payload hex      : 000834
 
     :param zone_idx: Zone index byte.
-    :type zone_idx: int
+    :type zone_idx: int | str
     :param setpoint_temp: Setpoint temperature in °C.
-    :type setpoint_temp: float
-
-    Sample Packet Logs & Protocol Notes:
-    # RQ --- 22:131874 01:063844 --:------ 2309 003 020708
-    # zone_mode  # TODO: messy
+    :type setpoint_temp: float | bool | None
     """
 
-    _STRUCT_FMT_ENTRY: ClassVar[str] = ">Bh"
+    _STRUCT_FMT: ClassVar[str] = ">Bh"
 
-    zone_idx: int
+    zone_idx: int | str
     setpoint_temp: float | bool | None
+
+    def __post_init__(self) -> None:
+        """Normalise index arguments."""
+        if isinstance(self.zone_idx, str):
+            object.__setattr__(self, "zone_idx", parse_idx(self.zone_idx))
 
     @classmethod
     def _parse_sp_val(cls, sp_raw: int) -> float | bool | None:
@@ -1555,34 +1591,24 @@ class SetPointInfoPayload(PayloadBase):
         return sp_raw / 100.0
 
     @classmethod
-    def from_bytes(cls, raw_data: bytes) -> Self | list[Self]:
-        """Unpack setpoint info binary payload.
+    def from_bytes(cls, raw_data: bytes) -> Self:
+        """Unpack 3-byte setpoint info binary payload.
 
         :param raw_data: Raw binary byte string.
         :type raw_data: bytes
-        :returns: Unpacked SetPointInfoPayload instance or list of instances.
-        :rtype: Self | list[Self]
+        :returns: Unpacked ZoneSetpoint3BPayload instance.
+        :rtype: Self
         :raises ValueError: If raw_data length is less than 3 bytes.
         """
         if len(raw_data) < 3:
-            raise ValueError(f"Invalid payload length for 2309: {len(raw_data)}")
-        if len(raw_data) > 3 and len(raw_data) % 3 == 0:
-            return [
-                cls(
-                    zone_idx=idx,
-                    setpoint_temp=cls._parse_sp_val(sp_raw),
-                )
-                for idx, sp_raw in (
-                    struct.unpack_from(cls._STRUCT_FMT_ENTRY, raw_data, i)
-                    for i in range(0, len(raw_data), 3)
-                )
-            ]
-
-        idx, sp_raw = struct.unpack_from(cls._STRUCT_FMT_ENTRY, raw_data, 0)
+            raise ValueError(
+                f"Invalid payload length for ZoneSetpoint3BPayload: {len(raw_data)}"
+            )
+        idx, sp_raw = struct.unpack_from(cls._STRUCT_FMT, raw_data, 0)
         return cls(zone_idx=idx, setpoint_temp=cls._parse_sp_val(sp_raw))
 
     def to_bytes(self) -> bytes:
-        """Pack setpoint info data into binary payload.
+        """Pack 3-byte setpoint info data into binary payload.
 
         :returns: Packed binary payload bytes.
         :rtype: bytes
@@ -1593,7 +1619,8 @@ class SetPointInfoPayload(PayloadBase):
             sp_raw = 0x7EFF
         else:
             sp_raw = int(round(self.setpoint_temp * 100.0))
-        return struct.pack(self._STRUCT_FMT_ENTRY, self.zone_idx, sp_raw)
+        idx = parse_idx(self.zone_idx)
+        return struct.pack(self._STRUCT_FMT, idx, sp_raw)
 
     def to_dict(self) -> dict[str, Any]:
         """Convert setpoint info payload to legacy dictionary layout.
@@ -1601,10 +1628,20 @@ class SetPointInfoPayload(PayloadBase):
         :returns: Decoded setpoint info dictionary.
         :rtype: dict[str, Any]
         """
+        idx_str = (
+            f"{self.zone_idx:02X}" if isinstance(self.zone_idx, int) else self.zone_idx
+        )
         return {
-            "zone_idx": f"{self.zone_idx:02X}",
+            "zone_idx": idx_str,
             "setpoint": self.setpoint_temp,
         }
+
+
+# Update VARIANTS property after variants are defined
+ZoneSetpointPayload.VARIANTS = (ZoneSetpoint3BPayload,)
+
+# Alias for backward compatibility
+SetPointInfoPayload = ZoneSetpointPayload
 
 
 # ----------------------------------------------------------------------
@@ -1836,9 +1873,49 @@ SystemZonesPayload.VARIANTS = (
 
 
 @register_payload("0008")
-@dataclass(frozen=True, slots=True)
 class RelayDemandPayload(PayloadBase):
-    """Relay demand payload (Opcode 0008).
+    """Master payload dispatcher for relay demand (Opcode 0008)."""
+
+    VARIANTS: ClassVar[tuple[type[PayloadBase], ...]] = ()
+
+    domain_or_zone_idx: int
+    demand_percent: float
+    raw_extra: bytes | None
+
+    def __new__(
+        cls,
+        domain_or_zone_idx: int = 0,
+        demand_percent: float = 0.0,
+        raw_extra: bytes | None = None,
+    ) -> Any:
+        """Construct RelayDemand payload variant dynamically."""
+        if cls is not RelayDemandPayload:
+            return super().__new__(cls)
+        return RelayDemand2BPayload(
+            domain_or_zone_idx=domain_or_zone_idx,
+            demand_percent=demand_percent,
+            raw_extra=raw_extra,
+        )
+
+    @classmethod
+    def from_bytes(cls, raw_data: bytes) -> "RelayDemand2BPayload":
+        """Unpack relay demand payload, dispatching to variant."""
+        return RelayDemand2BPayload.from_bytes(raw_data)
+
+    def to_bytes(self) -> bytes:
+        """Pack payload base default method.
+
+        :returns: Packed binary payload bytes.
+        :rtype: bytes
+        :raises NotImplementedError: Master dispatcher must dispatch to
+            variant sub-dataclass.
+        """
+        raise NotImplementedError("Use concrete variant sub-dataclass")
+
+
+@dataclass(frozen=True, slots=True)
+class RelayDemand2BPayload(RelayDemandPayload):
+    """2-byte relay demand payload (Opcode 0008).
 
     2-byte Relay Demand binary layout:
       Offset  Format  Len  Description                    Sample Hex
@@ -1849,16 +1926,6 @@ class RelayDemandPayload(PayloadBase):
       Field-spaced hex : 00 64
       Payload hex      : 0064
 
-    Sample Packet Logs & Protocol Notes:
-      # See: https://www.domoticaforum.eu/viewtopic.php?f=7&t=5806&start=105#p73681
-      # .I --- 01:145038 --:------ 01:145038 0008 002 0314
-      # .I --- 01:145038 --:------ 01:145038 0008 002 F914
-      # .I --- 01:054173 --:------ 01:054173 0008 002 FA00
-      # .I --- 01:145038 --:------ 01:145038 0008 002 FC14
-      # RP --- 13:109598 18:199952 --:------ 0008 002 0000
-      # RP --- 13:109598 18:199952 --:------ 0008 002 00C8
-      # Note: 0008[2:4] maps to 3EF0[2:4] and 3EF1[10:12]. Honeywell Jasper (JST) uses 13-byte variant.
-
     :param domain_or_zone_idx: Domain or zone index byte.
     :type domain_or_zone_idx: int
     :param demand_percent: Heat demand percentage (0.0 - 100.0).
@@ -1867,7 +1934,7 @@ class RelayDemandPayload(PayloadBase):
     :type raw_extra: bytes | None
     """
 
-    _STRUCT_FMT_2B: ClassVar[str] = ">BB"
+    _STRUCT_FMT: ClassVar[str] = ">BB"
 
     domain_or_zone_idx: int
     demand_percent: float
@@ -1875,17 +1942,19 @@ class RelayDemandPayload(PayloadBase):
 
     @classmethod
     def from_bytes(cls, raw_data: bytes) -> Self:
-        """Unpack relay demand binary payload.
+        """Unpack 2-byte relay demand binary payload.
 
         :param raw_data: Raw binary byte string.
         :type raw_data: bytes
-        :returns: Unpacked RelayDemandPayload instance.
+        :returns: Unpacked RelayDemand2BPayload instance.
         :rtype: Self
         :raises ValueError: If raw_data length is less than 2 bytes.
         """
         if len(raw_data) < 2:
-            raise ValueError(f"Invalid payload length for 0008: {len(raw_data)}")
-        idx, demand_raw = struct.unpack_from(cls._STRUCT_FMT_2B, raw_data, 0)
+            raise ValueError(
+                f"Invalid payload length for RelayDemand2BPayload: {len(raw_data)}"
+            )
+        idx, demand_raw = struct.unpack_from(cls._STRUCT_FMT, raw_data, 0)
         extra = raw_data[2:] if len(raw_data) > 2 else None
         return cls(
             domain_or_zone_idx=idx,
@@ -1894,13 +1963,13 @@ class RelayDemandPayload(PayloadBase):
         )
 
     def to_bytes(self) -> bytes:
-        """Pack relay demand data into binary payload.
+        """Pack 2-byte relay demand binary payload.
 
         :returns: Packed binary payload bytes.
         :rtype: bytes
         """
         demand_raw = min(200, max(0, int(round(self.demand_percent * 200.0))))
-        res = struct.pack(self._STRUCT_FMT_2B, self.domain_or_zone_idx, demand_raw)
+        res = struct.pack(self._STRUCT_FMT, self.domain_or_zone_idx, demand_raw)
         if self.raw_extra is not None:
             res += self.raw_extra
         return res
@@ -1909,8 +1978,13 @@ class RelayDemandPayload(PayloadBase):
         """Convert relay demand payload to legacy dictionary layout.
 
         :returns: Decoded relay demand dictionary.
+        :rtype: dict[str, Any]
         """
         return {"relay_demand": self.demand_percent}
+
+
+# Update VARIANTS property after variants are defined
+RelayDemandPayload.VARIANTS = (RelayDemand2BPayload,)
 
 
 # ----------------------------------------------------------------------
@@ -2319,12 +2393,55 @@ class Opcode1090Payload(PayloadBase):
 
 
 @register_payload("1100")
-class TpiParamsBasePayload(PayloadBase, ABC):
-    """Abstract base class for TPI parameters (Opcode 1100)."""
+class TpiParamsPayload(PayloadBase):
+    """Master payload dispatcher for TPI parameters (Opcode 1100).
+
+    Dispatches TPI parameter binary payloads to 4-byte or 8-byte
+    variant sub-dataclasses based on payload length.
+
+    Domain Notes & Sample Packet Logs:
+    # tpi_params (domain/zone/device)  # FIXME: a bit messy
+    # for:             TPI              // heatpump
+    #  - cycle_rate:   6 (3, 6, 9, 12)  // ?? (1-9)
+    #  - min_on_time:  1 (1-5)          // ?? (1, 5, 10,...30)
+    #  - min_off_time: 1 (1-?)          // ?? (0, 5, 10, 15)
+    #  I --- 01:172368 --:------ 01:172368 1100 008 FC180400007FFF00
+    #  I --- 01:172368 13:040439 --:------ 1100 008 FC042814007FFF00
+    # RQ --- 01:145038 13:163733 --:------ 1100 008 00180400007FFF01  # boiler relay
+    # RP --- 13:163733 01:145038 --:------ 1100 008 00180400FF7FFF01
+    # RQ --- 01:145038 13:035462 --:------ 1100 008 FC240428007FFF01  # not boiler relay
+    # RP --- 13:035462 01:145038 --:------ 1100 008 00240428007FFF01
+    # only 10:040239 does 0b01000000, only Itho Autotemp does 0b00010000
+    """
+
+    VARIANTS: ClassVar[tuple[type[PayloadBase], ...]] = ()
+
+    domain_id: int
+    cycle_rate: int
+    min_on_time: float
+    min_off_time: float
+    proportional_band_width: float | None = None
+
+    @classmethod
+    def from_bytes(cls, raw_data: bytes) -> "TpiParams4BPayload | TpiParams8BPayload":
+        """Unpack TPI params binary payload, dispatching by length."""
+        if len(raw_data) >= 8:
+            return TpiParams8BPayload.from_bytes(raw_data)
+        return TpiParams4BPayload.from_bytes(raw_data)
+
+    def to_bytes(self) -> bytes:
+        """Pack payload base default method.
+
+        :returns: Packed binary payload bytes.
+        :rtype: bytes
+        :raises NotImplementedError: Master dispatcher must dispatch to
+            variant sub-dataclass.
+        """
+        raise NotImplementedError("Use concrete variant sub-dataclass")
 
 
 @dataclass(frozen=True, slots=True)
-class TpiParams4BPayload(TpiParamsBasePayload):
+class TpiParams4BPayload(TpiParamsPayload):
     """TPI 4-byte parameters layout (Opcode 1100).
 
     4-byte TPI Parameters binary layout:
@@ -2346,6 +2463,8 @@ class TpiParams4BPayload(TpiParamsBasePayload):
     :type min_on_time: float
     :param min_off_time: Minimum off-time in minutes.
     :type min_off_time: float
+    :param proportional_band_width: Proportional band width (None for 4B payload).
+    :type proportional_band_width: float | None
     """
 
     _STRUCT_FMT: ClassVar[str] = ">BBBB"
@@ -2354,6 +2473,7 @@ class TpiParams4BPayload(TpiParamsBasePayload):
     cycle_rate: int
     min_on_time: float
     min_off_time: float
+    proportional_band_width: float | None = None
 
     @classmethod
     def from_bytes(cls, raw_data: bytes) -> Self:
@@ -2413,7 +2533,7 @@ class TpiParams4BPayload(TpiParamsBasePayload):
 
 
 @dataclass(frozen=True, slots=True)
-class TpiParams8BPayload(TpiParamsBasePayload):
+class TpiParams8BPayload(TpiParamsPayload):
     """TPI 8-byte parameters layout (Opcode 1100).
 
     8-byte TPI Parameters binary layout:
@@ -2448,7 +2568,7 @@ class TpiParams8BPayload(TpiParamsBasePayload):
     cycle_rate: int
     min_on_time: float
     min_off_time: float
-    proportional_band_width: float | None
+    proportional_band_width: float | None = None
 
     @classmethod
     def from_bytes(cls, raw_data: bytes) -> Self:
@@ -2517,36 +2637,11 @@ class TpiParams8BPayload(TpiParamsBasePayload):
         }
 
 
-@register_payload("1100")
-class TpiParamsPayload(PayloadBase, ABC):
-    """Master payload dispatcher for Opcode 1100.
-
-    Domain Notes & Sample Packet Logs:
-    # tpi_params (domain/zone/device)  # FIXME: a bit messy
-    # for:             TPI              // heatpump
-    #  - cycle_rate:   6 (3, 6, 9, 12)  // ?? (1-9)
-    #  - min_on_time:  1 (1-5)          // ?? (1, 5, 10,...30)
-    #  - min_off_time: 1 (1-?)          // ?? (0, 5, 10, 15)
-    #  I --- 01:172368 --:------ 01:172368 1100 008 FC180400007FFF00
-    #  I --- 01:172368 13:040439 --:------ 1100 008 FC042814007FFF00
-    # RQ --- 01:145038 13:163733 --:------ 1100 008 00180400007FFF01  # boiler relay
-    # RP --- 13:163733 01:145038 --:------ 1100 008 00180400FF7FFF01
-    # RQ --- 01:145038 13:035462 --:------ 1100 008 FC240428007FFF01  # not boiler relay
-    # RP --- 13:035462 01:145038 --:------ 1100 008 00240428007FFF01
-    # only 10:040239 does 0b01000000, only Itho Autotemp does 0b00010000
-    """
-
-    VARIANTS: ClassVar[tuple[type[PayloadBase], ...]] = (
-        TpiParams4BPayload,
-        TpiParams8BPayload,
-    )
-
-    @classmethod
-    def from_bytes(cls, raw_data: bytes) -> TpiParams4BPayload | TpiParams8BPayload:
-        """Unpack TPI params binary payload, dispatching by length."""
-        if len(raw_data) >= 8:
-            return TpiParams8BPayload.from_bytes(raw_data)
-        return TpiParams4BPayload.from_bytes(raw_data)
+# Update VARIANTS property after variants are defined
+TpiParamsPayload.VARIANTS = (
+    TpiParams4BPayload,
+    TpiParams8BPayload,
+)
 
 
 # ----------------------------------------------------------------------
@@ -2566,12 +2661,11 @@ class ChPressurePayload(PayloadBase):
       Field-spaced hex : 00 00EA
       Payload hex      : 0000EA
 
-    :param pressure_bar: CH system pressure in Bar, or None if invalid.
+    :param pressure_bar: Pressure in Bar float, or None if sentinel/invalid.
     :type pressure_bar: float | None
-
-    Domain Notes:
-    # 0x9F6 (2550 dec = 2.55 bar) appears to be a sentinel value
     """
+
+    _STRUCT_FMT: ClassVar[str] = ">Bh"
 
     pressure_bar: float | None
 
@@ -2586,13 +2680,12 @@ class ChPressurePayload(PayloadBase):
         :raises ValueError: If raw_data length is less than 3 bytes.
         """
         if len(raw_data) < 3:
-            raise ValueError(f"Invalid payload length for 1300: {len(raw_data)}")
-        if raw_data[1:3] in (b"\x09\xf6", b"\x7f\xff"):
-            return cls(pressure_bar=None)
-        val_raw = int.from_bytes(raw_data[1:3], byteorder="big", signed=True)
-        return cls(
-            pressure_bar=None if val_raw in (0x31FF, 0x7FFF) else val_raw / 100.0
-        )
+            raise ValueError(
+                f"Invalid payload length for ChPressurePayload: {len(raw_data)}"
+            )
+        _hdr, p_raw = struct.unpack_from(cls._STRUCT_FMT, raw_data, 0)
+        p_val = None if p_raw in (0x09F6, 0x31FF, 0x7FFF, 32767) else p_raw / 100.0
+        return cls(pressure_bar=p_val)
 
     def to_bytes(self) -> bytes:
         """Pack CH pressure data into binary payload.
@@ -2601,16 +2694,12 @@ class ChPressurePayload(PayloadBase):
         :rtype: bytes
         """
         if self.pressure_bar is None:
-            return b"\x00\x09\xf6"
-        val_raw = int(round(self.pressure_bar * 100.0))
-        return b"\x00" + val_raw.to_bytes(2, byteorder="big", signed=True)
+            return struct.pack(self._STRUCT_FMT, 0x00, 0x7FFF)
+        p_raw = int(round(self.pressure_bar * 100.0))
+        return struct.pack(self._STRUCT_FMT, 0x00, p_raw)
 
     def to_dict(self) -> dict[str, Any]:
-        """Convert CH pressure payload to legacy dictionary layout.
-
-        :returns: Decoded pressure dictionary.
-        :rtype: dict[str, Any]
-        """
+        """Convert CH pressure payload to legacy dictionary layout."""
         return {"pressure": self.pressure_bar}
 
 
@@ -2618,43 +2707,90 @@ class ChPressurePayload(PayloadBase):
 
 
 @register_payload("2349")
-@dataclass(frozen=True, slots=True)
 class ZoneModePayload(PayloadBase):
-    """Zone operating mode and override payload (Opcode 2349).
+    """Master payload dispatcher for zone mode (Opcode 2349)."""
 
-    7-byte Zone Mode binary layout:
+    VARIANTS: ClassVar[tuple[type[PayloadBase], ...]] = ()
+
+    zone_idx: int | str
+    setpoint_temp: float | None
+    mode_code: int | str
+    duration_minutes: int | None
+    until_dtm: str | dt | bytes | None
+
+    def __new__(
+        cls,
+        zone_idx: int | str = 0,
+        setpoint_temp: float | None = None,
+        mode_code: int | str = 0,
+        duration_minutes: int | None = None,
+        until_dtm: str | dt | bytes | None = None,
+    ) -> Any:
+        """Construct ZoneMode payload variant dynamically."""
+        if cls is not ZoneModePayload:
+            return super().__new__(cls)
+        if until_dtm is not None:
+            return ZoneMode13BPayload(
+                zone_idx=zone_idx,
+                setpoint_temp=setpoint_temp,
+                mode_code=mode_code,
+                duration_minutes=duration_minutes,
+                until_dtm=until_dtm,
+            )
+        return ZoneMode7BPayload(
+            zone_idx=zone_idx,
+            setpoint_temp=setpoint_temp,
+            mode_code=mode_code,
+            duration_minutes=duration_minutes,
+        )
+
+    @classmethod
+    def from_bytes(
+        cls, raw_data: bytes
+    ) -> "ZoneMode4BPayload | ZoneMode7BPayload | ZoneMode13BPayload":
+        """Unpack zone mode payload, dispatching by length."""
+        if len(raw_data) >= 13:
+            return ZoneMode13BPayload.from_bytes(raw_data)
+        if len(raw_data) >= 7:
+            return ZoneMode7BPayload.from_bytes(raw_data)
+        if len(raw_data) >= 4:
+            return ZoneMode4BPayload.from_bytes(raw_data)
+        raise ValueError(f"Invalid payload length for 2349: {len(raw_data)}")
+
+    def to_bytes(self) -> bytes:
+        """Pack payload base default method.
+
+        :returns: Packed binary payload bytes.
+        :rtype: bytes
+        :raises NotImplementedError: Master dispatcher must dispatch to
+            variant sub-dataclass.
+        """
+        raise NotImplementedError("Use concrete variant sub-dataclass")
+
+
+@dataclass(frozen=True, slots=True)
+class ZoneMode4BPayload(ZoneModePayload):
+    """4-byte zone mode basic payload (Opcode 2349).
+
+    4-byte Zone Mode binary layout:
       Offset  Format  Len  Description                    Sample Hex
       --------------------------------------------------------------
       +0       B      1B   Zone Index (uint8)           : 00
       +1       h      2B   Setpoint Temp (int16*100)    : 08 34 (21.00°C)
       +3       B      1B   Zone Mode Code (uint8)       : 00 (Follow)
-      +4       3B     3B   Duration / Until Bytes       : FF FF FF
       --------------------------------------------------------------
-      Field-spaced hex : 00 0834 00 FFFFFF
-      Payload hex      : 00083400FFFFFF
-
-    Protocol Notes & Sample Packet Logs:
-      # Hometronic controllers do not react to W/2349 but
-      # require W/2309 instead.
-      # RP --- 30:258557 34:225071 --:------ 2349 013 007FFF00FFFFFFFFFFFFFFFFFF
-      # RP --- 30:253184 34:010943 --:------ 2349 013 00064000FFFFFF00110E0507E5
-      # RQ --- 34:225071 30:258557 --:------ 2349 001 00
-      # .I --- 10:067219 --:------ 10:067219 2349 004 00000001
-      # .W --- 18:141846 01:050858 --:------ 2349 013 02-0960-04-FFFFFF-0409160607E5
+      Field-spaced hex : 00 0834 00
+      Payload hex      : 00083400
 
     :param zone_idx: Zone index byte.
-    :type zone_idx: int
+    :type zone_idx: int | str
     :param setpoint_temp: Target setpoint temperature in °C.
-    :type setpoint_temp: float
+    :type setpoint_temp: float | None
     :param mode_code: Zone mode code integer.
-    :type mode_code: int
-    :param duration_minutes: Override duration in minutes, if present.
-    :type duration_minutes: int | None
-    :param until_dtm: Expiration datetime for temporary override.
-    :type until_dtm: str | dt | bytes | None
+    :type mode_code: int | str
     """
 
-    _STRUCT_FMT_BASE: ClassVar[str] = ">BhB"
+    _STRUCT_FMT: ClassVar[str] = ">BhB"
 
     zone_idx: int | str
     setpoint_temp: float | None
@@ -2671,34 +2807,24 @@ class ZoneModePayload(PayloadBase):
 
     @classmethod
     def from_bytes(cls, raw_data: bytes) -> Self:
-        """Unpack zone mode binary payload.
+        """Unpack 4-byte zone mode binary payload.
 
         :param raw_data: Raw binary byte string.
         :type raw_data: bytes
-        :returns: Unpacked ZoneModePayload instance.
+        :returns: Unpacked ZoneMode4BPayload instance.
         :rtype: Self
         :raises ValueError: If raw_data length is less than 4 bytes.
         """
         if len(raw_data) < 4:
-            raise ValueError(f"Invalid payload length for 2349: {len(raw_data)}")
-        raw_idx, sp_raw, mode = struct.unpack_from(cls._STRUCT_FMT_BASE, raw_data, 0)
+            raise ValueError(
+                f"Invalid payload length for ZoneMode4BPayload: {len(raw_data)}"
+            )
+        raw_idx, sp_raw, mode = struct.unpack_from(cls._STRUCT_FMT, raw_data, 0)
         setpoint = None if sp_raw in (0x31FF, 0x7FFF) else sp_raw / 100.0
-        dur = None
-        if len(raw_data) >= 7 and raw_data[4:7] != b"\xff\xff\xff":
-            dur = int.from_bytes(raw_data[4:7], byteorder="big")
-        until_raw = None
-        if len(raw_data) >= 13:
-            until_raw = hex_to_dtm(raw_data[7:13].hex().upper())
-        return cls(
-            zone_idx=raw_idx,
-            setpoint_temp=setpoint,
-            mode_code=mode,
-            duration_minutes=dur,
-            until_dtm=until_raw,
-        )
+        return cls(zone_idx=raw_idx, setpoint_temp=setpoint, mode_code=mode)
 
     def to_bytes(self) -> bytes:
-        """Pack zone mode data into binary payload.
+        """Pack 4-byte zone mode data into binary payload.
 
         :returns: Packed binary payload bytes.
         :rtype: bytes
@@ -2713,7 +2839,234 @@ class ZoneModePayload(PayloadBase):
             if isinstance(self.mode_code, str)
             else self.mode_code
         )
-        res = struct.pack(self._STRUCT_FMT_BASE, idx, sp_raw, mode)
+        return struct.pack(self._STRUCT_FMT, idx, sp_raw, mode)
+
+    def to_dict(self) -> dict[str, Any]:
+        """Convert 4-byte zone mode payload to legacy dictionary layout.
+
+        :returns: Decoded zone mode dictionary.
+        :rtype: dict[str, Any]
+        """
+        mode_code_hex = (
+            f"{self.mode_code:02X}"
+            if isinstance(self.mode_code, int)
+            else str(self.mode_code)
+        )
+        mode_str = ZON_MODE_MAP.get(mode_code_hex, mode_code_hex)
+        idx_str = (
+            f"{self.zone_idx:02X}" if isinstance(self.zone_idx, int) else self.zone_idx
+        )
+        return {
+            "zone_idx": idx_str,
+            "mode": mode_str,
+            "setpoint": self.setpoint_temp,
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class ZoneMode7BPayload(ZoneModePayload):
+    """7-byte zone mode override with duration payload (Opcode 2349).
+
+    7-byte Zone Mode binary layout:
+      Offset  Format  Len  Description                    Sample Hex
+      --------------------------------------------------------------
+      +0       B      1B   Zone Index (uint8)           : 00
+      +1       h      2B   Setpoint Temp (int16*100)    : 08 34 (21.00°C)
+      +3       B      1B   Zone Mode Code (uint8)       : 00 (Follow)
+      +4       3B     3B   Duration Minutes (uint24)    : FF FF FF
+      --------------------------------------------------------------
+      Field-spaced hex : 00 0834 00 FFFFFF
+      Payload hex      : 00083400FFFFFF
+
+    :param zone_idx: Zone index byte.
+    :type zone_idx: int | str
+    :param setpoint_temp: Target setpoint temperature in °C.
+    :type setpoint_temp: float | None
+    :param mode_code: Zone mode code integer.
+    :type mode_code: int | str
+    :param duration_minutes: Override duration in minutes, if present.
+    :type duration_minutes: int | None
+    :param until_dtm: Expiration datetime (None for 7B payload).
+    :type until_dtm: str | dt | bytes | None
+    """
+
+    _STRUCT_FMT: ClassVar[str] = ">BhB"
+
+    zone_idx: int | str
+    setpoint_temp: float | None
+    mode_code: int | str
+    duration_minutes: int | None = None
+    until_dtm: str | dt | bytes | None = None
+
+    def __post_init__(self) -> None:
+        """Normalise index arguments."""
+        if isinstance(self.zone_idx, str):
+            object.__setattr__(self, "zone_idx", parse_idx(self.zone_idx))
+        if isinstance(self.mode_code, str):
+            object.__setattr__(self, "mode_code", int(self.mode_code, 16))
+
+    @classmethod
+    def from_bytes(cls, raw_data: bytes) -> Self:
+        """Unpack 7-byte zone mode binary payload.
+
+        :param raw_data: Raw binary byte string.
+        :type raw_data: bytes
+        :returns: Unpacked ZoneMode7BPayload instance.
+        :rtype: Self
+        :raises ValueError: If raw_data length is less than 7 bytes.
+        """
+        if len(raw_data) < 7:
+            raise ValueError(
+                f"Invalid payload length for ZoneMode7BPayload: {len(raw_data)}"
+            )
+        raw_idx, sp_raw, mode = struct.unpack_from(cls._STRUCT_FMT, raw_data, 0)
+        setpoint = None if sp_raw in (0x31FF, 0x7FFF) else sp_raw / 100.0
+        dur = None
+        if raw_data[4:7] != b"\xff\xff\xff":
+            dur = int.from_bytes(raw_data[4:7], byteorder="big")
+        return cls(
+            zone_idx=raw_idx,
+            setpoint_temp=setpoint,
+            mode_code=mode,
+            duration_minutes=dur,
+        )
+
+    def to_bytes(self) -> bytes:
+        """Pack 7-byte zone mode data into binary payload.
+
+        :returns: Packed binary payload bytes.
+        :rtype: bytes
+        """
+        idx = parse_idx(self.zone_idx)
+        if self.setpoint_temp is None:
+            sp_raw = 0x7FFF
+        else:
+            sp_raw = int(round(self.setpoint_temp * 100.0))
+        mode = (
+            int(self.mode_code, 16)
+            if isinstance(self.mode_code, str)
+            else self.mode_code
+        )
+        res = struct.pack(self._STRUCT_FMT, idx, sp_raw, mode)
+        if self.duration_minutes is not None:
+            res += self.duration_minutes.to_bytes(3, byteorder="big")
+        else:
+            res += b"\xff\xff\xff"
+        return res
+
+    def to_dict(self) -> dict[str, Any]:
+        """Convert 7-byte zone mode payload to legacy dictionary layout.
+
+        :returns: Decoded zone mode dictionary.
+        :rtype: dict[str, Any]
+        """
+        mode_code_hex = (
+            f"{self.mode_code:02X}"
+            if isinstance(self.mode_code, int)
+            else str(self.mode_code)
+        )
+        mode_str = ZON_MODE_MAP.get(mode_code_hex, mode_code_hex)
+        idx_str = (
+            f"{self.zone_idx:02X}" if isinstance(self.zone_idx, int) else self.zone_idx
+        )
+        res: dict[str, Any] = {
+            "zone_idx": idx_str,
+            "mode": mode_str,
+            "setpoint": self.setpoint_temp,
+        }
+        if self.duration_minutes is not None:
+            res["duration"] = self.duration_minutes
+        return res
+
+
+@dataclass(frozen=True, slots=True)
+class ZoneMode13BPayload(ZoneModePayload):
+    """13-byte zone mode override with expiration datetime payload (Opcode 2349).
+
+    13-byte Zone Mode binary layout:
+      Offset  Format  Len  Description                    Sample Hex
+      --------------------------------------------------------------
+      +0       B      1B   Zone Index (uint8)           : 00
+      +1       h      2B   Setpoint Temp (int16*100)    : 08 34 (21.00°C)
+      +3       B      1B   Zone Mode Code (uint8)       : 00 (Follow)
+      +4       3B     3B   Duration Minutes (uint24)    : FF FF FF
+      +7       6B     6B   Expiration Datetime          : 00 11 0E 05 07 E5
+      --------------------------------------------------------------
+      Field-spaced hex : 00 0834 00 FFFFFF 00110E0507E5
+      Payload hex      : 00083400FFFFFF00110E0507E5
+
+    :param zone_idx: Zone index byte.
+    :type zone_idx: int | str
+    :param setpoint_temp: Target setpoint temperature in °C.
+    :type setpoint_temp: float | None
+    :param mode_code: Zone mode code integer.
+    :type mode_code: int | str
+    :param duration_minutes: Override duration in minutes, if present.
+    :type duration_minutes: int | None
+    :param until_dtm: Expiration datetime for temporary override.
+    :type until_dtm: str | dt | bytes | None
+    """
+
+    _STRUCT_FMT: ClassVar[str] = ">BhB"
+
+    zone_idx: int | str
+    setpoint_temp: float | None
+    mode_code: int | str
+    duration_minutes: int | None = None
+    until_dtm: str | dt | bytes | None = None
+
+    def __post_init__(self) -> None:
+        """Normalise index arguments."""
+        if isinstance(self.zone_idx, str):
+            object.__setattr__(self, "zone_idx", parse_idx(self.zone_idx))
+        if isinstance(self.mode_code, str):
+            object.__setattr__(self, "mode_code", int(self.mode_code, 16))
+
+    @classmethod
+    def from_bytes(cls, raw_data: bytes) -> Self:
+        """Unpack 13-byte zone mode binary payload.
+
+        :param raw_data: Raw binary byte string.
+        :type raw_data: bytes
+        :returns: Unpacked ZoneMode13BPayload instance.
+        :rtype: Self
+        :raises ValueError: If raw_data length is less than 13 bytes.
+        """
+        if len(raw_data) < 13:
+            raise ValueError(
+                f"Invalid payload length for ZoneMode13BPayload: {len(raw_data)}"
+            )
+        raw_idx, sp_raw, mode = struct.unpack_from(cls._STRUCT_FMT, raw_data, 0)
+        setpoint = None if sp_raw in (0x31FF, 0x7FFF) else sp_raw / 100.0
+        dur = None
+        if raw_data[4:7] != b"\xff\xff\xff":
+            dur = int.from_bytes(raw_data[4:7], byteorder="big")
+        until_raw = hex_to_dtm(raw_data[7:13].hex().upper())
+        return cls(
+            zone_idx=raw_idx,
+            setpoint_temp=setpoint,
+            mode_code=mode,
+            duration_minutes=dur,
+            until_dtm=until_raw,
+        )
+
+    def to_bytes(self) -> bytes:
+        """Pack 13-byte zone mode data into binary payload.
+
+        :returns: Packed binary payload bytes.
+        :rtype: bytes
+        """
+        idx = parse_idx(self.zone_idx)
+        if self.setpoint_temp is None:
+            sp_raw = 0x7FFF
+        else:
+            sp_raw = int(round(self.setpoint_temp * 100.0))
+        mode = (
+            int(self.mode_code, 16)
+            if isinstance(self.mode_code, str)
+            else self.mode_code
+        )
+        res = struct.pack(self._STRUCT_FMT, idx, sp_raw, mode)
         if self.duration_minutes is not None:
             res += self.duration_minutes.to_bytes(3, byteorder="big")
         else:
@@ -2729,10 +3082,12 @@ class ZoneModePayload(PayloadBase):
                 res += bytes.fromhex(self.until_dtm)
             else:
                 res += bytes.fromhex(hex_from_dtm(self.until_dtm))
+        else:
+            res += b"\x00" * 6
         return res
 
     def to_dict(self) -> dict[str, Any]:
-        """Convert zone mode payload to legacy dictionary layout.
+        """Convert 13-byte zone mode payload to legacy dictionary layout.
 
         :returns: Decoded zone mode dictionary.
         :rtype: dict[str, Any]
@@ -2756,6 +3111,14 @@ class ZoneModePayload(PayloadBase):
         if self.until_dtm is not None:
             res["until"] = self.until_dtm
         return res
+
+
+# Update VARIANTS property after variants are defined
+ZoneModePayload.VARIANTS = (
+    ZoneMode4BPayload,
+    ZoneMode7BPayload,
+    ZoneMode13BPayload,
+)
 
 
 # ----------------------------------------------------------------------

--- a/src/ramses_rf/payloads/hvac.py
+++ b/src/ramses_rf/payloads/hvac.py
@@ -507,40 +507,21 @@ Co2Payload.VARIANTS = (
 
 
 @register_payload("12A0")
-@dataclass(frozen=True, slots=True)
 class RelativeHumidityPayload(PayloadBase):
-    """Relative humidity payload (Opcode 12A0).
+    """Master payload dispatcher for relative humidity (Opcode 12A0)."""
 
-    Multi-element 12A0 arrays (Ventura V1x, Orcon, etc.) contain indoor (00),
-    supply (01), and outdoor (02) sensor readings. See ramses_cc#742.
-
-    1-2 byte Relative Humidity binary layout:
-      Offset  Format  Len  Description                    Sample Hex
-      --------------------------------------------------------------
-      +0       B      1B   Humidity percentage (uint8)  : 64 (50.0%)
-      --------------------------------------------------------------
-      Field-spaced hex : 64
-      Payload hex      : 64
-
-    :param humidity_percent: Relative humidity value (0.0 - 100.0%).
-    :type humidity_percent: float
-    """
-
-    _STRUCT_FMT_1B: ClassVar[str] = ">B"
+    VARIANTS: ClassVar[tuple[type[PayloadBase], ...]] = ()
 
     humidity_percent: float | None
-    _hvac_idx: str | None = None
-    _temperature: float | None = None
-    _dewpoint_temp: float | None = None
 
     @property
     def humidity(self) -> float | None:
-        """Alias for humidity_percent for backward compatibility.
+        """Alias for humidity_percent.
 
         :returns: Humidity percentage or None.
         :rtype: float | None
         """
-        return self.humidity_percent
+        return getattr(self, "humidity_percent", None)
 
     @property
     def hvac_idx(self) -> str | None:
@@ -549,7 +530,7 @@ class RelativeHumidityPayload(PayloadBase):
         :returns: HVAC index or None.
         :rtype: str | None
         """
-        return self._hvac_idx
+        return getattr(self, "_hvac_idx", None)
 
     @property
     def temperature(self) -> float | None:
@@ -558,7 +539,7 @@ class RelativeHumidityPayload(PayloadBase):
         :returns: Temperature or None.
         :rtype: float | None
         """
-        return self._temperature
+        return getattr(self, "_temperature", None)
 
     @property
     def dewpoint_temp(self) -> float | None:
@@ -567,38 +548,206 @@ class RelativeHumidityPayload(PayloadBase):
         :returns: Dewpoint temperature or None.
         :rtype: float | None
         """
-        return self._dewpoint_temp
+        return getattr(self, "_dewpoint_temp", None)
 
     @classmethod
-    def from_bytes(cls, raw_data: bytes) -> Self | list[Self]:
-        """Unpack relative humidity binary payload.
+    def from_bytes(
+        cls, raw_data: bytes
+    ) -> "RelativeHumidityPayload | list[RelativeHumidityPayload]":
+        """Unpack relative humidity payload, dispatching by length."""
+        if not raw_data:
+            raise ValueError("Payload data cannot be empty")
+        if len(raw_data) > 7 and len(raw_data) % 7 == 0:
+            return [
+                RelativeHumidity6BPayload.from_bytes(raw_data[i : i + 7], is_array=True)
+                for i in range(0, len(raw_data), 7)
+            ]
+        if len(raw_data) >= 6:
+            return RelativeHumidity6BPayload.from_bytes(raw_data, is_array=False)
+        if len(raw_data) >= 2:
+            return RelativeHumidity2BPayload.from_bytes(raw_data)
+        return RelativeHumidity1BPayload.from_bytes(raw_data)
+
+    def to_bytes(self) -> bytes:
+        """Pack payload base default method.
+
+        :returns: Packed binary payload bytes.
+        :rtype: bytes
+        :raises NotImplementedError: Master dispatcher must dispatch to
+            variant sub-dataclass.
+        """
+        raise NotImplementedError("Use concrete variant sub-dataclass")
+
+
+@dataclass(frozen=True, slots=True)
+class RelativeHumidity1BPayload(RelativeHumidityPayload):
+    """1-byte relative humidity payload (Opcode 12A0).
+
+    1-byte Relative Humidity binary layout:
+      Offset  Format  Len  Description                    Sample Hex
+      --------------------------------------------------------------
+      +0       B      1B   Humidity percentage (uint8)  : 64 (50.0%)
+      --------------------------------------------------------------
+      Field-spaced hex : 64
+      Payload hex      : 64
+
+    :param humidity_percent: Relative humidity value (0.0 - 100.0%).
+    :type humidity_percent: float | None
+    """
+
+    _STRUCT_FMT: ClassVar[str] = ">B"
+
+    humidity_percent: float | None
+
+    @classmethod
+    def from_bytes(cls, raw_data: bytes) -> Self:
+        """Unpack 1-byte relative humidity binary payload.
 
         :param raw_data: Raw binary byte string.
         :type raw_data: bytes
-        :returns: Unpacked RelativeHumidityPayload instance or list of instances.
-        :rtype: Self | list[Self]
-        :raises ValueError: If raw_data is empty.
+        :returns: Unpacked RelativeHumidity1BPayload instance.
+        :rtype: Self
+        :raises ValueError: If raw_data length is less than 1 byte.
         """
-        if not raw_data:
-            raise ValueError("Payload data cannot be empty")
-
-        if len(raw_data) > 7 and len(raw_data) % 7 == 0:
-            return [
-                cls._from_7b_bytes(raw_data[i : i + 7], is_array=True)
-                for i in range(0, len(raw_data), 7)
-            ]
-
-        if len(raw_data) >= 6:
-            return cls._from_7b_bytes(raw_data, is_array=False)
-
-        offset = 1 if len(raw_data) >= 2 and raw_data[0] == 0 else 0
-        raw_val = raw_data[offset]
-        scale = 100.0 if len(raw_data) >= 2 else 2.0
-        hum = None if raw_val in (0x00, 0xEF, 0xFF) else raw_val / scale
+        if len(raw_data) < 1:
+            raise ValueError(
+                f"Invalid payload length for RelativeHumidity1BPayload: {len(raw_data)}"
+            )
+        raw_val = raw_data[0]
+        hum = None if raw_val in (0x00, 0xEF, 0xFF) else raw_val / 2.0
         return cls(humidity_percent=hum)
 
+    def to_bytes(self) -> bytes:
+        """Pack 1-byte relative humidity binary payload.
+
+        :returns: Packed binary payload bytes.
+        :rtype: bytes
+        """
+        if self.humidity_percent is None:
+            return struct.pack(self._STRUCT_FMT, 0x00)
+        raw_val = int(round(self.humidity_percent * 2.0))
+        return struct.pack(self._STRUCT_FMT, raw_val)
+
+    def to_dict(self, msg: Any = None) -> dict[str, Any]:
+        """Convert 1-byte humidity payload to legacy dictionary format.
+
+        :param msg: Optional message context object.
+        :type msg: Any
+        :returns: Decoded humidity dictionary.
+        :rtype: dict[str, Any]
+        """
+        return {SZ_INDOOR_HUMIDITY: self.humidity_percent}
+
+
+@dataclass(frozen=True, slots=True)
+class RelativeHumidity2BPayload(RelativeHumidityPayload):
+    """2-byte relative humidity payload (Opcode 12A0).
+
+    2-byte Relative Humidity binary layout:
+      Offset  Format  Len  Description                    Sample Hex
+      --------------------------------------------------------------
+      +0       B      1B   Header / Index               : 00
+      +1       B      1B   Humidity percentage (uint8)  : 32 (50.0%)
+      --------------------------------------------------------------
+      Field-spaced hex : 00 32
+      Payload hex      : 0032
+
+    :param humidity_percent: Relative humidity value (0.0 - 100.0%).
+    :type humidity_percent: float | None
+    """
+
+    _STRUCT_FMT: ClassVar[str] = ">BB"
+
+    humidity_percent: float | None
+
     @classmethod
-    def _from_7b_bytes(cls, raw_data: bytes, is_array: bool) -> Self:
+    def from_bytes(cls, raw_data: bytes) -> Self:
+        """Unpack 2-byte relative humidity binary payload.
+
+        :param raw_data: Raw binary byte string.
+        :type raw_data: bytes
+        :returns: Unpacked RelativeHumidity2BPayload instance.
+        :rtype: Self
+        :raises ValueError: If raw_data length is less than 2 bytes.
+        """
+        if len(raw_data) < 2:
+            raise ValueError(
+                f"Invalid payload length for RelativeHumidity2BPayload: {len(raw_data)}"
+            )
+        _hdr, raw_val = struct.unpack_from(cls._STRUCT_FMT, raw_data, 0)
+        hum = None if raw_val in (0x00, 0xEF, 0xFF) else raw_val / 100.0
+        return cls(humidity_percent=hum)
+
+    def to_bytes(self) -> bytes:
+        """Pack 2-byte relative humidity binary payload.
+
+        :returns: Packed binary payload bytes.
+        :rtype: bytes
+        """
+        if self.humidity_percent is None:
+            return struct.pack(self._STRUCT_FMT, 0x00, 0x00)
+        raw_val = int(round(self.humidity_percent * 100.0))
+        return struct.pack(self._STRUCT_FMT, 0x00, raw_val)
+
+    def to_dict(self, msg: Any = None) -> dict[str, Any]:
+        """Convert 2-byte humidity payload to legacy dictionary format.
+
+        :param msg: Optional message context object.
+        :type msg: Any
+        :returns: Decoded humidity dictionary.
+        :rtype: dict[str, Any]
+        """
+        return {SZ_INDOOR_HUMIDITY: self.humidity_percent}
+
+
+@dataclass(frozen=True, slots=True)
+class RelativeHumidity6BPayload(RelativeHumidityPayload):
+    """Multi-sensor relative humidity payload (Opcode 12A0).
+
+    Multi-sensor Relative Humidity binary layout:
+      Offset  Format  Len  Description                    Sample Hex
+      --------------------------------------------------------------
+      +0       B      1B   Sensor / HVAC Index (uint8)  : 00
+      +1       B      1B   Humidity percentage (uint8)  : 32 (50.0%)
+      +2       h      2B   Temperature (int16*100)      : 08 34 (21.00°C)
+      +4       h      2B   Dewpoint Temp (int16*100)    : 04 B0 (12.00°C)
+      --------------------------------------------------------------
+      Field-spaced hex : 00 32 0834 04B0
+      Payload hex      : 0032083404B0
+
+    :param humidity_percent: Relative humidity value (0.0 - 100.0%).
+    :type humidity_percent: float | None
+    :param _hvac_idx: HVAC index string.
+    :type _hvac_idx: str | None
+    :param _temperature: Temperature reading in °C.
+    :type _temperature: float | None
+    :param _dewpoint_temp: Dewpoint temperature in °C.
+    :type _dewpoint_temp: float | None
+    """
+
+    _STRUCT_FMT: ClassVar[str] = ">BBhh"
+
+    humidity_percent: float | None
+    _hvac_idx: str | None = None
+    _temperature: float | None = None
+    _dewpoint_temp: float | None = None
+
+    @classmethod
+    def from_bytes(cls, raw_data: bytes, is_array: bool = False) -> Self:
+        """Unpack multi-sensor relative humidity binary payload.
+
+        :param raw_data: Raw binary byte string.
+        :type raw_data: bytes
+        :param is_array: True if element from multi-sensor array.
+        :type is_array: bool
+        :returns: Unpacked RelativeHumidity6BPayload instance.
+        :rtype: Self
+        :raises ValueError: If raw_data length is less than 6 bytes.
+        """
+        if len(raw_data) < 6:
+            raise ValueError(
+                f"Invalid payload length for RelativeHumidity6BPayload: {len(raw_data)}"
+            )
         idx = f"{raw_data[0]:02X}" if is_array else None
         offset = (
             1 if (idx is not None or (raw_data[0] == 0 and len(raw_data) >= 6)) else 0
@@ -610,22 +759,38 @@ class RelativeHumidityPayload(PayloadBase):
         (dew_raw,) = struct.unpack_from(">h", raw_data, offset + 3)
         dew = None if dew_raw in (0x7FFF, 0x31FF) else dew_raw / 100.0
         return cls(
-            humidity_percent=hum, _hvac_idx=idx, _temperature=temp, _dewpoint_temp=dew
+            humidity_percent=hum,
+            _hvac_idx=idx,
+            _temperature=temp,
+            _dewpoint_temp=dew,
         )
 
     def to_bytes(self) -> bytes:
-        """Pack relative humidity data into binary payload.
+        """Pack multi-sensor relative humidity data into binary payload.
 
         :returns: Packed binary payload bytes.
         :rtype: bytes
         """
-        if self.humidity_percent is None:
-            return struct.pack(self._STRUCT_FMT_1B, 0x00)
-        raw_val = int(round(self.humidity_percent * 2.0))
-        return struct.pack(self._STRUCT_FMT_1B, raw_val)
+        hum_raw = (
+            0
+            if self.humidity_percent is None
+            else int(round(self.humidity_percent * 100.0))
+        )
+        temp_raw = (
+            0x7FFF
+            if self._temperature is None
+            else int(round(self._temperature * 100.0))
+        )
+        dew_raw = (
+            0x7FFF
+            if self._dewpoint_temp is None
+            else int(round(self._dewpoint_temp * 100.0))
+        )
+        idx_raw = int(self._hvac_idx, 16) if self._hvac_idx is not None else 0
+        return struct.pack(self._STRUCT_FMT, idx_raw, hum_raw, temp_raw, dew_raw)
 
     def to_dict(self, msg: Any = None) -> dict[str, Any]:
-        """Convert humidity payload to legacy dictionary format.
+        """Convert multi-sensor humidity payload to legacy dictionary format.
 
         :param msg: Optional message context object.
         :type msg: Any
@@ -637,21 +802,27 @@ class RelativeHumidityPayload(PayloadBase):
             res["hvac_idx"] = self.hvac_idx
             if self.hvac_idx == "00":
                 res[SZ_INDOOR_HUMIDITY] = self.humidity
+                res[SZ_TEMPERATURE] = self.temperature
+                res[SZ_DEWPOINT_TEMP] = self.dewpoint_temp
             elif self.hvac_idx == "02":
                 res[SZ_OUTDOOR_HUMIDITY] = self.humidity
+                res[SZ_TEMPERATURE] = self.temperature
+                res[SZ_DEWPOINT_TEMP] = self.dewpoint_temp
             else:
                 res["rel_humidity"] = self.humidity
         else:
             res[SZ_INDOOR_HUMIDITY] = self.humidity
-
-        if (
-            self.temperature is not None
-            or self.dewpoint_temp is not None
-            or len(getattr(self, "_raw", b"")) >= 6
-        ):
             res[SZ_TEMPERATURE] = self.temperature
             res[SZ_DEWPOINT_TEMP] = self.dewpoint_temp
         return res
+
+
+# Update VARIANTS property after variants are defined
+RelativeHumidityPayload.VARIANTS = (
+    RelativeHumidity1BPayload,
+    RelativeHumidity2BPayload,
+    RelativeHumidity6BPayload,
+)
 
 
 # ----------------------------------------------------------------------
@@ -1062,15 +1233,41 @@ class HvacProgrammeEnabledPayload(PayloadBase):
 
 
 @register_payload("22E0")
-# ----------------------------------------------------------------------
-
 @register_payload("22E5")
-# ----------------------------------------------------------------------
-
 @register_payload("22E9")
-@dataclass(frozen=True, slots=True)
 class HvacVentilationStatusPayload(PayloadBase):
-    """HVAC ventilation status payload (Opcode 22E0, 22E5, 22E9).
+    """Master payload dispatcher for HVAC ventilation status (Opcode 22E0, 22E5, 22E9)."""
+
+    VARIANTS: ClassVar[tuple[type[PayloadBase], ...]] = ()
+
+    flow_mode: int
+    status_flags: int
+
+    @classmethod
+    def from_bytes(
+        cls, raw_data: bytes
+    ) -> "HvacVentilationStatus2BPayload | HvacVentilationStatus4BPayload":
+        """Unpack ventilation status payload, dispatching by length."""
+        if len(raw_data) >= 4:
+            return HvacVentilationStatus4BPayload.from_bytes(raw_data)
+        if len(raw_data) >= 2:
+            return HvacVentilationStatus2BPayload.from_bytes(raw_data)
+        raise ValueError(f"Invalid payload length: {len(raw_data)}")
+
+    def to_bytes(self) -> bytes:
+        """Pack payload base default method.
+
+        :returns: Packed binary payload bytes.
+        :rtype: bytes
+        :raises NotImplementedError: Master dispatcher must dispatch to
+            variant sub-dataclass.
+        """
+        raise NotImplementedError("Use concrete variant sub-dataclass")
+
+
+@dataclass(frozen=True, slots=True)
+class HvacVentilationStatus2BPayload(HvacVentilationStatusPayload):
+    """2-byte HVAC ventilation status payload (Opcode 22E0, 22E5, 22E9).
 
     2-byte Ventilation Status binary layout:
       Offset  Format  Len  Description                    Sample Hex
@@ -1085,83 +1282,148 @@ class HvacVentilationStatusPayload(PayloadBase):
     :type flow_mode: int
     :param status_flags: Status flags byte.
     :type status_flags: int
-
-    Sample Packet Logs:
-    # RP --- 32:155617 18:005904 --:------ 22E0 004 00-34-A0-1E
-    # RP --- 32:153258 18:005904 --:------ 22E0 004 00-64-A0-1E
-    # RP --- 32:153258 18:005904 --:------ 22E5 004 00-96-C8-14
-    # RP --- 32:155617 18:005904 --:------ 22E5 004 00-72-C8-14
     """
 
     _STRUCT_FMT: ClassVar[str] = ">BB"
 
     flow_mode: int
     status_flags: int
-    _percent_2: float | None = None
-    _percent_4: float | None = None
-    _percent_6: float | None = None
-    _raw_bytes: bytes | None = None
 
     @classmethod
     def from_bytes(cls, raw_data: bytes) -> Self:
-        """Unpack ventilation status binary payload.
+        """Unpack 2-byte ventilation status binary payload.
 
         :param raw_data: Raw binary byte string.
         :type raw_data: bytes
-        :returns: Unpacked HvacVentilationStatusPayload instance.
+        :returns: Unpacked HvacVentilationStatus2BPayload instance.
         :rtype: Self
         :raises ValueError: If raw_data length is less than 2 bytes.
         """
         if len(raw_data) < 2:
-            raise ValueError(f"Invalid payload length: {len(raw_data)}")
-        if len(raw_data) >= 4:
-            hdr, r2, r4, r6 = struct.unpack_from(">BBBB", raw_data, 0)
-            return cls(
-                flow_mode=hdr,
-                status_flags=r2,
-                _percent_2=round(r2 / 200.0, 2),
-                _percent_4=round(r4 / 200.0, 2),
-                _percent_6=round(r6 / 200.0, 2),
-                _raw_bytes=raw_data,
+            raise ValueError(
+                f"Invalid payload length for HvacVentilationStatus2BPayload: {len(raw_data)}"
             )
         f_mode, s_flags = struct.unpack_from(cls._STRUCT_FMT, raw_data, 0)
-        return cls(
-            flow_mode=f_mode,
-            status_flags=s_flags,
-            _raw_bytes=raw_data if len(raw_data) > 2 else None,
-        )
+        return cls(flow_mode=f_mode, status_flags=s_flags)
 
     def to_bytes(self) -> bytes:
-        """Pack ventilation status data into binary payload.
+        """Pack 2-byte ventilation status data into binary payload.
 
         :returns: Packed binary payload bytes.
         :rtype: bytes
         """
-        if self._raw_bytes is not None:
-            return self._raw_bytes
         return struct.pack(self._STRUCT_FMT, self.flow_mode, self.status_flags)
 
     def to_dict(self, msg: Any = None) -> dict[str, Any]:
-        """Convert ventilation status payload to legacy dictionary layout.
+        """Convert 2-byte ventilation status payload to legacy dictionary layout.
 
         :param msg: Optional message context object.
         :type msg: Any
         :returns: Decoded ventilation status dictionary.
         :rtype: dict[str, Any]
         """
-        if self._raw_bytes is not None and len(self._raw_bytes) >= 4:
-            hdr, r2, r4, r6 = struct.unpack_from(">BBBB", self._raw_bytes, 0)
-            if r2 == 1:
-                return {"unknown_4": f"{r4:02X}", "unknown_6": f"{r6:02X}"}
-            return {
-                "percent_2": round(r2 / 200.0, 2),
-                "percent_4": round(r4 / 200.0, 2),
-                "percent_6": round(r6 / 200.0, 2),
-            }
         return {
             "flow_mode": self.flow_mode,
             "status_flags": self.status_flags,
         }
+
+
+@dataclass(frozen=True, slots=True)
+class HvacVentilationStatus4BPayload(HvacVentilationStatusPayload):
+    """4-byte HVAC ventilation status payload (Opcode 22E0, 22E5, 22E9).
+
+    4-byte Ventilation Status binary layout:
+      Offset  Format  Len  Description                    Sample Hex
+      --------------------------------------------------------------
+      +0       B      1B   Flow Mode Header             : 00
+      +1       B      1B   Raw byte 2 (uint8)           : 34
+      +2       B      1B   Raw byte 4 (uint8)           : A0
+      +3       B      1B   Raw byte 6 (uint8)           : 1E
+      --------------------------------------------------------------
+      Field-spaced hex : 00 34 A0 1E
+      Payload hex      : 0034A01E
+
+    :param flow_mode: Current ventilation flow mode byte.
+    :type flow_mode: int
+    :param status_flags: Status flags byte (raw byte 2).
+    :type status_flags: int
+    :param percent_2: Normalized percentage from byte 2.
+    :type percent_2: float | None
+    :param percent_4: Normalized percentage from byte 4.
+    :type percent_4: float | None
+    :param percent_6: Normalized percentage from byte 6.
+    :type percent_6: float | None
+    :param raw_bytes: Complete raw payload bytes.
+    :type raw_bytes: bytes
+    """
+
+    _STRUCT_FMT: ClassVar[str] = ">BBBB"
+
+    flow_mode: int
+    status_flags: int
+    percent_2: float | None = None
+    percent_4: float | None = None
+    percent_6: float | None = None
+    raw_bytes: bytes = b""
+
+    @classmethod
+    def from_bytes(cls, raw_data: bytes) -> Self:
+        """Unpack 4-byte ventilation status binary payload.
+
+        :param raw_data: Raw binary byte string.
+        :type raw_data: bytes
+        :returns: Unpacked HvacVentilationStatus4BPayload instance.
+        :rtype: Self
+        :raises ValueError: If raw_data length is less than 4 bytes.
+        """
+        if len(raw_data) < 4:
+            raise ValueError(
+                f"Invalid payload length for HvacVentilationStatus4BPayload: {len(raw_data)}"
+            )
+        hdr, r2, r4, r6 = struct.unpack_from(cls._STRUCT_FMT, raw_data, 0)
+        return cls(
+            flow_mode=hdr,
+            status_flags=r2,
+            percent_2=round(r2 / 200.0, 2),
+            percent_4=round(r4 / 200.0, 2),
+            percent_6=round(r6 / 200.0, 2),
+            raw_bytes=raw_data,
+        )
+
+    def to_bytes(self) -> bytes:
+        """Pack 4-byte ventilation status data into binary payload.
+
+        :returns: Packed binary payload bytes.
+        :rtype: bytes
+        """
+        if self.raw_bytes:
+            return self.raw_bytes
+        return struct.pack(self._STRUCT_FMT, self.flow_mode, self.status_flags, 0, 0)
+
+    def to_dict(self, msg: Any = None) -> dict[str, Any]:
+        """Convert 4-byte ventilation status payload to legacy dictionary layout.
+
+        :param msg: Optional message context object.
+        :type msg: Any
+        :returns: Decoded ventilation status dictionary.
+        :rtype: dict[str, Any]
+        """
+        if self.status_flags == 1:
+            r4 = self.raw_bytes[2] if len(self.raw_bytes) > 2 else 0
+            r6 = self.raw_bytes[3] if len(self.raw_bytes) > 3 else 0
+            return {"unknown_4": f"{r4:02X}", "unknown_6": f"{r6:02X}"}
+        return {
+            "percent_2": self.percent_2,
+            "percent_4": self.percent_4,
+            "percent_6": self.percent_6,
+        }
+
+
+# Update VARIANTS property after variants are defined
+HvacVentilationStatusPayload.VARIANTS = (
+    HvacVentilationStatus2BPayload,
+    HvacVentilationStatus4BPayload,
+)
 
 
 # ----------------------------------------------------------------------
@@ -3473,10 +3735,10 @@ class CoolingStatePayload(PayloadBase):
       Offset  Format  Len  Description                    Sample Hex
       --------------------------------------------------------------
       +0       B      1B   Domain / Zone Index (uint8)  : 00
-      +1       B      1B   Cooling Active (0=No, 1=Yes) : 01
+      +1       B      1B   Cooling Active (0=No, C8=Yes): C8
       --------------------------------------------------------------
-      Field-spaced hex : 00 01
-      Payload hex      : 0001
+      Field-spaced hex : 00 C8
+      Payload hex      : 00C8
 
     :param domain_or_zone_idx: Domain or zone index byte.
     :type domain_or_zone_idx: int

--- a/src/ramses_rf/payloads/system.py
+++ b/src/ramses_rf/payloads/system.py
@@ -6,7 +6,6 @@ device binding, fault log, and gateway heartbeat packet payloads.
 
 import re
 import struct
-from abc import ABC
 from dataclasses import dataclass
 from typing import Any, ClassVar, Self
 
@@ -516,14 +515,43 @@ class SystemFlagPayload(PayloadBase):
 # ----------------------------------------------------------------------
 
 
+# ----------------------------------------------------------------------
+
+
 @register_payload("0100")
-@dataclass(frozen=True, slots=True)
-class SystemLanguageBasePayload(PayloadBase, ABC):
-    """Abstract base class for system language (Opcode 0100)."""
+class SystemLanguagePayload(PayloadBase):
+    """Master payload dispatcher for system language (Opcode 0100).
+
+    Dispatches system language configuration payloads to 2-byte or
+    3-byte variant sub-dataclasses based on payload length.
+    """
+
+    VARIANTS: ClassVar[tuple[type[PayloadBase], ...]] = ()
+
+    language: str | None = None
+
+    @classmethod
+    def from_bytes(
+        cls, raw_data: bytes
+    ) -> "SystemLanguage2BPayload | SystemLanguage3BPayload":
+        """Unpack system language binary payload, dispatching by length."""
+        if len(raw_data) >= 3:
+            return SystemLanguage3BPayload.from_bytes(raw_data)
+        return SystemLanguage2BPayload.from_bytes(raw_data)
+
+    def to_bytes(self) -> bytes:
+        """Pack payload base default method.
+
+        :returns: Packed binary payload bytes.
+        :rtype: bytes
+        :raises NotImplementedError: Master dispatcher must dispatch to
+            variant sub-dataclass.
+        """
+        raise NotImplementedError("Use concrete variant sub-dataclass")
 
 
 @dataclass(frozen=True, slots=True)
-class SystemLanguage2BPayload(SystemLanguageBasePayload):
+class SystemLanguage2BPayload(SystemLanguagePayload):
     """System language 2-byte configuration layout (Opcode 0100).
 
     2-byte Language binary layout:
@@ -580,7 +608,7 @@ class SystemLanguage2BPayload(SystemLanguageBasePayload):
 
 
 @dataclass(frozen=True, slots=True)
-class SystemLanguage3BPayload(SystemLanguageBasePayload):
+class SystemLanguage3BPayload(SystemLanguagePayload):
     """System language 3-byte string configuration layout (Opcode 0100).
 
     3-byte Language binary layout:
@@ -632,27 +660,11 @@ class SystemLanguage3BPayload(SystemLanguageBasePayload):
         return {"language": self.language}
 
 
-@register_payload("0100")
-class SystemLanguagePayload(PayloadBase, ABC):
-    """Master payload dispatcher for system language (Opcode 0100).
-
-    Dispatches system language configuration payloads to 2-byte or
-    3-byte variant sub-dataclasses based on payload length.
-    """
-
-    VARIANTS: ClassVar[tuple[type[PayloadBase], ...]] = (
-        SystemLanguage2BPayload,
-        SystemLanguage3BPayload,
-    )
-
-    @classmethod
-    def from_bytes(
-        cls, raw_data: bytes
-    ) -> SystemLanguage2BPayload | SystemLanguage3BPayload:
-        """Unpack system language binary payload, dispatching by length."""
-        if len(raw_data) >= 3:
-            return SystemLanguage3BPayload.from_bytes(raw_data)
-        return SystemLanguage2BPayload.from_bytes(raw_data)
+# Update VARIANTS property after variants are defined
+SystemLanguagePayload.VARIANTS = (
+    SystemLanguage2BPayload,
+    SystemLanguage3BPayload,
+)
 
 
 # ----------------------------------------------------------------------
@@ -1234,13 +1246,40 @@ class SystemOutdoorTempPayload(PayloadBase):
 # ----------------------------------------------------------------------
 
 
+# ----------------------------------------------------------------------
+
+
 @register_payload("1F09")
-class SystemSyncHeartbeatBasePayload(PayloadBase, ABC):
-    """Abstract base class for system synchronization heartbeat (Opcode 1F09)."""
+class SystemSyncHeartbeatPayload(PayloadBase):
+    """Master payload dispatcher for system synchronization heartbeat (Opcode 1F09)."""
+
+    VARIANTS: ClassVar[tuple[type[PayloadBase], ...]] = ()
+
+    sync_sequence: int
+    remaining_seconds: float | None = None
+
+    @classmethod
+    def from_bytes(
+        cls, raw_data: bytes
+    ) -> "SystemSyncHeartbeat1BPayload | SystemSyncHeartbeat3BPayload":
+        """Unpack system sync heartbeat binary payload, dispatching by length."""
+        if len(raw_data) >= 3:
+            return SystemSyncHeartbeat3BPayload.from_bytes(raw_data)
+        return SystemSyncHeartbeat1BPayload.from_bytes(raw_data)
+
+    def to_bytes(self) -> bytes:
+        """Pack payload base default method.
+
+        :returns: Packed binary payload bytes.
+        :rtype: bytes
+        :raises NotImplementedError: Master dispatcher must dispatch to
+            variant sub-dataclass.
+        """
+        raise NotImplementedError("Use concrete variant sub-dataclass")
 
 
 @dataclass(frozen=True, slots=True)
-class SystemSyncHeartbeat1BPayload(SystemSyncHeartbeatBasePayload):
+class SystemSyncHeartbeat1BPayload(SystemSyncHeartbeatPayload):
     """System synchronization heartbeat 1-byte layout (Opcode 1F09).
 
     1-byte System Sync Heartbeat binary layout:
@@ -1253,11 +1292,14 @@ class SystemSyncHeartbeat1BPayload(SystemSyncHeartbeatBasePayload):
 
     :param sync_sequence: Synchronization sequence flag.
     :type sync_sequence: int
+    :param remaining_seconds: Remaining seconds (None for 1B payload).
+    :type remaining_seconds: float | None
     """
 
     _STRUCT_FMT: ClassVar[str] = ">B"
 
     sync_sequence: int
+    remaining_seconds: float | None = None
 
     @classmethod
     def from_bytes(cls, raw_data: bytes) -> Self:
@@ -1288,7 +1330,7 @@ class SystemSyncHeartbeat1BPayload(SystemSyncHeartbeatBasePayload):
 
 
 @dataclass(frozen=True, slots=True)
-class SystemSyncHeartbeat3BPayload(SystemSyncHeartbeatBasePayload):
+class SystemSyncHeartbeat3BPayload(SystemSyncHeartbeatPayload):
     """System synchronization heartbeat 3-byte layout (Opcode 1F09).
 
     3-byte System Sync Heartbeat binary layout:
@@ -1303,13 +1345,13 @@ class SystemSyncHeartbeat3BPayload(SystemSyncHeartbeatBasePayload):
     :param sync_sequence: Synchronization sequence flag.
     :type sync_sequence: int
     :param remaining_seconds: Remaining synchronization seconds.
-    :type remaining_seconds: float
+    :type remaining_seconds: float | None
     """
 
     _STRUCT_FMT: ClassVar[str] = ">BH"
 
     sync_sequence: int
-    remaining_seconds: float
+    remaining_seconds: float | None = None
 
     @classmethod
     def from_bytes(cls, raw_data: bytes) -> Self:
@@ -1334,7 +1376,11 @@ class SystemSyncHeartbeat3BPayload(SystemSyncHeartbeatBasePayload):
         :returns: Packed binary payload bytes.
         :rtype: bytes
         """
-        secs_raw = int(round(self.remaining_seconds * 10.0))
+        secs_raw = (
+            0
+            if self.remaining_seconds is None
+            else int(round(self.remaining_seconds * 10.0))
+        )
         return struct.pack(self._STRUCT_FMT, self.sync_sequence, secs_raw)
 
     def to_dict(self) -> dict[str, Any]:
@@ -1342,37 +1388,49 @@ class SystemSyncHeartbeat3BPayload(SystemSyncHeartbeatBasePayload):
         return {"remaining_seconds": self.remaining_seconds}
 
 
-@register_payload("1F09")
-class SystemSyncHeartbeatPayload(PayloadBase, ABC):
-    """Master payload dispatcher for Opcode 1F09."""
-
-    VARIANTS: ClassVar[tuple[type[PayloadBase], ...]] = (
-        SystemSyncHeartbeat1BPayload,
-        SystemSyncHeartbeat3BPayload,
-    )
-
-    @classmethod
-    def from_bytes(
-        cls, raw_data: bytes
-    ) -> SystemSyncHeartbeat1BPayload | SystemSyncHeartbeat3BPayload:
-        """Unpack system sync heartbeat binary payload, dispatching by length."""
-        if len(raw_data) >= 3:
-            return SystemSyncHeartbeat3BPayload.from_bytes(raw_data)
-        return SystemSyncHeartbeat1BPayload.from_bytes(raw_data)
+# Update VARIANTS property after variants are defined
+SystemSyncHeartbeatPayload.VARIANTS = (
+    SystemSyncHeartbeat1BPayload,
+    SystemSyncHeartbeat3BPayload,
+)
 
 
 # ----------------------------------------------------------------------
 
 
 @register_payload("2E04")
-# ----------------------------------------------------------------------
+@register_payload("2E10")
+class SystemConfigPayload(PayloadBase):
+    """Master payload dispatcher for Opcode 2E04 and 2E10."""
 
-class SystemConfigBasePayload(PayloadBase, ABC):
-    """Abstract base class for system configuration parameter (Opcode 2E04, 2E10)."""
+    VARIANTS: ClassVar[tuple[type[PayloadBase], ...]] = ()
+
+    config_idx: int
+    config_val: int
+    raw_extra: bytes | None = None
+
+    @classmethod
+    def from_bytes(
+        cls, raw_data: bytes
+    ) -> "SystemConfig2BPayload | SystemConfigVarPayload":
+        """Unpack system config binary payload, dispatching by length."""
+        if len(raw_data) > 2:
+            return SystemConfigVarPayload.from_bytes(raw_data)
+        return SystemConfig2BPayload.from_bytes(raw_data)
+
+    def to_bytes(self) -> bytes:
+        """Pack payload base default method.
+
+        :returns: Packed binary payload bytes.
+        :rtype: bytes
+        :raises NotImplementedError: Master dispatcher must dispatch to
+            variant sub-dataclass.
+        """
+        raise NotImplementedError("Use concrete variant sub-dataclass")
 
 
 @dataclass(frozen=True, slots=True)
-class SystemConfig2BPayload(SystemConfigBasePayload):
+class SystemConfig2BPayload(SystemConfigPayload):
     """System configuration parameter 2-byte payload (Opcode 2E04, 2E10).
 
     2-byte System Config binary layout:
@@ -1388,15 +1446,15 @@ class SystemConfig2BPayload(SystemConfigBasePayload):
     :type config_idx: int
     :param config_val: Configuration value byte.
     :type config_val: int
-
-    Protocol Notes:
-    # presence_detect, HVAC sensor, or Timed boost for Vasco D60
+    :param raw_extra: Trailing bytes (None for 2B payload).
+    :type raw_extra: bytes | None
     """
 
     _STRUCT_FMT: ClassVar[str] = ">BB"
 
     config_idx: int
     config_val: int
+    raw_extra: bytes | None = None
 
     @classmethod
     def from_bytes(cls, raw_data: bytes) -> Self:
@@ -1445,32 +1503,32 @@ class SystemConfig2BPayload(SystemConfigBasePayload):
 
 
 @dataclass(frozen=True, slots=True)
-class SystemConfigVarPayload(SystemConfigBasePayload):
+class SystemConfigVarPayload(SystemConfigPayload):
     """System configuration parameter variable-length payload (Opcode 2E04, 2E10).
 
     Variable-length System Config binary layout:
       Offset  Format  Len  Description                    Sample Hex
       --------------------------------------------------------------
-      +0       B      1B   Config Index (uint8)         : 00
+      +0       B      1B   Config Index (uint8)         : 01
       +1       B      1B   Config Value (uint8)         : 00
-      +2       s     ...   Trailing config bytes        : ...
+      +2       6s     6B   Trailing config bytes        : 00 00 00 00 00 00
       --------------------------------------------------------------
-      Field-spaced hex : 00 00 ...
-      Payload hex      : 0000...
+      Field-spaced hex : 01 00 000000000000
+      Payload hex      : 0100000000000000
 
     :param config_idx: Configuration index byte.
     :type config_idx: int
     :param config_val: Configuration value byte.
     :type config_val: int
     :param raw_extra: Trailing configuration bytes.
-    :type raw_extra: bytes
+    :type raw_extra: bytes | None
     """
 
     _STRUCT_FMT: ClassVar[str] = ">BB"
 
     config_idx: int
     config_val: int
-    raw_extra: bytes
+    raw_extra: bytes | None = None
 
     @classmethod
     def from_bytes(cls, raw_data: bytes) -> Self:
@@ -1495,9 +1553,8 @@ class SystemConfigVarPayload(SystemConfigBasePayload):
         :returns: Packed binary payload bytes.
         :rtype: bytes
         """
-        return (
-            struct.pack(self._STRUCT_FMT, self.config_idx, self.config_val)
-            + self.raw_extra
+        return struct.pack(self._STRUCT_FMT, self.config_idx, self.config_val) + (
+            self.raw_extra or b""
         )
 
     def to_dict(self, msg: Any = None) -> dict[str, Any]:
@@ -1525,60 +1582,129 @@ class SystemConfigVarPayload(SystemConfigBasePayload):
         return {"config_idx": self.config_idx, "config_val": self.config_val}
 
 
-@register_payload("2E04")
-@register_payload("2E10")
-class SystemConfigPayload(PayloadBase, ABC):
-    """Master payload dispatcher for Opcode 2E04 and 2E10."""
-
-    VARIANTS: ClassVar[tuple[type[PayloadBase], ...]] = (
-        SystemConfig2BPayload,
-        SystemConfigVarPayload,
-    )
-
-    @classmethod
-    def from_bytes(
-        cls, raw_data: bytes
-    ) -> SystemConfig2BPayload | SystemConfigVarPayload:
-        """Unpack system config binary payload, dispatching by length."""
-        if len(raw_data) > 2:
-            return SystemConfigVarPayload.from_bytes(raw_data)
-        return SystemConfig2BPayload.from_bytes(raw_data)
+# Update VARIANTS property after variants are defined
+SystemConfigPayload.VARIANTS = (
+    SystemConfig2BPayload,
+    SystemConfigVarPayload,
+)
 
 
 # ----------------------------------------------------------------------
 
 
 @register_payload("313F")
-@dataclass(frozen=True, slots=True)
 class SystemDateTimePayload(PayloadBase):
-    """System date and time payload (Opcode 313F).
+    """Master payload dispatcher for system date and time (Opcode 313F)."""
+
+    VARIANTS: ClassVar[tuple[type[PayloadBase], ...]] = ()
+
+    domain_idx: int
+    datetime_str: str | None = None
+    is_dst: bool | None = None
+
+    @classmethod
+    def from_bytes(
+        cls, raw_data: bytes
+    ) -> "SystemDateTime2BPayload | SystemDateTime9BPayload":
+        """Unpack system date & time payload, dispatching by length."""
+        if len(raw_data) >= 9:
+            return SystemDateTime9BPayload.from_bytes(raw_data)
+        return SystemDateTime2BPayload.from_bytes(raw_data)
+
+    def to_bytes(self) -> bytes:
+        """Pack payload base default method.
+
+        :returns: Packed binary payload bytes.
+        :rtype: bytes
+        :raises NotImplementedError: Master dispatcher must dispatch to
+            variant sub-dataclass.
+        """
+        raise NotImplementedError("Use concrete variant sub-dataclass")
+
+
+@dataclass(frozen=True, slots=True)
+class SystemDateTime2BPayload(SystemDateTimePayload):
+    """2-byte system date and time header payload (Opcode 313F).
+
+    2-byte System Date & Time Header binary layout:
+      Offset  Format  Len  Description                    Sample Hex
+      --------------------------------------------------------------
+      +0       B      1B   Domain / Header Index        : 00
+      +1       B      1B   Sub-index / Flag             : 00
+      --------------------------------------------------------------
+      Field-spaced hex : 00 00
+      Payload hex      : 0000
+
+    :param domain_idx: Domain/header index byte.
+    :type domain_idx: int
+    """
+
+    _STRUCT_FMT: ClassVar[str] = ">BB"
+
+    domain_idx: int
+
+    @classmethod
+    def from_bytes(cls, raw_data: bytes) -> Self:
+        """Unpack 2-byte system date & time header binary payload.
+
+        :param raw_data: Raw binary byte string.
+        :type raw_data: bytes
+        :returns: Unpacked SystemDateTime2BPayload instance.
+        :rtype: Self
+        :raises ValueError: If raw_data length is less than 2 bytes.
+        """
+        if len(raw_data) < 2:
+            raise ValueError(
+                f"Invalid payload length for SystemDateTime2BPayload: {len(raw_data)}"
+            )
+        dom, _flag = struct.unpack_from(cls._STRUCT_FMT, raw_data, 0)
+        return cls(domain_idx=dom)
+
+    def to_bytes(self) -> bytes:
+        """Pack 2-byte system date & time header binary payload.
+
+        :returns: Packed binary payload bytes.
+        :rtype: bytes
+        """
+        return struct.pack(self._STRUCT_FMT, self.domain_idx, 0x00)
+
+    def to_dict(self) -> dict[str, Any]:
+        """Convert 2-byte system date & time payload to legacy dictionary layout.
+
+        :returns: Decoded system date & time dictionary.
+        :rtype: dict[str, Any]
+        """
+        return {"is_dst": None}
+
+
+@dataclass(frozen=True, slots=True)
+class SystemDateTime9BPayload(SystemDateTimePayload):
+    """9-byte system date and time payload (Opcode 313F).
 
     9-byte System Date & Time binary layout:
       Offset  Format  Len  Description                    Sample Hex
       --------------------------------------------------------------
       +0       B      1B   Domain / Header Index        : 00
       +1       B      1B   Sub-index / Flags            : F0
-      +2       B      1B   Year | DST flag (0x80)       : 96 (22 | 0x80)
-      +3       B      1B   Month (1-12)                 : 05
-      +4       B      1B   Day (1-31)                   : 02
-      +5       B      1B   Hours (0-23)                 : 0A (10)
-      +6       B      1B   Minutes (0-59)               : 02
-      +7       B      1B   Seconds (0-59)               : 36 (54)
-      +8       B      1B   Padding / Reserved           : 00
+      +2       B      1B   Seconds | DST Flag (0x80)    : BB (59s + DST)
+      +3       B      1B   Minutes (0-59)               : 00 (0m)
+      +4       B      1B   Hours (0-23)                 : 04 (4h)
+      +5       B      1B   Day (1-31)                   : 0C (12)
+      +6       B      1B   Month (1-12)                 : 05 (May)
+      +7       H      2B   Year (uint16)                : 07 EA (2026)
       --------------------------------------------------------------
-      Field-spaced hex : 00 F0 36 02 0A 02 05 07 E6
-      Payload hex      : 00F036020A020507E6
-
+      Field-spaced hex : 00 F0 BB 00 04 0C 05 07EA
+      Payload hex      : 00F0BB00040C0507EA
 
     :param domain_idx: Domain/header index byte.
-    :type domain_idx: str | int | None
-    :param datetime_str: Formatted ISO datetime string (e.g., '2022-05-02T10:02:54').
+    :type domain_idx: int
+    :param datetime_str: Formatted ISO datetime string (e.g., '2026-05-12T04:00:59').
     :type datetime_str: str | None
     :param is_dst: Daylight Saving Time active flag.
     :type is_dst: bool | None
     """
 
-    _STRUCT_FMT_HEADER: ClassVar[str] = ">B"
+    _STRUCT_FMT: ClassVar[str] = ">BBBBBBBH"
 
     domain_idx: int
     datetime_str: str | None = None
@@ -1586,31 +1712,30 @@ class SystemDateTimePayload(PayloadBase):
 
     @classmethod
     def from_bytes(cls, raw_data: bytes) -> Self:
-        """Unpack system date & time binary payload.
+        """Unpack 9-byte system date & time binary payload.
 
         :param raw_data: Raw binary byte string.
         :type raw_data: bytes
-        :returns: Unpacked SystemDateTimePayload instance.
+        :returns: Unpacked SystemDateTime9BPayload instance.
         :rtype: Self
-        :raises ValueError: If raw_data length is less than 2 bytes.
+        :raises ValueError: If raw_data length is less than 9 bytes.
         """
-        if len(raw_data) < 2:
-            raise ValueError(f"Invalid payload length for 313F: {len(raw_data)}")
-
-        (dom,) = struct.unpack_from(cls._STRUCT_FMT_HEADER, raw_data, 0)
-        if len(raw_data) >= 9:
-            hex_str = raw_data[2:9].hex().upper()
-            dt_str = hex_to_dtm(hex_str)
-            dst_flag = True if bool(raw_data[2] & 0x80) else None
-            return cls(
-                domain_idx=dom,
-                datetime_str=dt_str,
-                is_dst=dst_flag,
+        if len(raw_data) < 9:
+            raise ValueError(
+                f"Invalid payload length for SystemDateTime9BPayload: {len(raw_data)}"
             )
-        return cls(domain_idx=dom)
+        dom = raw_data[0]
+        hex_str = raw_data[2:9].hex().upper()
+        dt_str = hex_to_dtm(hex_str)
+        dst_flag = True if bool(raw_data[2] & 0x80) else None
+        return cls(
+            domain_idx=dom,
+            datetime_str=dt_str,
+            is_dst=dst_flag,
+        )
 
     def to_bytes(self) -> bytes:
-        """Pack system date & time data into binary payload.
+        """Pack 9-byte system date & time data into binary payload.
 
         :returns: Packed binary payload bytes.
         :rtype: bytes
@@ -1619,12 +1744,8 @@ class SystemDateTimePayload(PayloadBase):
             dt_hex = hex_from_dtm(
                 self.datetime_str, is_dst=self.is_dst or False, incl_seconds=True
             )
-            return (
-                struct.pack(self._STRUCT_FMT_HEADER, self.domain_idx)
-                + b"\xf0"
-                + bytes.fromhex(dt_hex)
-            )
-        return struct.pack(self._STRUCT_FMT_HEADER, self.domain_idx) + b"\x00"
+            return bytes([self.domain_idx, 0xF0]) + bytes.fromhex(dt_hex)
+        return struct.pack(self._STRUCT_FMT, self.domain_idx, 0xF0, 0, 0, 0, 0, 0, 0, 0)
 
     def to_dict(self) -> dict[str, Any]:
         """Convert system date & time payload to legacy dictionary layout.
@@ -1637,6 +1758,13 @@ class SystemDateTimePayload(PayloadBase):
             res["datetime"] = self.datetime_str
         res["is_dst"] = self.is_dst
         return res
+
+
+# Update VARIANTS property after variants are defined
+SystemDateTimePayload.VARIANTS = (
+    SystemDateTime2BPayload,
+    SystemDateTime9BPayload,
+)
 
 
 @dataclass(frozen=True, slots=True)

--- a/tests/tests_rf/test_command_builders_parity.py
+++ b/tests/tests_rf/test_command_builders_parity.py
@@ -5,7 +5,6 @@ from ramses_rf.commands.builders import dhw, heat, opentherm, schedules, zones
 from ramses_rf.commands.core import Command
 from ramses_rf.enums import Action
 from ramses_rf.payloads.dhw import DhwParams6BPayload, DhwParamsPayload
-from ramses_rf.payloads.heating import DhwTemperaturePayload
 from ramses_tx.const import I_, RQ, W_, Code
 
 
@@ -48,22 +47,8 @@ def test_dhw_params_payload_roundtrip() -> None:
     assert payload.hex() == raw_hex
 
 
-def test_dhw_temperature_payload_dispatch() -> None:
-    """Verify DhwTemperaturePayload.from_bytes dispatches 6-byte 10A0 payloads to DhwParamsPayload."""
-    # Arrange
-    raw_bytes = bytes.fromhex("001388050064")
-
-    # Act
-    payload = DhwTemperaturePayload.from_bytes(raw_bytes)
-
-    # Assert
-    assert isinstance(payload, DhwParams6BPayload)
-    assert payload.dhw_idx == 0
-    assert payload.setpoint == 50.0
-
-
 def test_build_put_dhw_temp_parity() -> None:
-    """Verify build_put_dhw_temp generates correct hex payload via DhwTemperaturePayload."""
+    """Verify build_put_dhw_temp generates correct hex payload via DhwTempPayload."""
     # Arrange
     cmd = Command(
         src=Address("07:123456"),

--- a/tests/tests_rf/test_payload_codecs.py
+++ b/tests/tests_rf/test_payload_codecs.py
@@ -147,13 +147,82 @@ def test_payload_dataclass_truncated_bytes_rejection(
     assert sample_hex is not None
     raw_bytes = bytes.fromhex(sample_hex)
 
-    # If payload requires fixed byte length > 0, test truncated byte rejection
     if len(raw_bytes) == 0:
         pytest.skip("0-byte payload")
 
-    # Act & Assert
+    # Act & Assert 1: Rejection of empty byte string
     try:
         instance = target_cls.from_bytes(b"")
         assert isinstance(instance, (target_cls, list, base_mod.PayloadBase))
     except ValueError:
         pass  # Expected rejection for strict fixed-length payloads
+
+    # Act & Assert 2: Rejection of 1-byte truncated byte string
+    if len(raw_bytes) > 1:
+        truncated_bytes = raw_bytes[:-1]
+        try:
+            instance = target_cls.from_bytes(truncated_bytes)
+            assert isinstance(instance, (target_cls, list, base_mod.PayloadBase))
+        except ValueError:
+            pass  # Expected rejection for fixed-length struct payloads
+
+
+# Build list of polymorphic Master Dispatchers and their variant classes
+DISPATCHER_TARGETS: list[
+    tuple[str, type[base_mod.PayloadBase], type[base_mod.PayloadBase]]
+] = []
+
+for opcode, master_cls in sorted(PAYLOAD_REGISTRY._registry.items()):
+    variants = getattr(master_cls, "VARIANTS", ())
+    if variants:
+        for v in variants:
+            DISPATCHER_TARGETS.append((opcode, master_cls, v))
+
+
+@pytest.mark.parametrize("opcode, master_cls, variant_cls", DISPATCHER_TARGETS)
+def test_master_dispatcher_dynamic_dispatch(
+    opcode: str,
+    master_cls: type[base_mod.PayloadBase],
+    variant_cls: type[base_mod.PayloadBase],
+) -> None:
+    """Verify Master Dispatcher dynamically constructs the correct variant sub-dataclass."""
+    # Arrange
+    sample_hex = _extract_sample_hex(variant_cls)
+    assert sample_hex is not None, (
+        f"Missing sample hex for variant {variant_cls.__name__} (Opcode {opcode})"
+    )
+    raw_bytes = bytes.fromhex(sample_hex)
+
+    # Act
+    decoded = master_cls.from_bytes(raw_bytes)
+    item = decoded[0] if isinstance(decoded, list) else decoded
+
+    # Assert
+    assert isinstance(item, variant_cls), (
+        f"Master Dispatcher '{master_cls.__name__}' for Opcode {opcode} failed to "
+        f"dispatch to variant '{variant_cls.__name__}' on input hex '{sample_hex}'! "
+        f"Got instance of '{type(item).__name__}'."
+    )
+    assert isinstance(item, master_cls), (
+        f"Variant instance '{type(item).__name__}' is not an instance of "
+        f"Master Dispatcher '{master_cls.__name__}'!"
+    )
+
+
+@pytest.mark.parametrize("opcode, target_cls", DISCOVERED_PAYLOAD_TARGETS)
+def test_payload_dataclass_hex_representation(
+    opcode: str, target_cls: type[base_mod.PayloadBase]
+) -> None:
+    """Verify payload dataclass serialization to uppercase hex strings."""
+    # Arrange
+    sample_hex = _extract_sample_hex(target_cls)
+    assert sample_hex is not None
+    raw_bytes = bytes.fromhex(sample_hex)
+
+    # Act
+    decoded = target_cls.from_bytes(raw_bytes)
+    item = decoded[0] if isinstance(decoded, list) else decoded
+    encoded_hex = item.to_bytes().hex().upper()
+
+    # Assert
+    assert encoded_hex == sample_hex.upper()

--- a/tests/tests_rf/test_payload_parity.py
+++ b/tests/tests_rf/test_payload_parity.py
@@ -10,11 +10,16 @@ import ramses_rf.payloads.system
 import ramses_tx.const as tx_const
 from ramses_rf.parsers.decoder import decode_packet
 from ramses_rf.payloads.adapters import payload_to_dict
-from ramses_rf.payloads.dhw import DhwConfigPayload, DhwStatePayload, DhwTempPayload
+from ramses_rf.payloads.dhw import (
+    DhwConfigPayload,
+    DhwParams3BPayload,
+    DhwParamsPayload,
+    DhwStatePayload,
+    DhwTempPayload,
+)
 from ramses_rf.payloads.heating import (
     ActuatorStatePayload,
     BindingPayload,
-    DhwTemperaturePayload,
     FlowTempPayload,
     HeatDemandPayload,
     OutdoorTempPayload,
@@ -183,23 +188,28 @@ def test_schedule_switchpoint_payload_0404_parity() -> None:
     }
 
 
-def test_dhw_temperature_payload_10a0_parity() -> None:
+def test_dhw_params_payload_10a0_parity() -> None:
     # Arrange
     raw_hex = "000ED8"
     raw_bytes = bytes.fromhex(raw_hex)
 
     # Act
-    payload = DhwTemperaturePayload.from_bytes(raw_bytes)
+    payload = DhwParamsPayload.from_bytes(raw_bytes)
+    assert isinstance(payload, DhwParams3BPayload)
     reencoded = payload.to_bytes().hex().upper()
     as_dict = payload_to_dict(payload)
 
     # Assert
-    assert isinstance(payload, DhwTemperaturePayload)
     assert payload.dhw_idx == 0
-    assert payload.temperature == 38.0
+    assert payload.setpoint == 38.0
 
     assert reencoded == raw_hex
-    assert as_dict == {"dhw_idx": 0, "temperature": 38.0}
+    assert as_dict == {
+        "dhw_idx": 0,
+        "setpoint": 38.0,
+        "overrun": None,
+        "differential": None,
+    }
 
 
 def test_system_sync_payload_1030_parity() -> None:
@@ -451,6 +461,7 @@ def test_zone_setpoint_payload_0004_parity() -> None:
 
     # Act
     payload = ZoneSetpointPayload.from_bytes(raw_bytes)
+    assert not isinstance(payload, list)
     reencoded = payload.to_bytes().hex().upper()
     as_dict = payload_to_dict(payload)
 
@@ -847,7 +858,7 @@ def test_system_config_payload_2e04_parity() -> None:
     assert payload.config_idx == 0
     assert payload.config_val == 0
     assert reencoded == raw_hex
-    assert as_dict == {"config_idx": 0, "config_val": 0}
+    assert as_dict == {"config_idx": 0, "config_val": 0, "raw_extra": None}
 
 
 def test_zone_config_payload_000a_array_parity() -> None:
@@ -1249,3 +1260,152 @@ def test_payload_invalid_byte_length_exception_handling() -> None:
 
     with pytest.raises(ValueError, match="Invalid payload length"):
         ramses_rf.payloads.system.DeviceBatteryPayload.from_bytes(b"\x00")
+
+
+def test_polymorphic_dispatchers_parity_comprehensive() -> None:
+    """Verify polymorphic dispatcher decoding, serialization, and dictionary parity across all variants."""
+    # 1. ZoneName (0004): 22B and Short 3B
+    p_0004_22b = ZoneNamePayload.from_bytes(
+        bytes.fromhex("00004C6976696E6720526F6F6D000000000000000000")
+    )
+    assert isinstance(p_0004_22b, ramses_rf.payloads.heating.ZoneName22BPayload)
+    assert p_0004_22b.name == "Living Room"
+    assert p_0004_22b.zone_idx == 0
+    assert payload_to_dict(p_0004_22b) == {"zone_idx": 0, "name": "Living Room"}
+
+    p_0004_3b = ZoneNamePayload.from_bytes(bytes.fromhex("0007D0"))
+    assert isinstance(p_0004_3b, ramses_rf.payloads.heating.ZoneNameShort3BPayload)
+    assert p_0004_3b.zone_idx == 0
+    assert p_0004_3b.setpoint_temp == 20.0
+    assert payload_to_dict(p_0004_3b) == {"zone_idx": 0, "setpoint_temp": 20.0}
+
+    # 2. RelayDemand (0008): 2B and Jasper 13B
+    p_0008_2b = RelayDemandPayload.from_bytes(bytes.fromhex("00C8"))
+    assert isinstance(p_0008_2b, ramses_rf.payloads.heating.RelayDemand2BPayload)
+    assert p_0008_2b.demand_percent == 1.0
+    assert payload_to_dict(p_0008_2b) == {
+        "domain_or_zone_idx": 0,
+        "demand_percent": 1.0,
+        "raw_extra": None,
+    }
+
+    p_0008_13b = RelayDemandPayload.from_bytes(
+        bytes.fromhex("00000000000000000000000000")
+    )
+    assert isinstance(p_0008_13b, ramses_rf.payloads.heating.RelayDemand2BPayload)
+    assert p_0008_13b.to_bytes().hex().upper() == "00000000000000000000000000"
+
+    # 3. SystemLanguage (0100): 2B and 3B
+    p_0100_2b = ramses_rf.payloads.system.SystemLanguagePayload.from_bytes(
+        bytes.fromhex("0000")
+    )
+    assert isinstance(p_0100_2b, ramses_rf.payloads.system.SystemLanguage2BPayload)
+    assert p_0100_2b.language == "00"
+    assert payload_to_dict(p_0100_2b) == {"language": "00"}
+
+    p_0100_3b = ramses_rf.payloads.system.SystemLanguagePayload.from_bytes(
+        bytes.fromhex("00454E")
+    )
+    assert isinstance(p_0100_3b, ramses_rf.payloads.system.SystemLanguage3BPayload)
+    assert p_0100_3b.language == "EN"
+    assert payload_to_dict(p_0100_3b) == {"language": "EN"}
+
+    # 4. TpiParams (1100): 4B and 8B
+    p_1100_4b = ramses_rf.payloads.heating.TpiParamsPayload.from_bytes(
+        bytes.fromhex("FC180404")
+    )
+    assert isinstance(p_1100_4b, ramses_rf.payloads.heating.TpiParams4BPayload)
+    assert p_1100_4b.cycle_rate == 6
+    assert p_1100_4b.min_on_time == 1.0
+    assert p_1100_4b.min_off_time == 1.0
+
+    p_1100_8b = ramses_rf.payloads.heating.TpiParamsPayload.from_bytes(
+        bytes.fromhex("FC180404007FFF00")
+    )
+    assert isinstance(p_1100_8b, ramses_rf.payloads.heating.TpiParams8BPayload)
+    assert p_1100_8b.cycle_rate == 6
+    assert p_1100_8b.proportional_band_width is None
+
+    # 5. RelativeHumidity (12A0): 1B, 2B, and 6B
+    p_12a0_1b = RelativeHumidityPayload.from_bytes(bytes.fromhex("64"))
+    assert isinstance(p_12a0_1b, ramses_rf.payloads.hvac.RelativeHumidity1BPayload)
+    assert p_12a0_1b.humidity_percent == 50.0
+    assert payload_to_dict(p_12a0_1b) == {"humidity_percent": 50.0}
+
+    p_12a0_2b = RelativeHumidityPayload.from_bytes(bytes.fromhex("0064"))
+    assert isinstance(p_12a0_2b, ramses_rf.payloads.hvac.RelativeHumidity2BPayload)
+    assert p_12a0_2b.humidity_percent == 1.0
+    assert payload_to_dict(p_12a0_2b) == {"humidity_percent": 1.0}
+
+    p_12a0_6b = RelativeHumidityPayload.from_bytes(bytes.fromhex("006407D00834"))
+    assert isinstance(p_12a0_6b, ramses_rf.payloads.hvac.RelativeHumidity6BPayload)
+    assert p_12a0_6b.humidity_percent == 1.0
+    assert p_12a0_6b.temperature == 20.0
+    assert p_12a0_6b.dewpoint_temp == 21.0
+    assert payload_to_dict(p_12a0_6b) == {"humidity_percent": 1.0}
+
+    # 6. HvacVentilationStatus (22E0, 22E5, 22E9): 2B and 4B
+    p_22e0_2b = HvacVentilationStatusPayload.from_bytes(bytes.fromhex("0100"))
+    assert isinstance(p_22e0_2b, ramses_rf.payloads.hvac.HvacVentilationStatus2BPayload)
+    assert p_22e0_2b.flow_mode == 1
+    assert p_22e0_2b.status_flags == 0
+    assert payload_to_dict(p_22e0_2b) == {"flow_mode": 1, "status_flags": 0}
+
+    p_22e0_4b = HvacVentilationStatusPayload.from_bytes(bytes.fromhex("0034A01E"))
+    assert isinstance(p_22e0_4b, ramses_rf.payloads.hvac.HvacVentilationStatus4BPayload)
+    assert p_22e0_4b.flow_mode == 0
+    assert p_22e0_4b.status_flags == 0x34
+    assert payload_to_dict(p_22e0_4b)["flow_mode"] == 0
+
+    # 7. ZoneSetpoint (2309): 3B
+    p_2309 = ZoneSetpointPayload.from_bytes(bytes.fromhex("0007D0"))
+    assert isinstance(p_2309, ramses_rf.payloads.heating.ZoneSetpoint3BPayload)
+    assert p_2309.zone_idx == 0
+    assert p_2309.setpoint_temp == 20.0
+    assert payload_to_dict(p_2309) == {"zone_idx": 0, "setpoint_temp": 20.0}
+
+    # 8. ZoneMode (2349): 4B, 7B, and 13B
+    p_2349_4b = ZoneModePayload.from_bytes(bytes.fromhex("0007D000"))
+    assert isinstance(p_2349_4b, ramses_rf.payloads.heating.ZoneMode4BPayload)
+    assert p_2349_4b.zone_idx == 0
+    assert p_2349_4b.setpoint_temp == 20.0
+    assert p_2349_4b.mode_code == 0
+    assert payload_to_dict(p_2349_4b) == {
+        "zone_idx": 0,
+        "setpoint_temp": 20.0,
+        "mode_code": 0,
+        "duration_minutes": None,
+        "until_dtm": None,
+    }
+
+    p_2349_7b = ZoneModePayload.from_bytes(bytes.fromhex("0007D00200003C"))
+    assert isinstance(p_2349_7b, ramses_rf.payloads.heating.ZoneMode7BPayload)
+    assert p_2349_7b.duration_minutes == 60
+    assert payload_to_dict(p_2349_7b).get("duration_minutes") == 60
+
+    p_2349_13b = ZoneModePayload.from_bytes(bytes.fromhex("0007D001FFFFFF00110E0507E5"))
+    assert isinstance(p_2349_13b, ramses_rf.payloads.heating.ZoneMode13BPayload)
+    assert p_2349_13b.zone_idx == 0
+    assert p_2349_13b.setpoint_temp == 20.0
+    assert p_2349_13b.until_dtm == "2021-05-14T17:00:00"
+
+    # 9. SystemDateTime (313F): 2B and 9B
+    p_313f_2b = SystemDateTimePayload.from_bytes(bytes.fromhex("0000"))
+    assert isinstance(p_313f_2b, ramses_rf.payloads.system.SystemDateTime2BPayload)
+    assert p_313f_2b.domain_idx == 0
+    assert payload_to_dict(p_313f_2b) == {"domain_idx": 0}
+
+    p_313f_9b = SystemDateTimePayload.from_bytes(bytes.fromhex("00F0BB00040C0507EA"))
+    assert isinstance(p_313f_9b, ramses_rf.payloads.system.SystemDateTime9BPayload)
+    assert p_313f_9b.datetime_str == "2026-05-12T04:00:59"
+    assert p_313f_9b.is_dst is True
+
+    # 10. HeatDemand (3150): 1B and 2B
+    p_3150_1b = HeatDemandPayload.from_bytes(bytes.fromhex("C8"))
+    assert isinstance(p_3150_1b, ramses_rf.payloads.heating.HeatDemand1BPayload)
+    assert p_3150_1b.demand_percent == 200
+
+    p_3150_2b = HeatDemandPayload.from_bytes(bytes.fromhex("01CA"))
+    assert isinstance(p_3150_2b, ramses_rf.payloads.heating.HeatDemand2BPayload)
+    assert p_3150_2b.domain_or_zone_idx == 1
+    assert p_3150_2b.demand_percent == 202

--- a/tests/tests_rf/test_payload_structure.py
+++ b/tests/tests_rf/test_payload_structure.py
@@ -321,3 +321,50 @@ def test_all_discovered_payload_dataclasses_specification_compliance() -> None:
         assert "to_bytes" in target_cls.__dict__ or hasattr(target_cls, "to_bytes"), (
             f"Class '{target_name}' in {target_file} missing to_bytes"
         )
+
+
+def test_master_dispatcher_variant_subclassing_and_decorator_exclusivity() -> None:
+    """Verify polymorphic Master Dispatcher inheritance and @register_payload exclusivity.
+
+    Enforces the PR #1037 / Issue #837 rule:
+    1. Every variant in MasterDispatcher.VARIANTS must inherit directly from MasterDispatcher.
+    2. Variant sub-dataclasses must NEVER carry @register_payload themselves.
+    """
+    for opcode, payload_cls in REGISTERED_PAYLOAD_CLASSES:
+        variants: tuple[type, ...] = getattr(payload_cls, "VARIANTS", ())
+        if not variants:
+            continue
+
+        assert isinstance(variants, tuple), (
+            f"Master Dispatcher '{payload_cls.__name__}' VARIANTS must be a tuple"
+        )
+
+        for variant_cls in variants:
+            v_name = variant_cls.__name__
+
+            # 1. Direct inheritance check
+            assert issubclass(variant_cls, payload_cls), (
+                f"SPECIFICATION VIOLATION: Variant '{v_name}' does not inherit from "
+                f"Master Dispatcher '{payload_cls.__name__}' for Opcode {opcode}!"
+            )
+
+            # 2. Decorator exclusivity check
+            assert variant_cls not in PAYLOAD_REGISTRY._registry.values(), (
+                f"SPECIFICATION VIOLATION: Variant '{v_name}' is decorated with @register_payload! "
+                f"Only the Master Dispatcher '{payload_cls.__name__}' must be decorated."
+            )
+
+
+def test_opcode_registration_coverage_against_known_opcodes() -> None:
+    """Verify that all known opcodes in CODE_NAME_LOOKUP are registered in PAYLOAD_REGISTRY."""
+    from ramses_rf.protocol.ramses import CODE_NAME_LOOKUP
+
+    missing_opcodes = [
+        code.value
+        for code in CODE_NAME_LOOKUP
+        if str(code.value) not in PAYLOAD_REGISTRY._registry
+    ]
+    assert not missing_opcodes, (
+        f"The following opcodes in CODE_NAME_LOOKUP are missing from PAYLOAD_REGISTRY: {missing_opcodes}"
+    )
+    assert len(PAYLOAD_REGISTRY._registry) >= 100


### PR DESCRIPTION
### Summary
This pull request represents **PR 14** of tracking issue #1001, completing **Phase 6** of the refactoring plan outlined in #639. Following a comprehensive codebase audit conducted with Google Gemini 3.7 Flash, this PR cleans up, standardises, and validates all semantic payload dataclasses and test suites against the **Issue #837 / PR #1037 Specification Standard**.

### The Problem:
- Several polymorphic opcodes (`0004`, `0008`, `0100`, `1100`, `12A0`, `1F09`, `22E0`, `2309`, `2349`, `2E04`, `313F`, `3150`) had inconsistencies in master dispatcher hierarchy, missing length validation guards, or duplicate registrations in `PAYLOAD_REGISTRY`.
- Duplicate payload class implementations existed across modules (e.g. `DhwTemperaturePayload` in `heating.py` vs `DhwTempPayload` in `dhw.py`).
- Test suites lacked dynamic dispatch verification across all Master Dispatcher variants, truncation rejection tests, and roundtrip serialization checks.

### The Fix:
- **Master Dispatcher Architecture**: Standardised all 13 polymorphic opcodes with Master Dispatchers defined first, decorated with `@register_payload("<OPCODE>")`, and concrete variant sub-dataclasses inheriting directly from the Master Dispatcher without duplicate registry decoration.
- **Binary Struct Parsing & Guards**: Enforced C-level `_STRUCT_FMT` ClassVars, `struct.unpack_from`/`struct.pack`, and `len(raw_data) < N` length validation guards across all concrete payload dataclasses.
- **BOFM & Docstring Alignment**: Formatted and validated all Binary Offset Format Map tables and docstring sample hex strings.
- **Specification Documentation**: Updated `docs/developer_guide/payload_registry_spec.md` and `.agents/AGENTS.md` (Section 7) to clarify single-layout vs polymorphic dataclass architecture and decorator exclusivity rules for future LLM contributors.
- **Test Suite Expansion**: Added comprehensive test coverage in `test_payload_structure.py`, `test_payload_codecs.py`, and `test_payload_parity.py`, expanding dedicated payload tests from 719 to 945 passing tests.

### Testing Performed:
- **Dedicated Payload Test Suite**: **945 / 945 passed** (100%).
- **Full Project Test Suite (`pytest`)**: **2,441 passed**, 4 skipped, **99 / 99 regression snapshots passed**.
- **Packet Log Audit**: Successfully decoded 32,315 real log packets across multiple log fixtures with 0 unpack or adapter errors.
- **Type Checking (`mypy --strict`)**: 0 errors across 256 source files.
- **Pre-commit Hooks (`prek run -a`)**: 17 / 17 hooks passed.
- **Docstring Compliance (`ruff check -s D`)**: 100% compliant across all payload modules.

### AI Assistance Disclosure:
This contribution was developed with the assistance of Google Gemini 3.7 Flash for code generation, auditing, and documentation. All logic and implementations were reviewed and verified by the author.