### PR TITLE
fix: deep_merge handles unhashable list elements (dicts)

### DIFF
--- a/src/ramses_rf/helpers.py
+++ b/src/ramses_rf/helpers.py
@@ -64,7 +64,19 @@ def deep_merge(
             new_dst[key] = source[key]  # not expected, but maybe
 
         else:
-            new_dst[key] = list(set(source[key] + new_dst[key]))  # will sort
+            # Merge lists, deduplicating.  Use set() when elements are
+            # hashable (strings, ints); fall back to manual dedup for
+            # unhashable elements (dicts, like _commands dict templates).
+            combined = source[key] + new_dst[key]
+            try:
+                new_dst[key] = list(set(combined))  # will sort
+            except TypeError:
+                # Unhashable elements (e.g. dicts) — dedup manually
+                seen: list = []
+                for item in combined:
+                    if item not in seen:
+                        seen.append(item)
+                new_dst[key] = seen
 
     # assert _is_subset(shrink(src), shrink(new_dst))
     return new_dst

--- a/src/ramses_rf/helpers.py
+++ b/src/ramses_rf/helpers.py
@@ -72,7 +72,7 @@ def deep_merge(
                 new_dst[key] = list(set(combined))  # will sort
             except TypeError:
                 # Unhashable elements (e.g. dicts) — dedup manually
-                seen: list = []
+                seen: list[Any] = []
                 for item in combined:
                     if item not in seen:
                         seen.append(item)


### PR DESCRIPTION
## Summary

`deep_merge` used `list(set(source[key] + new_dst[key]))` to deduplicate list elements, which fails with `TypeError: cannot use 'dict' as a set element (unhashable type: 'dict')` when list elements are dicts (e.g. `_commands` dict templates in ramses_cc schemas).

Now falls back to manual dedup (linear scan with `in` check) when `set()` raises `TypeError`.

## Context

Reported in https://github.com/ramses-rf/ramses_cc/issues/995 — when a ramses_cc schema has `_commands` with dict template entries on FAN devices, `merge_schemas` calls `deep_merge` which crashes because the dict entries are unhashable.

#### Test plan
- [x] Existing `deep_merge` tests pass (hashable elements still use `set()`)
- [x] Manual test with dict list elements no longer crashes