### PR TITLE
Fix TCS and zone thermal mode hydration during cached packet restore

### DIFF
--- a/src/ramses_rf/pipeline/ingestion.py
+++ b/src/ramses_rf/pipeline/ingestion.py
@@ -458,6 +458,32 @@ class StateProjector:
                             err,
                         )
 
+            # Route system-level opcodes (0100/2E04/313F/2D49) to the TCS.
+            # The ingestion loop routes to src_dev (Controller/UFC device),
+            # but the TCS is the system read-model entity whose system_state
+            # / thermal_mode is queried by downstream integrations.
+            # See: https://github.com/ramses-rf/ramses_cc/issues/965
+            if msg.code in (
+                Code._0100,
+                Code._2E04,
+                Code._313F,
+                Code._2D49,
+            ):
+                tcs_target = system_by_id.get(msg.src.id) or getattr(
+                    src_dev, "tcs", None
+                )
+                if tcs_target is None and len(systems) == 1:
+                    tcs_target = systems[0]
+                if tcs_target is not None:
+                    try:
+                        self._update_system_state(tcs_target, payload, msg)
+                    except Exception as err:
+                        _LOGGER.error(
+                            "CQRS extraction failed for TCS %s: %s",
+                            tcs_target.id,
+                            err,
+                        )
+
         # --- CQRS Reactor Hooks ---
         # Automate the legacy Actuator discovery query (3EF1) in response to 3EF0 (I)
         if msg.code == Code._3EF0 and getattr(msg, "verb", "") == I_:

--- a/src/ramses_rf/state_projector.py
+++ b/src/ramses_rf/state_projector.py
@@ -21,6 +21,8 @@ from .const import (
     SZ_BYPASS_POSITION,
     SZ_BYPASS_STATE,
     SZ_CO2_LEVEL,
+    SZ_COOLING_DEMAND,
+    SZ_COOLING_MODE,
     SZ_DATETIME,
     SZ_DIFFERENTIAL,
     SZ_DOMAIN_INDEX,
@@ -135,6 +137,7 @@ class StateProjector:
         self._registry.register(Code._0100, _update_system_state)
         self._registry.register(Code._2E04, _update_system_state)
         self._registry.register(Code._313F, _update_system_state)
+        self._registry.register(Code._2D49, _update_system_state)
 
         self._registry.register(Code._10A0, _update_dhw_state)
         self._registry.register(Code._1F41, _update_dhw_state)
@@ -297,10 +300,10 @@ def _resolve_logical_targets(
             if tcs.dhw not in targets:
                 targets.append(tcs.dhw)
 
-    # 6. System-level opcodes (2E04/0100/313F) target the TCS directly.
+    # 6. System-level opcodes (2E04/0100/313F/2D49) target the TCS directly.
     #    These packets have no domain_id/zone_index, so steps 4/5 miss them.
     if (
-        msg.code in (Code._2E04, Code._0100, Code._313F)
+        msg.code in (Code._2E04, Code._0100, Code._313F, Code._2D49)
         and tcs
         and tcs not in targets
     ):
@@ -343,7 +346,8 @@ def _resolve_logical_targets(
 def _update_system_state(target: Any, p: dict[str, Any], msg: Message) -> None:
     """Translate system configuration opcodes into SystemState.
 
-    Handles 2E04 (system_mode), 0100 (language), and 313F (datetime).
+    Handles 2E04 (system_mode), 0100 (language), 313F (datetime), and
+    2D49 (cooling_mode).
 
     :param target: Target entity (TCS/Evohome) to update.
     :type target: Any
@@ -368,6 +372,9 @@ def _update_system_state(target: Any, p: dict[str, Any], msg: Message) -> None:
     elif msg.code == Code._313F:
         if SZ_DATETIME in p:
             updates[SZ_DATETIME] = p[SZ_DATETIME]
+    elif msg.code == Code._2D49:
+        if SZ_COOLING_DEMAND in p:
+            updates[SZ_COOLING_MODE] = p[SZ_COOLING_DEMAND]
     else:
         return
 

--- a/src/ramses_rf/systems/zones.py
+++ b/src/ramses_rf/systems/zones.py
@@ -168,6 +168,32 @@ class ZoneBase(Child, Parent, Entity):
         """Return the current state."""
         return {}
 
+    async def thermal_mode(self) -> ThermalMode | None:
+        """Return the active thermal mode of the zone.
+
+        :returns: Active ThermalMode or None.
+        :rtype: ThermalMode | None
+        """
+        if self.tcs:
+            return await self.tcs.thermal_mode()
+        return ThermalMode.HEAT
+
+    async def thermal_demand(self) -> ThermalDemandDTO | None:
+        """Return zone thermal demand as a CQRS DTO.
+
+        :returns: ThermalDemandDTO or None.
+        :rtype: ThermalDemandDTO | None
+        """
+        heat_demand_value = self.demand_state.heat_demand
+        if heat_demand_value is None:
+            return None
+        mode = await self.thermal_mode() or ThermalMode.HEAT
+        return ThermalDemandDTO(
+            thermal_demand=heat_demand_value,
+            mode=mode,
+            ufh_index=str(self.index),
+        )
+
 
 class ZoneSchedule(ZoneBase):  # 0404
     """Zone mixin providing schedule retrieval and modification."""
@@ -340,7 +366,7 @@ class DhwZone(ZoneSchedule):  # CS92A
         }
 
     async def setpoint(self) -> float | None:  # 10A0
-        """Return target DHW setpoint temperature in degrees Celsius."""
+        """Return the target DHW setpoint temperature in degrees Celsius."""
         return self.dhw_state.setpoint
 
     async def set_setpoint(self, value: float) -> Message:  # 10A0
@@ -350,32 +376,6 @@ class DhwZone(ZoneSchedule):  # CS92A
     async def temperature(self) -> float | None:  # 1260
         """Return current hot water temperature in degrees Celsius."""
         return self.temp_state.temperature
-
-    async def thermal_mode(self) -> ThermalMode | None:
-        """Return the active thermal mode of the zone.
-
-        :returns: Active ThermalMode or None.
-        :rtype: ThermalMode | None
-        """
-        if self.tcs:
-            return await self.tcs.thermal_mode()
-        return ThermalMode.HEAT
-
-    async def thermal_demand(self) -> ThermalDemandDTO | None:
-        """Return zone thermal demand as a CQRS DTO.
-
-        :returns: ThermalDemandDTO or None.
-        :rtype: ThermalDemandDTO | None
-        """
-        heat_demand_value = self.demand_state.heat_demand
-        if heat_demand_value is None:
-            return None
-        mode = await self.thermal_mode() or ThermalMode.HEAT
-        return ThermalDemandDTO(
-            thermal_demand=heat_demand_value,
-            mode=mode,
-            ufh_index=str(self.index),
-        )
 
     async def heat_demand(self) -> float | None:  # 3150
         """Return the DHW heat demand percentage (0.0 to 1.0)."""

--- a/tests/tests_rf/pipeline/test_state_projector.py
+++ b/tests/tests_rf/pipeline/test_state_projector.py
@@ -12,10 +12,12 @@ import uuid
 from typing import Any
 
 from ramses_rf.const import (
+    SZ_COOLING_DEMAND,
     SZ_MODULATION_LEVEL,
     SZ_REL_MODULATION_LEVEL,
     SZ_REMAINING_DAYS,
     SZ_SETPOINT,
+    SZ_ZONE_INDEX,
     Code,
     DevType,
     Verb,
@@ -26,6 +28,7 @@ from ramses_rf.models import (
     HvacState,
     OpenThermState,
     StateUpdatedEvent,
+    SystemState,
 )
 from ramses_rf.pipeline.ingestion import StateProjector
 from ramses_rf.protocol.opentherm import OtDataId
@@ -86,6 +89,7 @@ class FakeDevice:
         self.opentherm_state: OpenThermState = OpenThermState()
         self.act_state: ActuatorState = ActuatorState()
         self.hvac_state: HvacState = HvacState()
+        self.tcs: Any | None = None
         self.events: list[StateUpdatedEvent] = []
 
     def apply_state_update(self, event: StateUpdatedEvent) -> None:
@@ -390,3 +394,105 @@ def test_state_projector_routes_opentherm_3220_data_id_responses() -> None:
     assert device.opentherm_state.temperatures.boiler_return == 41.2
     assert device.opentherm_state.temperatures.dhw_setpoint == 52.0
     assert device.opentherm_state.temperatures.ch_max_setpoint == 75.0
+
+
+def test_state_projector_routes_controller_2d49_to_tcs() -> None:
+    # Arrange
+    ctl_dev = FakeDevice()
+    ctl_dev.id = "01:054173"
+    ctl_dev._SLUG = DevType.CTL
+
+    class FakeTcs:
+        id = "01:054173"
+        zone_by_index: dict[str, Any] = {}
+        system_state: SystemState = SystemState()
+
+    mock_tcs = FakeTcs()
+    ctl_dev.tcs = mock_tcs
+    registry = FakeRegistry(ctl_dev)
+    registry.systems = [mock_tcs]
+
+    gwy_adapter = FakeGatewayAdapter(registry)
+    queue: asyncio.Queue[Message] = asyncio.Queue()
+    worker = StateProjector(gwy_adapter, queue)
+
+    # Act: Controller broadcasts 2D49 (Cooling Active)
+    broadcast_msg = MockMessage(
+        code=Code._2D49,
+        verb=Verb.I_,
+        payload={SZ_ZONE_INDEX: "00", SZ_COOLING_DEMAND: True},
+        src_id="01:054173",
+        dst_id="--:------",
+    )
+    worker.process_message_state(broadcast_msg)
+
+    # Assert
+    assert mock_tcs.system_state.cooling_mode is True
+
+
+def test_state_projector_routes_ufc_2d49_to_tcs() -> None:
+    # Arrange
+    ufc_dev = FakeDevice()
+    ufc_dev.id = "02:123456"
+    ufc_dev._SLUG = DevType.UFC
+
+    class FakeTcs:
+        id = "01:054173"
+        zone_by_index: dict[str, Any] = {}
+        system_state: SystemState = SystemState()
+
+    mock_tcs = FakeTcs()
+    ufc_dev.tcs = mock_tcs
+    registry = FakeRegistry(ufc_dev)
+    registry.systems = [mock_tcs]
+
+    gwy_adapter = FakeGatewayAdapter(registry)
+    queue: asyncio.Queue[Message] = asyncio.Queue()
+    worker = StateProjector(gwy_adapter, queue)
+
+    # Act: UFC broadcasts 2D49 (Cooling Active)
+    broadcast_msg = MockMessage(
+        code=Code._2D49,
+        verb=Verb.I_,
+        payload={SZ_ZONE_INDEX: "01", SZ_COOLING_DEMAND: True},
+        src_id="02:123456",
+        dst_id="--:------",
+    )
+    worker.process_message_state(broadcast_msg)
+
+    # Assert
+    assert mock_tcs.system_state.cooling_mode is True
+
+
+def test_state_projector_routes_2d49_inactive_cooling_to_tcs() -> None:
+    # Arrange
+    ctl_dev = FakeDevice()
+    ctl_dev.id = "01:054173"
+    ctl_dev._SLUG = DevType.CTL
+
+    class FakeTcs:
+        id = "01:054173"
+        zone_by_index: dict[str, Any] = {}
+        system_state: SystemState = SystemState()
+
+    mock_tcs = FakeTcs()
+    ctl_dev.tcs = mock_tcs
+    registry = FakeRegistry(ctl_dev)
+    registry.systems = [mock_tcs]
+
+    gwy_adapter = FakeGatewayAdapter(registry)
+    queue: asyncio.Queue[Message] = asyncio.Queue()
+    worker = StateProjector(gwy_adapter, queue)
+
+    # Act: Controller broadcasts 2D49 (Cooling Inactive)
+    broadcast_msg = MockMessage(
+        code=Code._2D49,
+        verb=Verb.I_,
+        payload={SZ_ZONE_INDEX: "00", SZ_COOLING_DEMAND: False},
+        src_id="01:054173",
+        dst_id="--:------",
+    )
+    worker.process_message_state(broadcast_msg)
+
+    # Assert
+    assert mock_tcs.system_state.cooling_mode is False

--- a/tests/tests_rf/test_hcc100_cooling.py
+++ b/tests/tests_rf/test_hcc100_cooling.py
@@ -1,6 +1,7 @@
 """Focused HCC100 cooling packet and UFC relay tests."""
 
 from datetime import datetime as dt
+from pathlib import Path
 from typing import Any
 from unittest.mock import MagicMock
 
@@ -30,6 +31,9 @@ from ramses_rf.systems.tcs import System
 from ramses_tx.address import Address
 from ramses_tx.const import Code, Verb
 from ramses_tx.dtos import PacketDTO
+from tests_rf.data_driven.helpers import TEST_DIR, load_test_gwy
+
+_SIMPLE_DIR = Path(f"{TEST_DIR}/systems/heat_simple")
 
 
 def _decode(
@@ -362,3 +366,79 @@ async def test_system_thermal_mode_heating_fallback() -> None:
     # Assert
     assert cooling_mode is False
     assert thermal_mode == ThermalMode.HEAT
+
+
+@pytest.mark.asyncio
+async def test_gateway_cached_packet_restore_hcc100_active_cooling() -> None:
+    # Arrange
+    gwy = await load_test_gwy(_SIMPLE_DIR)
+
+    try:
+        tcs = gwy.tcs
+        assert tcs is not None
+        ctl_id = tcs.id
+
+        cached_packets = {
+            "2026-08-15T12:00:00.000000Z": {
+                "rssi": 45,
+                "frame": f" I --- {ctl_id} --:------ {ctl_id} 2D49 003 00C800",
+            },
+        }
+
+        # Act
+        await gwy._restore_cached_packets(cached_packets)
+
+        # Assert
+        assert tcs.system_state.cooling_mode is True
+        assert await tcs.thermal_mode() == ThermalMode.COOL
+        assert len(tcs.zones) > 0
+        assert await tcs.zones[0].thermal_mode() == ThermalMode.COOL
+    finally:
+        await gwy.stop()
+
+
+@pytest.mark.asyncio
+async def test_gateway_cached_packet_restore_hcc100_inactive_cooling() -> None:
+    # Arrange
+    gwy = await load_test_gwy(_SIMPLE_DIR)
+
+    try:
+        tcs = gwy.tcs
+        assert tcs is not None
+        ctl_id = tcs.id
+
+        cached_packets = {
+            "2026-08-15T12:00:00.000000Z": {
+                "rssi": 45,
+                "frame": f" I --- {ctl_id} --:------ {ctl_id} 2D49 003 010000",
+            },
+        }
+
+        # Act
+        await gwy._restore_cached_packets(cached_packets)
+
+        # Assert
+        assert tcs.system_state.cooling_mode is False
+        assert await tcs.thermal_mode() == ThermalMode.HEAT
+        assert len(tcs.zones) > 0
+        assert await tcs.zones[0].thermal_mode() == ThermalMode.HEAT
+    finally:
+        await gwy.stop()
+
+
+@pytest.mark.asyncio
+async def test_gateway_cached_packet_restore_heating_only_baseline() -> None:
+    # Arrange
+    gwy = await load_test_gwy(_SIMPLE_DIR)
+
+    try:
+        tcs = gwy.tcs
+        assert tcs is not None
+
+        # Assert
+        assert tcs.system_state.cooling_mode is None
+        assert await tcs.thermal_mode() is None
+        assert len(tcs.zones) > 0
+        assert await tcs.zones[0].thermal_mode() is None
+    finally:
+        await gwy.stop()


### PR DESCRIPTION
### The Problem:
When restoring cached packet logs via `_restore_cached_packets()`, `tcs.thermal_mode()` and `zone.thermal_mode()` remained `None` despite cached `2D49` (cooling demand) packets being present. This caused climate entities in downstream integrations (like `ramses-rf/ramses_cc#965`) to fall back to `HVACMode.HEAT` upon restart until a fresh live RF packet was received.

### The Fix:
- Registered `Code._2D49` with `_update_system_state` in `StateProjector` and routed system-level `2D49` packets directly to the `tcs` read-model target (`system_by_id` or `src_dev.tcs`) in `src/ramses_rf/pipeline/ingestion.py` and `src/ramses_rf/state_projector.py`.
- Promoted `thermal_mode()` and `thermal_demand()` from `DhwZone` to `ZoneBase` in `src/ramses_rf/systems/zones.py` so all zone types delegate active thermal mode resolution to `await self.tcs.thermal_mode()`.

### Testing Performed:
- Added pure unit tests in `tests/tests_rf/pipeline/test_state_projector.py` verifying `StateProjector` maps `2D49` packets (both active and inactive cooling demand) from controller and UFC sources to `tcs.system_state.cooling_mode`.
- Added end-to-end cached packet restore test cases in `tests/tests_rf/test_hcc100_cooling.py` verifying `_restore_cached_packets()` hydrates `tcs.thermal_mode() == ThermalMode.COOL` and `zone.thermal_mode() == ThermalMode.COOL`.
- Ran `.venv/bin/prek run -a` (all linters and formatters passed).
- Ran `.venv/bin/mypy --strict .` (265 source files checked, 0 errors).
- Ran `.venv/bin/python -u -m pytest -n auto` (2575 passed, 3 skipped, 99 snapshots passed in 37s).

### AI Assistance Disclosure:
This contribution was developed with the assistance of Google Gemini 3.7 Flash for code generation and documentation. All logic and implementations were reviewed and verified by the author.