### PR TITLE
refactor(naming): resolve built-in shadowing and migrate helper function casing (#1039)

### DIFF
--- a/src/ramses_rf/config.py
+++ b/src/ramses_rf/config.py
@@ -20,19 +20,19 @@ from .typing import DeviceListT
 _T = TypeVar("_T")
 
 
-def ConvertNullToDict() -> Callable[[_T | None], _T | dict[Never, Never]]:
-    """Return a validator that converts a null node value to an empty dictionary.
+def convert_null_to_dict() -> Callable[[_T | None], _T | dict[Never, Never]]:
+    """Return validator converting a null node value to an empty dict.
 
     :returns: A callable validator function for voluptuous schemas.
     :rtype: Callable[[_T | None], _T | dict[Never, Never]]
     """
 
-    def convert_null_to_dict(node_value: _T | None) -> _T | dict[Never, Never]:
+    def _convert(node_value: _T | None) -> _T | dict[Never, Never]:
         if node_value is None:
             return {}
         return node_value
 
-    return convert_null_to_dict
+    return _convert
 
 
 SZ_ALIAS: Final = "alias"
@@ -132,7 +132,7 @@ def sch_global_traits_dict_factory(
     )
 
     SCH_TRAITS = vol.Any(
-        vol.All(None, ConvertNullToDict()),
+        vol.All(None, convert_null_to_dict()),
         vol.Any(SCH_TRAITS_HEAT, SCH_TRAITS_HVAC),
         extra=vol.PREVENT_EXTRA,
     )
@@ -143,11 +143,11 @@ def sch_global_traits_dict_factory(
 
     global_traits_dict = {
         vol.Optional(SZ_KNOWN_LIST, default={}): vol.Any(
-            vol.All(None, ConvertNullToDict()),
+            vol.All(None, convert_null_to_dict()),
             vol.All(SCH_DEVICE, vol.Length(min=0)),
         ),
         vol.Optional(SZ_BLOCK_LIST, default={}): vol.Any(
-            vol.All(None, ConvertNullToDict()),
+            vol.All(None, convert_null_to_dict()),
             vol.All(SCH_DEVICE, vol.Length(min=0)),
         ),
     }

--- a/src/ramses_rf/payloads/hvac.py
+++ b/src/ramses_rf/payloads/hvac.py
@@ -2855,12 +2855,12 @@ class HvacSpiderSetpointBoundsPayload(PayloadBase):
         for i in range(num_pairs):
             (min_val,) = struct.unpack_from(">h", min_bytes, i * 2)
             (max_val,) = struct.unpack_from(">h", max_bytes, i * 2)
-            min_t = None if min_val in (0x31FF, 0x7FFF) else min_val / 100.0
-            max_t = None if max_val in (0x31FF, 0x7FFF) else max_val / 100.0
-            if min_t is None and max_t is None:
+            min_temp = None if min_val in (0x31FF, 0x7FFF) else min_val / 100.0
+            max_temp = None if max_val in (0x31FF, 0x7FFF) else max_val / 100.0
+            if min_temp is None and max_temp is None:
                 bounds.append(None)
             else:
-                bounds.append((min_t, max_t))
+                bounds.append((min_temp, max_temp))
         return cls(hdr=hdr, mode_code=mode_code, setpoint_bounds=tuple(bounds))
 
     def to_bytes(self) -> bytes:
@@ -2872,9 +2872,9 @@ class HvacSpiderSetpointBoundsPayload(PayloadBase):
         min_b = bytearray()
         max_b = bytearray()
         for b in self.setpoint_bounds:
-            min_t, max_t = b if b is not None else (None, None)
-            min_val = 0x7FFF if min_t is None else int(round(min_t * 100.0))
-            max_val = 0x7FFF if max_t is None else int(round(max_t * 100.0))
+            min_temp, max_temp = b if b is not None else (None, None)
+            min_val = 0x7FFF if min_temp is None else int(round(min_temp * 100.0))
+            max_val = 0x7FFF if max_temp is None else int(round(max_temp * 100.0))
             min_b.extend(struct.pack(">h", min_val))
             max_b.extend(struct.pack(">h", max_val))
         return bytes([self.hdr]) + min_b + bytes([self.mode_code]) + max_b
@@ -3473,12 +3473,14 @@ class SetpointBoundsPayload(PayloadBase):
         if len(raw_data) >= 6 and len(raw_data) % 6 == 0:
             res: list[Self] = []
             for i in range(0, len(raw_data), 6):
-                idx, min_t, max_t, mode_code = struct.unpack_from(">BhhB", raw_data, i)
+                idx, min_raw, max_raw, mode_code = struct.unpack_from(
+                    ">BhhB", raw_data, i
+                )
                 res.append(
                     cls(
                         ufh_idx=idx,
-                        min_temp=cls._parse_temp(min_t),
-                        max_temp=cls._parse_temp(max_t),
+                        min_temp=cls._parse_temp(min_raw),
+                        max_temp=cls._parse_temp(max_raw),
                         mode_code=mode_code,
                     )
                 )
@@ -3486,11 +3488,11 @@ class SetpointBoundsPayload(PayloadBase):
 
         if len(raw_data) < 6:
             raise ValueError(f"Invalid payload length for 22C9: {len(raw_data)}")
-        idx, min_t, max_t, mode_code = struct.unpack_from(">BhhB", raw_data, 0)
+        idx, min_raw, max_raw, mode_code = struct.unpack_from(">BhhB", raw_data, 0)
         return cls(
             ufh_idx=idx,
-            min_temp=cls._parse_temp(min_t),
-            max_temp=cls._parse_temp(max_t),
+            min_temp=cls._parse_temp(min_raw),
+            max_temp=cls._parse_temp(max_raw),
             mode_code=mode_code,
         )
 

--- a/src/ramses_rf/schemas.py
+++ b/src/ramses_rf/schemas.py
@@ -117,8 +117,8 @@ SCH_UFH_IDX = vol.Match(r"^0[0-8]$")
 SCH_ZON_IDX = vol.Match(r"^0[0-9AB]$")  # TODO: what if > 12 zones? (e.g. hometronics)
 
 
-def ErrorRenamedKey(new_key: str) -> Callable[[Any], None]:
-    """Return a voluptuous validator function that raises an invalid key error.
+def error_renamed_key(new_key: str) -> Callable[[Any], None]:
+    """Return a voluptuous validator function raising an invalid key error.
 
     :param new_key: The new key name to instruct the user to rename to.
     :type new_key: str
@@ -140,7 +140,7 @@ SCH_TCS_SYS = vol.Schema(
         vol.Required(SZ_APPLIANCE_CONTROL, default=None): vol.Any(
             None, SCH_DEVICE_ID_APP
         ),
-        vol.Optional("heating_control"): ErrorRenamedKey(SZ_APPLIANCE_CONTROL),
+        vol.Optional("heating_control"): error_renamed_key(SZ_APPLIANCE_CONTROL),
     },
     extra=vol.PREVENT_EXTRA,
 )
@@ -150,7 +150,7 @@ SCH_TCS_DHW = vol.Schema(
         vol.Optional(SZ_SENSOR, default=None): vol.Any(None, SCH_DEVICE_ID_DHW),
         vol.Optional(SZ_DHW_VALVE, default=None): vol.Any(None, SCH_DEVICE_ID_BDR),
         vol.Optional(SZ_HTG_VALVE, default=None): vol.Any(None, SCH_DEVICE_ID_BDR),
-        vol.Optional(SZ_DHW_SENSOR): ErrorRenamedKey(SZ_SENSOR),
+        vol.Optional(SZ_DHW_SENSOR): error_renamed_key(SZ_SENSOR),
     },
     extra=vol.PREVENT_EXTRA,
 )
@@ -179,12 +179,12 @@ SCH_TCS_ZONES_ZON = vol.Schema(
     {
         vol.Optional(SZ_CLASS, default=None): vol.Any(None, *HEAT_ZONES_STRS),
         vol.Optional(SZ_SENSOR, default=None): vol.Any(None, SCH_DEVICE_ID_SEN),
-        vol.Optional(SZ_DEVICES): ErrorRenamedKey(SZ_ACTUATORS),
+        vol.Optional(SZ_DEVICES): error_renamed_key(SZ_ACTUATORS),
         vol.Optional(SZ_ACTUATORS, default=[]): vol.All(
             [SCH_DEVICE_ID_ANY], vol.Length(min=0)
         ),
-        vol.Optional(SZ_ZONE_TYPE): ErrorRenamedKey(SZ_CLASS),
-        vol.Optional("zone_sensor"): ErrorRenamedKey(SZ_SENSOR),
+        vol.Optional(SZ_ZONE_TYPE): error_renamed_key(SZ_CLASS),
+        vol.Optional("zone_sensor"): error_renamed_key(SZ_SENSOR),
         # vol.Optional(SZ_SENSOR_FAKED): bool,
         vol.Optional(f"_{SZ_NAME}"): vol.Any(None, str),
     },
@@ -305,7 +305,7 @@ SCH_GLOBAL_CONFIG = (
 
 #
 # 6/7: External Schemas, to be used by clients of this library
-def NormaliseRestoreCache() -> Callable[[bool | dict[str, bool]], dict[str, bool]]:
+def normalise_restore_cache() -> Callable[[bool | dict[str, bool]], dict[str, bool]]:
     """Convert a shorthand restore_cache bool to a dict.
 
     restore_cache: bool ->  restore_cache:
@@ -316,12 +316,14 @@ def NormaliseRestoreCache() -> Callable[[bool | dict[str, bool]], dict[str, bool
     :rtype: Callable[[bool | dict[str, bool]], dict[str, bool]]
     """
 
-    def normalise_restore_cache(node_value: bool | dict[str, bool]) -> dict[str, bool]:
+    def _normalise(
+        node_value: bool | dict[str, bool],
+    ) -> dict[str, bool]:
         if isinstance(node_value, dict):
             return node_value
         return {SZ_RESTORE_SCHEMA: node_value, SZ_RESTORE_STATE: node_value}
 
-    return normalise_restore_cache
+    return _normalise
 
 
 SZ_RESTORE_CACHE: Final = "restore_cache"
@@ -330,7 +332,7 @@ SZ_RESTORE_STATE: Final = "restore_state"
 
 SCH_RESTORE_CACHE_DICT = {
     vol.Optional(SZ_RESTORE_CACHE, default=True): vol.Any(
-        vol.All(bool, NormaliseRestoreCache()),
+        vol.All(bool, normalise_restore_cache()),
         vol.Schema(
             {
                 vol.Optional(SZ_RESTORE_SCHEMA, default=True): bool,

--- a/src/ramses_tx/helpers.py
+++ b/src/ramses_tx/helpers.py
@@ -297,8 +297,16 @@ def hex_from_dtm(
     :rtype: HexStr12 | HexStr14
     """
 
-    def _dtm_to_hex(year, mon, mday, hour, min, sec, *args: int) -> str:  # type: ignore[no-untyped-def]
-        return f"{sec:02X}{min:02X}{hour:02X}{mday:02X}{mon:02X}{year:04X}"
+    def _dtm_to_hex(
+        year: int,
+        month: int,
+        mday: int,
+        hour: int,
+        minute: int,
+        second: int,
+        *args: int,
+    ) -> str:
+        return f"{second:02X}{minute:02X}{hour:02X}{mday:02X}{month:02X}{year:04X}"
 
     if dtm is None:
         return "FF" * (7 if incl_seconds else 6)

--- a/tests/tests_rf/test_schemas.py
+++ b/tests/tests_rf/test_schemas.py
@@ -3,7 +3,7 @@
 import pytest
 import voluptuous as vol
 
-from ramses_rf.schemas import SCH_DOM_ID, SCH_UFH_IDX, SCH_ZON_IDX, ErrorRenamedKey
+from ramses_rf.schemas import SCH_DOM_ID, SCH_UFH_IDX, SCH_ZON_IDX, error_renamed_key
 
 
 def test_sch_dom_id_validation() -> None:
@@ -51,8 +51,8 @@ def test_sch_ufh_idx_validation() -> None:
 
 
 def test_error_renamed_key_raises() -> None:
-    """Verify ErrorRenamedKey validator helper raises descriptive voluptuous error."""
-    validator = ErrorRenamedKey("new_feature_key")
+    """Verify error_renamed_key validator helper raises voluptuous error."""
+    validator = error_renamed_key("new_feature_key")
     with pytest.raises(
         vol.Invalid, match="the key name has changed: rename it to 'new_feature_key'"
     ):


### PR DESCRIPTION
### ⚠️ STACKED PR: Depends on #1050 < was merged

### The Problem:
`ramses_rf` contained legacy `PascalCase` schema helper function names (`ConvertNullToDict`, `ErrorRenamedKey`, `NormaliseRestoreCache`) and parameter naming that shadowed Python built-ins (`min` in `_dtm_to_hex`).

### The Fix:
- Renamed `ConvertNullToDict` -> `convert_null_to_dict` in `config.py`.
- Renamed `ErrorRenamedKey` -> `error_renamed_key` in `schemas.py` and updated `tests/tests_rf/test_schemas.py`.
- Renamed `NormaliseRestoreCache` -> `normalise_restore_cache` in `schemas.py`.
- Renamed parameter `min` -> `minute` in `ramses_tx/helpers.py`.
- Renamed local temperature unpacking variables `min_t`/`max_t` -> `min_temp`/`max_temp` in `payloads/hvac.py`.

### Testing Performed:
- `prek run -a` (`ruff check`, `ruff format`, `codespell`): Passed.
- `mypy`: Passed (0 issues across 254 source files).
- `pytest -n auto`: Passed (2,468 passed, 3 skipped, 99 snapshots passed).

### AI Assistance Disclosure:
This contribution was developed with the assistance of Google Gemini 3.7 Flash for code generation and documentation. All logic and implementations were reviewed and verified by the author.