### PR TITLE
fix(routing): isolate DHW state projection in multi-TCS installations

### DIFF
--- a/src/ramses_rf/discovery_scan.py
+++ b/src/ramses_rf/discovery_scan.py
@@ -664,6 +664,34 @@ class DiscoveryScan:
                         code,
                         verb.strip(),
                     )
+                # DHW topology inference for known devices: directed interaction
+                # between a CTL (01:/23:) and a DHW sensor (07:) confirms binding.
+                elif (
+                    not is_hgi
+                    and device_id.startswith("07:")
+                    and not is_source
+                    and source
+                    and _is_valid_address(source)
+                    and source.startswith(("01:", "23:"))
+                    and code in (Code._10A0, Code._1260, Code._000C)
+                ):
+                    if device.bound_to != source:
+                        device.bound_to = source
+                        device.confidence = "high"
+                        self._dirty = True
+                elif (
+                    not is_hgi
+                    and device_id.startswith("07:")
+                    and is_source
+                    and destination
+                    and _is_valid_address(destination)
+                    and destination.startswith(("01:", "23:"))
+                    and code in (Code._10A0, Code._1260)
+                ):
+                    if device.bound_to != destination:
+                        device.bound_to = destination
+                        device.confidence = "high"
+                        self._dirty = True
             return
 
         now = dt.now().isoformat(timespec="seconds")
@@ -735,6 +763,29 @@ class DiscoveryScan:
                 and code in _HVAC_PARENT_INFERENCE_CODES
             ):
                 device.bound_to = source
+            # DHW topology inference: directed interaction between CTL and DHW sensor
+            elif (
+                not is_hgi
+                and device_id.startswith("07:")
+                and not is_source
+                and source
+                and _is_valid_address(source)
+                and source.startswith(("01:", "23:"))
+                and code in (Code._10A0, Code._1260, Code._000C)
+            ):
+                device.bound_to = source
+                device.confidence = "high"
+            elif (
+                not is_hgi
+                and device_id.startswith("07:")
+                and is_source
+                and destination
+                and _is_valid_address(destination)
+                and destination.startswith(("01:", "23:"))
+                and code in (Code._10A0, Code._1260)
+            ):
+                device.bound_to = destination
+                device.confidence = "high"
             self._devices[device_id] = device
             self._dirty = True
             _LOGGER.info(
@@ -826,6 +877,33 @@ class DiscoveryScan:
         ):
             device.bound_to = source
             changed = True
+        # DHW topology inference for existing devices
+        elif (
+            not is_hgi
+            and device_id.startswith("07:")
+            and not is_source
+            and source
+            and _is_valid_address(source)
+            and source.startswith(("01:", "23:"))
+            and code in (Code._10A0, Code._1260, Code._000C)
+        ):
+            if device.bound_to != source:
+                device.bound_to = source
+                device.confidence = "high"
+                changed = True
+        elif (
+            not is_hgi
+            and device_id.startswith("07:")
+            and is_source
+            and destination
+            and _is_valid_address(destination)
+            and destination.startswith(("01:", "23:"))
+            and code in (Code._10A0, Code._1260)
+        ):
+            if device.bound_to != destination:
+                device.bound_to = destination
+                device.confidence = "high"
+                changed = True
 
         # Upgrade confidence based on accumulated evidence
         new_conf = _recompute_confidence(device)

--- a/src/ramses_rf/state_projector.py
+++ b/src/ramses_rf/state_projector.py
@@ -199,19 +199,11 @@ def _get_dhw_zone_from_msg(msg: Message, source_device: Any) -> DhwZone | None:
     )
     if tcs is None and hasattr(source_device, "dhw"):
         tcs = source_device
-    if tcs is None and hasattr(source_device, "_gateway"):
-        tcs = getattr(source_device._gateway, "tcs", None)
-    if tcs is None and getattr(msg, "_gateway", None) is not None:
-        tcs = getattr(msg._gateway, "tcs", None)
 
     if tcs is None:
         return None
 
-    if getattr(tcs, "dhw", None) is not None:
-        return cast(DhwZone | None, tcs.dhw)
-    if hasattr(tcs, "get_dhw_zone"):
-        return cast(DhwZone | None, tcs.get_dhw_zone(msg=msg))
-    return None
+    return cast(DhwZone | None, getattr(tcs, "dhw", None))
 
 
 def _resolve_logical_targets(

--- a/tests/tests_rf/test_multi_tcs_dhw_isolation.py
+++ b/tests/tests_rf/test_multi_tcs_dhw_isolation.py
@@ -1,0 +1,190 @@
+# --- START OF FILE test_multi_tcs_dhw_isolation.py ---
+
+"""Tests for DHW isolation in multi-controller (multi-TCS) setups.
+
+Verifies:
+- Unassociated DHW sensors do not route to arbitrary fallback systems.
+- Multi-controller setups route DHW opcodes only to systems with DHW.
+- DiscoveryScan establishes bound_to for DHW sensors from directed packets.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime as dt
+from typing import Any
+from unittest.mock import MagicMock
+
+from ramses_rf.const import Code, DevType, Verb
+from ramses_rf.discovery_scan import DiscoveryScan
+from ramses_rf.state_projector import _get_dhw_zone_from_msg
+from ramses_tx.address import Address
+from ramses_tx.dtos import PacketDTO
+
+
+def make_dto(
+    src: str = "07:045491",
+    dst: str = "--:------",
+    addr3: str = "--:------",
+    code: str = Code._1260,
+    verb: str = Verb.I_,
+    payload: str = "000771",
+) -> PacketDTO:
+    """Create a PacketDTO for testing."""
+    return PacketDTO(
+        timestamp=dt.now(),
+        rssi="-65",
+        verb=verb,
+        seq="00",
+        addr1=src,
+        addr2=dst,
+        addr3=addr3,
+        code=code,
+        length=f"{len(payload) // 2:03d}",
+        payload=payload,
+        raw_payload=payload,
+    )
+
+
+def make_mock_gateway() -> MagicMock:
+    """Create a minimal mock Gateway for DiscoveryScan."""
+    gwy = MagicMock()
+    gwy.device_registry = MagicMock()
+    gwy.device_registry.device_by_id = {}
+    gwy._gwy_config = MagicMock()
+    gwy._gwy_config.known_list = {}
+    gwy._gwy_config.schema = {}
+    gwy.add_raw_packet_handler = MagicMock(return_value=lambda: None)
+    return gwy
+
+
+class MockDevice:
+    """Mock device without dynamic attributes."""
+
+    def __init__(
+        self,
+        dev_type: str,
+        slug: str,
+        tcs: Any = None,
+        dhw: Any = None,
+    ) -> None:
+        self.type = dev_type
+        self._SLUG = slug
+        self.tcs = tcs
+        self._tcs = tcs
+        if dhw is not None:
+            self.dhw = dhw
+
+
+def test_get_dhw_zone_from_msg_unassociated_returns_none() -> None:
+    # Arrange
+    msg = MagicMock()
+    msg.code = Code._1260
+    msg.src = Address("07:999999")
+
+    source_device = MockDevice("07", DevType.DHW)
+
+    # Act
+    result = _get_dhw_zone_from_msg(msg, source_device)
+
+    # Assert
+    assert result is None
+
+
+def test_get_dhw_zone_from_msg_multi_tcs_isolation() -> None:
+    # Arrange
+    dhw_zone_mock = MagicMock()
+
+    tcs_with_dhw = MagicMock()
+    tcs_with_dhw.id = "01:111111"
+    tcs_with_dhw.dhw = dhw_zone_mock
+
+    tcs_without_dhw = MagicMock()
+    tcs_without_dhw.id = "01:222222"
+    tcs_without_dhw.dhw = None
+
+    # Device associated with tcs_with_dhw
+    dhw_sensor = MockDevice("07", DevType.DHW, tcs=tcs_with_dhw)
+
+    msg_dhw = MagicMock()
+    msg_dhw.code = Code._1260
+    msg_dhw.src = Address("07:045491")
+
+    # Controller without DHW sending 10A0
+    msg_ctl_no_dhw = MagicMock()
+    msg_ctl_no_dhw.code = Code._10A0
+    msg_ctl_no_dhw.src = Address("01:222222")
+
+    ctl_no_dhw_dev = MockDevice("01", DevType.CTL, tcs=tcs_without_dhw)
+
+    # Act
+    res_dhw = _get_dhw_zone_from_msg(msg_dhw, dhw_sensor)
+    res_no_dhw = _get_dhw_zone_from_msg(msg_ctl_no_dhw, ctl_no_dhw_dev)
+
+    # Assert
+    assert res_dhw is dhw_zone_mock
+    assert res_no_dhw is None
+
+
+def test_discovery_scan_dhw_directed_rq_sets_bound_to() -> None:
+    # Arrange
+    scan = DiscoveryScan(gateway=make_mock_gateway())
+    dto = make_dto(
+        src="01:161591",
+        dst="07:045491",
+        code=Code._10A0,
+        verb=Verb.RQ,
+        payload="00",
+    )
+
+    # Act
+    scan._process_packet(dto)
+    devices = {d.device_id: d for d in scan.get_devices()}
+
+    # Assert
+    assert "07:045491" in devices
+    dhw_dev = devices["07:045491"]
+    assert dhw_dev.bound_to == "01:161591"
+    assert dhw_dev.confidence == "high"
+
+
+def test_discovery_scan_dhw_directed_rp_sets_bound_to() -> None:
+    # Arrange
+    scan = DiscoveryScan(gateway=make_mock_gateway())
+    dto = make_dto(
+        src="07:045491",
+        dst="01:161591",
+        code=Code._1260,
+        verb=Verb.RP,
+        payload="000771",
+    )
+
+    # Act
+    scan._process_packet(dto)
+    devices = {d.device_id: d for d in scan.get_devices()}
+
+    # Assert
+    assert "07:045491" in devices
+    dhw_dev = devices["07:045491"]
+    assert dhw_dev.bound_to == "01:161591"
+    assert dhw_dev.confidence == "high"
+
+
+def test_discovery_scan_dhw_broadcast_remains_unbound() -> None:
+    # Arrange
+    scan = DiscoveryScan(gateway=make_mock_gateway())
+    dto = make_dto(
+        src="07:045491",
+        dst="--:------",
+        code=Code._1260,
+        verb=Verb.I_,
+        payload="000771",
+    )
+
+    # Act
+    scan._process_packet(dto)
+    devices = {d.device_id: d for d in scan.get_devices()}
+
+    # Assert
+    assert "07:045491" in devices
+    dhw_dev = devices["07:045491"]
+    assert dhw_dev.bound_to is None


### PR DESCRIPTION
### The Problem:
In multi-controller (multi-TCS) installations, `_get_dhw_zone_from_msg` in `state_projector.py` was falling back to `gateway.tcs` when a DHW packet arrived from an unassociated source, and calling `tcs.get_dhw_zone(msg=msg)` on the fallback controller. This imperatively fabricated a `DhwZone` on heating-only controllers (such as downstairs controllers without domestic hot water) and violated CQRS read-model principles.

### The Fix:
- Refactored `_get_dhw_zone_from_msg` to strictly return `getattr(tcs, "dhw", None)` without fallback to `gateway.tcs` or mutating factory calls.
- Updated `DiscoveryScan` to infer DHW controller parentage only when concrete directed exchanges occur (`RQ`/`RP` with `10A0`, `1260`, or `000C`). Ambient broadcasts to `--:------` leave `bound_to` as `None`.
- Added unit test suite in `tests/tests_rf/test_multi_tcs_dhw_isolation.py`.

### Testing Performed:
- Ran `.venv/bin/prek run -a` (all checks passed).
- Ran `.venv/bin/ruff check --select D` (all checks passed).
- Ran `.venv/bin/mypy --strict` (0 issues across 260 source files).
- Ran full test suite via `.venv/bin/pytest -n auto` (2,553 passed, 3 skipped, 99 snapshots passed).

### AI Assistance Disclosure:
This contribution was developed with the assistance of Google Gemini 3.7 Flash for code generation and documentation. All logic and implementations were reviewed and verified by the author.