### PR TITLE
fix: ventilator set_fan_mode should not wait for reply

### DIFF
--- a/src/ramses_rf/devices/hvac_ventilators.py
+++ b/src/ramses_rf/devices/hvac_ventilators.py
@@ -624,8 +624,11 @@ class HvacVentilator(FilterChange):  # FAN: RP/31DA, I/31D[9A], 2411
             action=Action.SET_FAN_MODE,
             data={"fan_mode": fan_mode, "scheme": self._scheme or "orcon"},
         )
+        # Ventilators do not ack 22F1 commands — the REM→FAN direction is
+        # one-way.  wait_for_reply=True causes a timeout on every call
+        # (issue 995).  Fire-and-forget instead.
         return await self._gateway.dispatcher.send(
-            intent, priority=Priority.HIGH, wait_for_reply=True
+            intent, priority=Priority.HIGH, wait_for_reply=False
         )
 
     async def air_quality(self) -> float | None:

--- a/tests/tests_rf/device/test_hvac_ventilator.py
+++ b/tests/tests_rf/device/test_hvac_ventilator.py
@@ -605,6 +605,7 @@ async def test_set_fan_mode_with_bound_rem() -> None:
     # 2. Verify the intent was transmitted with the correct QoS
     dev._gateway.dispatcher.send.assert_awaited_once()
     intent = dev._gateway.dispatcher.send.await_args[0][0]
+    kwargs = dev._gateway.dispatcher.send.await_args.kwargs
 
     from ramses_rf.enums import Action
 
@@ -612,6 +613,8 @@ async def test_set_fan_mode_with_bound_rem() -> None:
     assert intent.src.id == "37:654321"
     assert intent.dst.id == "32:123456"
     assert intent.data == {"fan_mode": "low", "scheme": "orcon"}
+    # Ventilators don't ack 22F1 — fire-and-forget (issue 995)
+    assert kwargs.get("wait_for_reply") is False
     assert result == "mock_packet"
 
 
@@ -634,6 +637,7 @@ async def test_set_fan_mode_with_hgi_fallback() -> None:
     # Verify the intent was built using the HGI's ID ("18:000730")
     dev._gateway.dispatcher.send.assert_awaited_once()
     intent = dev._gateway.dispatcher.send.await_args[0][0]
+    kwargs = dev._gateway.dispatcher.send.await_args.kwargs
 
     from ramses_rf.enums import Action
 
@@ -641,6 +645,8 @@ async def test_set_fan_mode_with_hgi_fallback() -> None:
     assert intent.src.id == "18:000730"
     assert intent.dst.id == "32:123456"
     assert intent.data == {"fan_mode": "high", "scheme": "orcon"}
+    # Ventilators don't ack 22F1 — fire-and-forget (issue 995)
+    assert kwargs.get("wait_for_reply") is False
 
 
 async def test_set_fan_mode_no_src_id_raises() -> None:


### PR DESCRIPTION
## Summary

- `HvacVentilator.set_fan_mode` used `wait_for_reply=True`, but ventilators do not ack 22F1 commands (REM→FAN is one-way)
- This caused a timeout on every `set_fan_mode` call (ramses_cc issue 995), even though the HRU correctly changed speed
- Changed to `wait_for_reply=False` (fire-and-forget)

## Context

Reported in https://github.com/ramses-rf/ramses_cc/issues/995 — the user sees `Timeout waiting for reply to set_fan_mode` when selecting built-in fan modes (off/auto/low/medium/high) from the climate dropdown. The HRU does change speed, so the command is received — it just never sends a reply packet.

The `wait_for_reply=True` was likely copied from other set commands (zones, TCS) where devices do ack. Ventilators are different: 22F1 I from REM→FAN is a one-way command.

#### Test plan

- [x] `pytest tests/tests_rf/device/test_hvac_ventilator.py` — 24 passed
- [x] `pytest tests/tests_rf/commands/test_command_builders.py` — 157 passed
- [x] Tests updated to assert `wait_for_reply=False`