### PR TITLE
fix: auto-reclassify misclassified FAN to DIS via contradiction detection

### DIFF
--- a/src/ramses_rf/config.py
+++ b/src/ramses_rf/config.py
@@ -82,6 +82,7 @@ def sch_global_traits_dict_factory(
             ),
             vol.Optional(SZ_IS_BATTERY, default=False): vol.Any(None, bool),
             vol.Optional(vol.Remove("_note")): str,
+            vol.Optional("locked", default=False): vol.Any(None, bool),
         },
         extra=vol.PREVENT_EXTRA,
     )
@@ -171,6 +172,7 @@ _TRAIT_KEY_MAP: Final[dict[str, str]] = {
     "_class": SZ_CLASS,
     "_polling_interval": SZ_POLLING_INTERVAL,
     "_is_battery": SZ_IS_BATTERY,
+    "_locked": "locked",
 }
 
 # _-prefixed keys that are preserved as-is (not stripped/mapped) because

--- a/src/ramses_rf/devices/dev_registry.py
+++ b/src/ramses_rf/devices/dev_registry.py
@@ -363,6 +363,15 @@ class DeviceRegistry:
                 f"UPDATED SSOT TRAITS: {event.device_id} class -> {new_class_slug} via {event.causation}"
             )
 
+            # 2. For contradiction-based reclassifications (e.g. a FAN
+            # that is actually a DIS), do NOT auto-swap the device
+            # object at runtime.  The SSOT known_list is updated so the
+            # discovery/config flow can present the suggested class to
+            # the user.  The user accepts the change via the config
+            # flow, which reloads the integration and creates the
+            # correct entities.  This is consistent with how other
+            # promotions work.
+
     def _handle_create_controller(self, event: TopologyChangedEvent) -> None:
         """Instruct a device to initialize its Evohome TCS."""
         if not event.device_id:

--- a/src/ramses_rf/discovery_scan.py
+++ b/src/ramses_rf/discovery_scan.py
@@ -130,6 +130,44 @@ _HVAC_PARENT_INFERENCE_CODES: frozenset[Code | str] = frozenset(
     }
 )
 
+# Contradiction threshold: after this many consecutive source packets
+# where _classify disagrees with likely_type (without a matching packet
+# resetting the count), likely_type is updated.  Mirrors the HvacTopologyHandler's
+# threshold (3 non-FAN packets).  Generic — works for any device class.
+_CONTRADICTION_THRESHOLD: int = 3
+
+
+def _is_evidence_based(
+    device_id: str, code: str, verb: str, is_source: bool
+) -> bool:
+    """Check if a (verb, code) pair provides evidence-based classification.
+
+    Returns True if the pair maps to a specific DevType via _VC_TO_TYPE
+    (a verb+code signature match), or if the code is CTL-only.  These
+    are evidence-based classifications that can legitimately contradict
+    a declared class.
+
+    Returns False for prefix fallbacks (e.g. 37: → REM is a guess based
+    on the device ID prefix, not on what the packet actually says).  A
+    prefix fallback should NOT count as a contradiction — otherwise a
+    CO2 device sending generic codes like 10E0 would be re-classified as
+    REM just because 37: falls to REM by prefix.
+    """
+    vc_key = (verb, code)
+    if vc_key in _VC_TO_TYPE:
+        return True
+    return bool(
+        is_source
+        and (
+            code in _CTL_ONLY_CODES
+            or (
+                code in _CTL_ONLY_CODES_WITH_VERB
+                and verb in _CTL_ONLY_CODES_WITH_VERB[code]
+            )
+        )
+    )
+
+
 # TPI loop codes broadcast by a BDR (13:) or OTB (10:) acting as the
 # appliance_control (boiler relay).  These are sent as I broadcasts at
 # the TPI cycle rate (usu. 6x/hr).  This is the same signature
@@ -220,6 +258,15 @@ class DiscoveredDevice:
     is_battery: bool = False  # seen sending battery info
     source_count: int = 0  # number of packets where this device was src
     destination_count: int = 0  # number of packets where this device was dst
+    # Contradiction tracking (issue 1000): for known devices, count
+    # source packets where _classify disagrees with the current
+    # likely_type.  After _CONTRADICTION_THRESHOLD consecutive
+    # disagreements (without a matching packet resetting the count),
+    # likely_type is updated to the new classification.  This uses the
+    # existing _classify function — no HVAC-specific logic here.  When
+    # the strategy pattern arrives, _classify becomes
+    # strategy.classify(packet) and this tracking moves with it.
+    contradiction_count: int = 0
 
     def to_dict(self) -> dict[str, Any]:
         """Serialize to a plain dict (for JSON export)."""
@@ -335,6 +382,24 @@ class DiscoveryScan:
 
         # Check schema keys (CTL IDs are top-level keys — declared intent)
         return device_id in self._gateway._gwy_config.schema
+
+    def _get_declared_class(self, device_id: str) -> DevType | None:
+        """Get the declared class for a known device from the known_list.
+
+        :param device_id: The device ID to look up.
+        :return: The declared DevType, or None if the device is not in
+            the known_list or has no class.
+        """
+        entry = self._gateway._gwy_config.known_list.get(device_id)
+        if not isinstance(entry, dict):
+            return None
+        cls = entry.get("class")
+        if not isinstance(cls, str) or not cls:
+            return None
+        try:
+            return DevType(cls)
+        except ValueError:
+            return None
 
     def _is_declared_hotwater_valve(self, device_id: str) -> bool:
         """Check if a device is declared as hotwater_valve in the schema.
@@ -552,9 +617,51 @@ class DiscoveryScan:
                 # entry so codes_seen is accumulated (needed for DHW valve
                 # inference via 1100 code, etc.)
                 now = dt.now().isoformat(timespec="seconds")
-                likely_type = _classify(
-                    device_id, code, verb, is_source=is_source
-                )
+                # Use the declared class from the known_list as the
+                # initial likely_type (issue 1000).  The known_list is
+                # derived from the schema, which is authoritative.
+                # This ensures the scan engine starts with the declared
+                # class and only re-classifies after contradiction
+                # threshold is reached.  Without this, a restarted scan
+                # engine creates 37:169161 with likely_type=REM (prefix
+                # fallback) instead of FAN (declared), so no
+                # contradiction is ever detected.
+                declared_class = self._get_declared_class(device_id)
+                if declared_class is not None:
+                    likely_type = declared_class
+                    initial_conf = "high"  # declared class is authoritative
+                else:
+                    likely_type = _classify(
+                        device_id, code, verb, is_source=is_source
+                    )
+                    # Confidence: "high" if evidence-based (VC pair
+                    # match, CTL-only code, or zone binding code),
+                    # "medium" if prefix fallback (37: → REM is a
+                    # guess).  This prevents false-positive class
+                    # mismatches where the scan engine confidently says
+                    # "REM" based on a prefix fallback for a device
+                    # that is actually a CO2.
+                    vc_key = (verb, code)
+                    is_vc_match = (
+                        vc_key in _VC_TO_TYPE
+                        and _VC_TO_TYPE[vc_key]
+                        in _AMBIGUOUS_HVAC_PREFIX_TYPES.get(
+                            device_id[:2], frozenset()
+                        )
+                    ) or (
+                        is_source
+                        and (
+                            code in _CTL_ONLY_CODES
+                            or (
+                                code in _CTL_ONLY_CODES_WITH_VERB
+                                and verb in _CTL_ONLY_CODES_WITH_VERB[code]
+                            )
+                        )
+                    )
+                    is_binding = is_source and code in _ZONE_BINDING_CODES
+                    initial_conf = (
+                        "high" if (is_vc_match or is_binding) else "medium"
+                    )
                 device = DiscoveredDevice(
                     device_id=device_id,
                     first_seen=now,
@@ -562,7 +669,7 @@ class DiscoveryScan:
                     likely_type=likely_type,
                     codes_seen=[code] if code else [],
                     rssi=rssi,
-                    confidence="high",
+                    confidence=initial_conf,
                     is_battery=code in _BATTERY_CODES,
                     source_count=1 if is_source else 0,
                     destination_count=0 if is_source else 1,
@@ -692,6 +799,81 @@ class DiscoveryScan:
                         device.bound_to = destination
                         device.confidence = "high"
                         self._dirty = True
+
+                # Re-classify known devices using the same _classify
+                # function as for new devices (issue 1000).  Without
+                # this, likely_type is frozen at the first packet's
+                # classification, so a FAN-classified device that sends
+                # DIS-like packets (RQ 31DA, I 22F1) never gets
+                # re-classified and check_class_mismatches sees no
+                # mismatch.
+                #
+                # Uses a contradiction counter: consecutive source
+                # packets where _classify disagrees with likely_type
+                # increment the counter; a matching packet resets it.
+                # After _CONTRADICTION_THRESHOLD, likely_type is
+                # updated.  This avoids flapping on a single ambiguous
+                # packet.
+                #
+                # When the strategy pattern arrives, _classify becomes
+                # strategy.classify(packet) — this tracking naturally
+                # moves with it.
+                if is_source and code:
+                    new_type = _classify(
+                        device_id,
+                        code,
+                        verb,
+                        is_source=is_source,
+                        device=device,
+                    )
+                    if (
+                        new_type != DevType.DEV
+                        and new_type != device.likely_type
+                    ):
+                        # Only count evidence-based contradictions
+                        # (VC pair match or CTL-only code).  A prefix
+                        # fallback (e.g. 37: → REM) is a guess, not
+                        # evidence — it should NOT contradict a declared
+                        # class.  Otherwise a CO2 device sending generic
+                        # codes like 10E0 would be re-classified as REM
+                        # just because 37: falls to REM by prefix.
+                        if not _is_evidence_based(
+                            device_id, code, verb, is_source
+                        ):
+                            # Prefix fallback — skip, don't contradict
+                            pass
+                        else:
+                            device.contradiction_count += 1
+                            self._dirty = True
+                            if (
+                                device.contradiction_count
+                                >= _CONTRADICTION_THRESHOLD
+                            ):
+                                _LOGGER.debug(
+                                    "DiscoveryScan: re-classified known "
+                                    "device %s: %s -> %s (after %d "
+                                    "contradictions, code=%s, verb=%s)",
+                                    device_id,
+                                    device.likely_type,
+                                    new_type,
+                                    device.contradiction_count,
+                                    code,
+                                    verb.strip(),
+                                )
+                                device.likely_type = new_type
+                                device.contradiction_count = 0
+                                # Re-classification after threshold is
+                                # evidence-based — set confidence to
+                                # "high" so check_class_mismatches
+                                # trusts it (it skips HVAC devices with
+                                # "medium" confidence prefix-fallback
+                                # classifications).
+                                device.confidence = "high"
+                    elif new_type == device.likely_type:
+                        # Matching packet — reset contradiction count
+                        if device.contradiction_count > 0:
+                            device.contradiction_count = 0
+                            self._dirty = True
             return
 
         now = dt.now().isoformat(timespec="seconds")
@@ -989,13 +1171,37 @@ class DiscoveryScan:
         """Load a previously exported list (for resume after restart).
 
         Replaces the current in-memory dict.
+
+        For known devices (in the known_list), the declared class
+        overrides the imported likely_type (issue 1000).  This ensures
+        the scan engine always starts from the declared class and only
+        re-classifies after contradiction threshold is reached.  Without
+        this, a restarted scan engine keeps a stale likely_type from a
+        previous VC pair match (e.g. FAN from I 31DA) even though the
+        device is declared as REM in the schema.
         """
         parsed = json.loads(data)
         self._devices = {
             d["device_id"]: DiscoveredDevice.from_dict(d)
             for d in parsed.get("devices", [])
         }
-        self._dirty = False
+        # Override likely_type for known devices with declared class
+        had_overrides = False
+        for device_id, device in self._devices.items():
+            declared = self._get_declared_class(device_id)
+            if declared is not None and device.likely_type != declared:
+                _LOGGER.debug(
+                    "DiscoveryScan: overriding imported likely_type "
+                    "for known device %s: %s -> %s (declared class)",
+                    device_id,
+                    device.likely_type,
+                    declared,
+                )
+                device.likely_type = declared
+                device.contradiction_count = 0
+                device.confidence = "high"
+                had_overrides = True
+        self._dirty = had_overrides
         _LOGGER.info("DiscoveryScan: imported %d devices", len(self._devices))
 
     def device_count(self) -> int:
@@ -1051,6 +1257,15 @@ def _classify(
        accept VC pairs that map to a type valid for that prefix
     4. CH prefix — fallback for heating domain devices
     5. Accumulated codes — re-evaluate with full evidence
+
+    TODO: DIS (Orcon RF15 Display) is not distinguishable from REM by
+    this function.  A DIS sends RQ 2411 and RQ 31DA as normal behavior,
+    but so does a REM (per the protocol table, with "VMI only?" caveats).
+    The scan engine falls to the 37: prefix fallback (REM) for both.
+    When the strategy pattern arrives (issue 939), a DisStrategy could
+    use 2411 frequency or the presence of 1470/042F (DIS-only codes) to
+    distinguish.  See also: protocol/ramses.py _HVAC_VC_PAIR_BY_CLASS,
+    pipeline/topology_handlers/hvac.py HvacTopologyHandler.
     """
     prefix = device_id[:2]
 
@@ -1093,23 +1308,13 @@ def _classify(
                 # only classify as CTL if the current verb matches
                 if verb in ctl_verbs:
                     return DevType.CTL
-        # Check HVAC codes from accumulated data — but only with the
-        # current verb.  Trying all verbs (I, RP, RQ, W) caused
-        # misclassification: a DIS sending RQ 31DA (requesting fan status
-        # from a FAN) was classified as FAN because (I, 31DA) maps to FAN
-        # in _VC_TO_TYPE.  The device never sent I 31DA — it only sent
-        # RQ 31DA — but the loop tried all verbs regardless.
-        #
-        # By only checking the current verb, we ensure:
-        # - RQ 31DA (DIS asking FAN for status) → not in _VC_TO_TYPE → skip
-        # - I 31DA (FAN broadcasting status) → FAN
-        # - RP 31DA (FAN responding to request) → FAN
-        valid_types = _AMBIGUOUS_HVAC_PREFIX_TYPES.get(prefix)
-        for code_seen in device.codes_seen:
-            if (verb, code_seen) in _VC_TO_TYPE:
-                vc_type = _VC_TO_TYPE[(verb, code_seen)]
-                if valid_types is None or vc_type in valid_types:
-                    return vc_type
+        # NOTE: HVAC VC-pair classification from accumulated codes_seen
+        # was removed — it caused misclassification because codes_seen
+        # doesn't track per-code verbs.  A DIS sending I 22F1 was
+        # classified as FAN because 31DA was in codes_seen (from a
+        # previous RQ 31DA) and (I, 31DA) maps to FAN.  Step 3 above
+        # already checks the current (verb, code) pair, which is
+        # sufficient for correct classification.
 
     # 5. CH prefix fallback
     if prefix in _PREFIX_TO_TYPE:

--- a/src/ramses_rf/gateway.py
+++ b/src/ramses_rf/gateway.py
@@ -206,6 +206,7 @@ class Gateway(GatewayLifecycle, GatewayInterface):
         # Instantiate the new asynchronous Topology Builder engine
         self._topology_builder = TopologyBuilder(
             emit_event_cb=self._device_registry.handle_topology_event,
+            device_class_lookup_cb=self._lookup_device_class,
         )
 
         self._message_store: MessageStoreInterface | None = None
@@ -237,6 +238,29 @@ class Gateway(GatewayLifecycle, GatewayInterface):
             send_func=lambda dto: self.async_send_cmd(dto),
         )
         self._polling_manager = PollingManager(self, shadow_mode=False)
+
+    def _lookup_device_class(self, device_id: str) -> dict[str, Any] | None:
+        """Look up the current device traits for a device_id.
+
+        Used by topology handlers to detect contradictions between
+        the known_list class and observed message patterns.
+
+        :param device_id: The device ID to look up.
+        :type device_id: str
+        :returns: A dict with keys "class" (device slug) and "locked"
+            (whether the user has locked the class), or None.
+        :rtype: dict[str, Any] | None
+        """
+        device = self._device_registry.device_by_id.get(DeviceIdT(device_id))
+        if not device:
+            return None
+        slug = getattr(device, "_SLUG", None)
+        # Check known_list for _locked trait (user override)
+        known = self._gwy_config.known_list.get(device_id, {})
+        return {
+            "class": slug,
+            "locked": bool(known.get("_locked", False)),
+        }
 
     def __repr__(self) -> str:
         """Return an unambiguous string representation."""

--- a/src/ramses_rf/pipeline/topology_builder.py
+++ b/src/ramses_rf/pipeline/topology_builder.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import logging
 from collections.abc import Callable
+from typing import Any
 
 from ramses_rf.messages.core import Message
 from ramses_rf.models import TopologyChangedEvent
@@ -48,6 +49,8 @@ class TopologyBuilder:
         self,
         emit_event_cb: Callable[[TopologyChangedEvent], None],
         enable_eavesdrop: bool = False,
+        device_class_lookup_cb: Callable[[str], dict[str, Any] | None]
+        | None = None,
     ) -> None:
         """Initialize the TopologyBuilder.
 
@@ -57,6 +60,11 @@ class TopologyBuilder:
         :param enable_eavesdrop: Flag toggling heuristic class promotions.
             If False (default), only explicit configuration rules process.
         :type enable_eavesdrop: bool
+        :param device_class_lookup_cb: Optional callback to look up the
+            current device traits (dict with "class", "locked", etc.)
+            by device_id.  Passed to handlers that need it for
+            contradiction detection.
+        :type device_class_lookup_cb: Callable[[str], dict[str, Any] | None] | None
         :returns: None
         :rtype: None
         """
@@ -83,7 +91,9 @@ class TopologyBuilder:
                 emit_event_cb, enable_eavesdrop=enable_eavesdrop
             ),
             HvacTopologyHandler(
-                emit_event_cb, enable_eavesdrop=enable_eavesdrop
+                emit_event_cb,
+                enable_eavesdrop=enable_eavesdrop,
+                device_class_lookup_cb=device_class_lookup_cb,
             ),
         ]
 

--- a/src/ramses_rf/pipeline/topology_handlers/base.py
+++ b/src/ramses_rf/pipeline/topology_handlers/base.py
@@ -17,6 +17,8 @@ class TopologyHandler(abc.ABC):
         self,
         emit_event_cb: Callable[[TopologyChangedEvent], None],
         enable_eavesdrop: bool = False,
+        device_class_lookup_cb: Callable[[str], dict[str, Any] | None]
+        | None = None,
     ) -> None:
         """Initialize the subsystem topology handler.
 
@@ -24,9 +26,18 @@ class TopologyHandler(abc.ABC):
         :type emit_event_cb: Callable[[TopologyChangedEvent], None]
         :param enable_eavesdrop: If True, heuristic class promotions are enabled.
         :type enable_eavesdrop: bool
+        :param device_class_lookup_cb: Optional callback to look up the
+            current device traits (dict with keys like "class",
+            "locked") by device_id.  Used by handlers that need to
+            detect contradictions between the known_list class and
+            observed message patterns.
+        :type device_class_lookup_cb: Callable[[str], dict[str, Any] | None] | None
         """
         self._emit: Callable[[TopologyChangedEvent], None] = emit_event_cb
         self._enable_eavesdrop: bool = enable_eavesdrop
+        self._device_class_lookup_cb: (
+            Callable[[str], dict[str, Any] | None] | None
+        ) = device_class_lookup_cb
 
     @abc.abstractmethod
     def consume(self, msg: Message) -> None:

--- a/src/ramses_rf/pipeline/topology_handlers/hvac.py
+++ b/src/ramses_rf/pipeline/topology_handlers/hvac.py
@@ -2,16 +2,77 @@
 
 from __future__ import annotations
 
+import logging
+from collections.abc import Callable
+from typing import Any
+
 from ramses_rf.const import DevType
 from ramses_rf.enums import TopologyAction
 from ramses_rf.messages.core import Message
 from ramses_rf.models import TopologyChangedEvent
 from ramses_rf.pipeline.topology_handlers.base import TopologyHandler
 from ramses_rf.protocol.ramses import HVAC_KLASS_BY_VC_PAIR
+from ramses_tx.const import Code, Verb
+
+_LOGGER = logging.getLogger(__name__)
+
+# VC pairs that are strong evidence a device is a FAN (broadcasts/responds
+# with ventilation status).  A real FAN sends these as src.
+_FAN_EVIDENCE: frozenset[tuple[Verb, Code]] = frozenset(
+    {
+        (Verb.I_, Code._31D9),
+        (Verb.I_, Code._31DA),
+        (Verb.RP, Code._31DA),
+        (Verb.RP, Code._2411),  # FAN responds to 2411 parameter requests
+    }
+)
+
+# VC pairs that are strong evidence a device is NOT a FAN but a
+# remote/display (DIS/REM):
+# - RQ 31DA: a DIS/REM requests fan status from the FAN (a FAN never
+#   sends RQ 31DA as src).
+# - RQ 2411: a DIS/REM requests 2411 parameters from the FAN (a FAN
+#   never sends RQ 2411 as src — it responds with RP 2411).
+# - I 22F1: a DIS/REM sends fan-mode commands to the FAN (a FAN never
+#   sends I 22F1 as src — it receives them).
+_NON_FAN_EVIDENCE: frozenset[tuple[Verb, Code]] = frozenset(
+    {
+        (Verb.RQ, Code._31DA),
+        (Verb.RQ, Code._2411),
+        (Verb.I_, Code._22F1),
+    }
+)
+
+# Minimum number of contradictory packets before reclassifying.
+_RECLASSIFY_THRESHOLD: int = 3
 
 
 class HvacTopologyHandler(TopologyHandler):
     """CQRS Topology Handler for Ventilation and HVAC devices."""
+
+    def __init__(
+        self,
+        emit_event_cb: Callable[[TopologyChangedEvent], None],
+        enable_eavesdrop: bool = False,
+        device_class_lookup_cb: Callable[[str], dict[str, Any] | None]
+        | None = None,
+    ) -> None:
+        """Initialize the handler with per-device evidence tracking.
+
+        :param emit_event_cb: Callback to emit topology events.
+        :param enable_eavesdrop: If True, heuristic class promotions are enabled.
+        :param device_class_lookup_cb: Optional callback to look up the
+            current device traits (dict with "class", "locked", etc.)
+            by device_id.  Used to detect contradictions between the
+            known_list class and observed message patterns.
+        """
+        super().__init__(
+            emit_event_cb,
+            enable_eavesdrop=enable_eavesdrop,
+            device_class_lookup_cb=device_class_lookup_cb,
+        )
+        # Per-device evidence: {device_id: {"fan": int, "non_fan": int}}
+        self._evidence: dict[str, dict[str, int]] = {}
 
     def consume(self, msg: Message) -> None:
         """Evaluate HVAC class promotion rules.
@@ -19,49 +80,142 @@ class HvacTopologyHandler(TopologyHandler):
         :param msg: The incoming message envelope.
         :type msg: Message
         """
-        if not self._enable_eavesdrop:
-            return
-
         msg_verb = msg.header.verb
         msg_code = str(msg.header.code)
 
-        dev_class = None
-        for (
-            schema_verb,
-            schema_code,
-        ), dev_class_name in HVAC_KLASS_BY_VC_PAIR.items():
-            if (schema_verb is None or schema_verb == msg_verb) and str(
-                schema_code
-            ) == msg_code:
-                dev_class = dev_class_name
-                break
+        # --- Standard promotion via VC pair lookup ---
+        # Only run heuristic promotions when eavesdrop is enabled.
+        if self._enable_eavesdrop:
+            dev_class = None
+            for (
+                schema_verb,
+                schema_code,
+            ), dev_class_name in HVAC_KLASS_BY_VC_PAIR.items():
+                if (schema_verb is None or schema_verb == msg_verb) and str(
+                    schema_code
+                ) == msg_code:
+                    dev_class = dev_class_name
+                    break
 
-        if dev_class:
-            if msg.src.id != "--:------" and getattr(
-                msg.src, "type", None
-            ) not in (
-                "01",
-                DevType.CTL,
-            ):
-                self._emit(
-                    TopologyChangedEvent(
-                        action=TopologyAction.UPDATE_DEVICE_CLASS,
-                        device_id=msg.src.id,
-                        metadata={"device_class": dev_class},
-                        causation="Rule_HVAC_Signature_Source",
+            if dev_class:
+                if msg.src.id != "--:------" and getattr(
+                    msg.src, "type", None
+                ) not in (
+                    "01",
+                    DevType.CTL,
+                ):
+                    self._emit(
+                        TopologyChangedEvent(
+                            action=TopologyAction.UPDATE_DEVICE_CLASS,
+                            device_id=msg.src.id,
+                            metadata={"device_class": dev_class},
+                            causation="Rule_HVAC_Signature_Source",
+                        )
                     )
-                )
+
+                if (
+                    msg.dst.id != "--:------"
+                    and msg.dst.id != msg.src.id
+                    and getattr(msg.dst, "type", None)
+                    not in ("01", DevType.CTL)
+                ):
+                    self._emit(
+                        TopologyChangedEvent(
+                            action=TopologyAction.UPDATE_DEVICE_CLASS,
+                            device_id=msg.dst.id,
+                            metadata={"device_class": dev_class},
+                            causation="Rule_HVAC_Signature_Target",
+                        )
+                    )
+
+        # --- Contradiction detection: FAN misclassified as DIS/REM ---
+        # Track evidence for the src device.  If a device currently typed
+        # as FAN only sends RQ 31DA (non-FAN behavior) and never sends
+        # I/RP 31DA or I 31D9 (FAN behavior), it is likely a DIS or REM
+        #
+        # TODO: The reclassification target is always DIS, but we cannot
+        # reliably distinguish DIS from REM yet.  A DIS (Orcon RF15
+        # Display) sends RQ 2411 and RQ 31DA as normal behavior, while a
+        # bound REM only sends 2411 when prompted by a VMI.  The protocol
+        # table (_DEV_KLASSES_HVAC) lists 2411 for both REM and DIS with
+        # "VMI only?" caveats for REM.  When the strategy pattern arrives
+        # (issue 939), a DisStrategy could use 2411 frequency or the
+        # presence of 1470/042F (DIS-only codes) to distinguish.
+        # See also: discovery_scan.py _classify,
+        # protocol/ramses.py _HVAC_VC_PAIR_BY_CLASS.
+        # that was wrongly promoted to FAN.
+        if msg.src.id != "--:------":
+            src_id = msg.src.id
+            vc = (msg_verb, msg.header.code)
+            ev = self._evidence.setdefault(src_id, {"fan": 0, "non_fan": 0})
+            if vc in _FAN_EVIDENCE:
+                ev["fan"] += 1
+            elif vc in _NON_FAN_EVIDENCE:
+                ev["non_fan"] += 1
+
+            # Check for contradiction: device is typed FAN but behaves
+            # like a DIS/REM.  We look up the current device traits via
+            # the callback (msg.src.type is only the address prefix,
+            # not the device class).
+            traits = (
+                self._device_class_lookup_cb(src_id)
+                if self._device_class_lookup_cb
+                else None
+            )
+            current_class = traits.get("class") if traits else None
+            is_locked = bool(traits.get("locked")) if traits else False
 
             if (
-                msg.dst.id != "--:------"
-                and msg.dst.id != msg.src.id
-                and getattr(msg.dst, "type", None) not in ("01", DevType.CTL)
+                current_class == DevType.FAN
+                and ev["non_fan"] >= _RECLASSIFY_THRESHOLD
+                and ev["fan"] == 0
             ):
-                self._emit(
-                    TopologyChangedEvent(
-                        action=TopologyAction.UPDATE_DEVICE_CLASS,
-                        device_id=msg.dst.id,
-                        metadata={"device_class": dev_class},
-                        causation="Rule_HVAC_Signature_Target",
+                if is_locked:
+                    # User has explicitly locked this device's class.
+                    # Log once at INFO level and do not emit a
+                    # reclassification event — _locked means "don't
+                    # touch this".
+                    if not ev.get("warned_locked", False):
+                        _LOGGER.info(
+                            "Device %s is typed as FAN but behaves as "
+                            "a DIS/REM (%d non-FAN packets, 0 FAN "
+                            "packets) — class is locked by user, "
+                            "not reclassifying",
+                            src_id,
+                            ev["non_fan"],
+                        )
+                        ev["warned_locked"] = True
+                else:
+                    # Emit the reclassification event every time (the
+                    # SSOT update is idempotent, and this ensures the
+                    # discovery/config flow sees the suggestion even
+                    # if it was missed on the first emit).
+                    self._emit(
+                        TopologyChangedEvent(
+                            action=TopologyAction.UPDATE_DEVICE_CLASS,
+                            device_id=src_id,
+                            metadata={"device_class": DevType.DIS},
+                            causation="Rule_HVAC_Contradiction_FAN_to_DIS",
+                        )
                     )
-                )
+                    # Warn only once per session to avoid log spam.
+                    # The device object stays as FAN (notify-only
+                    # strategy) so the class lookup keeps returning
+                    # FAN — the warned flag prevents repeat warnings
+                    # until the user accepts the change via the config
+                    # flow (which reloads the integration and resets
+                    # the handler).
+                    if not ev.get("warned", False):
+                        _LOGGER.warning(
+                            "Device %s is typed as FAN but has only "
+                            "sent RQ 31DA / I 22F1 (%d packets) and "
+                            "never I/RP 31DA or I 31D9 — suggesting "
+                            "reclassification to DIS (likely a "
+                            "display/remote, not a ventilator).  Run "
+                            "the discovery/config flow to accept this "
+                            "change, or add '_locked: true' to "
+                            "suppress this warning.",
+                            src_id,
+                            ev["non_fan"],
+                        )
+                        ev["warned"] = True

--- a/src/ramses_rf/protocol/ramses.py
+++ b/src/ramses_rf/protocol/ramses.py
@@ -744,6 +744,13 @@ _DEV_KLASSES_HVAC: dict[str, dict[Code, dict[Verb, Any]]] = {
         Code._22F1: {I_: {}},
         Code._22F3: {I_: {}},
         Code._22F7: {RQ: {}, W_: {}},  # from a VMI (only?)
+        # TODO: 2411 is listed for REM with "VMI only?" caveat, but a
+        # normal REM does NOT send 2411 — only a DIS does.  The scan
+        # engine and HvacTopologyHandler cannot distinguish DIS from REM
+        # by VC pairs alone (see _HVAC_VC_PAIR_BY_CLASS).  When the
+        # strategy pattern arrives (issue 939), a DisStrategy could use
+        # 2411 frequency to distinguish.  See also: discovery_scan.py
+        # _classify, pipeline/topology_handlers/hvac.py.
         Code._2411: {RQ: {}, W_: {}},  # from a VMI (only?)
         Code._313F: {RQ: {}, W_: {}},  # from a VMI (only?)
         Code._31DA: {RQ: {}},  # to a VMI (only?)
@@ -834,6 +841,16 @@ _HVAC_VC_PAIR_BY_CLASS: dict[DevType, tuple[tuple[Verb, Code], ...]] = {
     DevType.FAN: ((I_, Code._31D9), (I_, Code._31DA), (RP, Code._31DA)),
     DevType.HUM: ((I_, Code._12A0),),
     DevType.REM: ((I_, Code._22F1), (I_, Code._22F3)),
+    # TODO: DIS is not distinguishable from REM by VC pairs alone.
+    # A DIS (Orcon RF15 Display) sends RQ 2411 and RQ 31DA as normal
+    # behavior, but so does a REM (per the protocol table, with "VMI
+    # only?" caveats).  The key difference is that a DIS sends 2411
+    # routinely, while a bound REM only sends it when prompted by a VMI.
+    # The scan engine's _classify cannot distinguish DIS from REM — it
+    # falls to the 37: prefix fallback (REM) for both.  When the strategy
+    # pattern arrives (issue 939), a DisStrategy could use 2411 frequency
+    # or the presence of 1470/042F (DIS-only codes) to distinguish.
+    # See also: discovery_scan.py _classify, hvac.py HvacTopologyHandler.
 }
 HVAC_KLASS_BY_VC_PAIR: dict[tuple[Verb, Code], DevType] = {
     t: k for k, v in _HVAC_VC_PAIR_BY_CLASS.items() for t in v

--- a/tests/tests_rf/test_discovery_scan.py
+++ b/tests/tests_rf/test_discovery_scan.py
@@ -1968,3 +1968,116 @@ class TestHvacParentInference:
             assert dev.bound_to == FAN_ID
         finally:
             scan.stop()
+
+
+class TestEvidenceBasedContradiction:
+    """Tests for evidence-based contradiction re-classification.
+
+    The scan engine re-classifies known devices when source packets
+    contradict the declared class.  But only evidence-based
+    classifications (VC pair matches, CTL-only codes) should count as
+    contradictions — prefix fallbacks (e.g. 37: -> REM) are guesses and
+    should NOT contradict a declared class.
+
+    Without this, a CO2 device (37: prefix) sending generic codes like
+    10E0 would be re-classified as REM just because 37: falls to REM
+    by prefix (false positive on hass).
+    """
+
+    def test_co2_not_reclassified_by_generic_code(self) -> None:
+        """A CO2 device sending 10E0 (generic) should NOT be re-classified.
+
+        37:126776 is declared as CO2 in the known_list.  It sends 10E0
+        (a generic code).  _classify returns REM for 37: prefix fallback,
+        but this is a guess, not evidence -- so it should NOT increment
+        contradiction_count or re-classify the device.
+        """
+        gwy = make_mock_gateway(known_list={"37:126776": {"class": "CO2"}})
+        scan = DiscoveryScan(gwy)
+        # Send 3+ generic 10E0 packets -- would trigger re-classification
+        # if prefix fallbacks counted as contradictions
+        for _ in range(5):
+            scan._process_packet(
+                make_dto(src="37:126776", code=Code._10E0, verb=Verb.I_)
+            )
+        dev = scan.get_device("37:126776")
+        assert dev is not None
+        assert dev.likely_type == DevType.CO2  # still CO2
+        assert dev.contradiction_count == 0  # no contradiction counted
+        scan.stop()
+
+    def test_co2_not_reclassified_by_31e0(self) -> None:
+        """A CO2 device sending 31E0 (vent_demand) should NOT be re-classified.
+
+        31E0 is not in _VC_TO_TYPE, so _classify falls to prefix (REM).
+        But 31E0 is a generic HVAC code -- not evidence of REM.
+        """
+        gwy = make_mock_gateway(known_list={"37:126776": {"class": "CO2"}})
+        scan = DiscoveryScan(gwy)
+        for _ in range(5):
+            scan._process_packet(
+                make_dto(src="37:126776", code=Code._31E0, verb=Verb.I_)
+            )
+        dev = scan.get_device("37:126776")
+        assert dev is not None
+        assert dev.likely_type == DevType.CO2
+        assert dev.contradiction_count == 0
+        scan.stop()
+
+    def test_co2_matching_packet_resets_contradiction(self) -> None:
+        """A CO2 device sending 1298 (CO2 VC pair) resets contradiction count.
+
+        (I, 1298) maps to CO2 in _VC_TO_TYPE -- this is evidence-based
+        and matches the declared class, so it resets the count.
+        """
+        gwy = make_mock_gateway(known_list={"37:126776": {"class": "CO2"}})
+        scan = DiscoveryScan(gwy)
+        # Send a 1298 packet (evidence-based, matches CO2)
+        scan._process_packet(
+            make_dto(src="37:126776", code=Code._1298, verb=Verb.I_)
+        )
+        dev = scan.get_device("37:126776")
+        assert dev is not None
+        assert dev.likely_type == DevType.CO2
+        assert dev.contradiction_count == 0
+        scan.stop()
+
+    def test_rem_reclassified_by_co2_evidence(self) -> None:
+        """A REM device sending 1298 (CO2 evidence) IS re-classified to CO2.
+
+        (I, 1298) is a VC pair match for CO2 -- this IS evidence-based.
+        After 3+ such packets, the device should be re-classified.
+        """
+        gwy = make_mock_gateway(known_list={"37:222222": {"class": "REM"}})
+        scan = DiscoveryScan(gwy)
+        # Send 4x 1298 packets (evidence-based, contradicts REM)
+        # First packet creates the device, subsequent packets increment
+        # contradiction_count.  After 3 contradictions (4th packet),
+        # likely_type is updated.
+        for _ in range(4):
+            scan._process_packet(
+                make_dto(src="37:222222", code=Code._1298, verb=Verb.I_)
+            )
+        dev = scan.get_device("37:222222")
+        assert dev is not None
+        assert dev.likely_type == DevType.CO2  # re-classified
+        assert dev.confidence == "high"
+        scan.stop()
+
+    def test_fan_reclassified_by_rem_evidence(self) -> None:
+        """A FAN device sending 22F1 (REM evidence) IS re-classified to REM.
+
+        (I, 22F1) is a VC pair match for REM -- this IS evidence-based.
+        After 3+ such packets, the device should be re-classified.
+        """
+        gwy = make_mock_gateway(known_list={"37:333333": {"class": "FAN"}})
+        scan = DiscoveryScan(gwy)
+        for _ in range(4):
+            scan._process_packet(
+                make_dto(src="37:333333", code=Code._22F1, verb=Verb.I_)
+            )
+        dev = scan.get_device("37:333333")
+        assert dev is not None
+        assert dev.likely_type == DevType.REM  # re-classified
+        assert dev.confidence == "high"
+        scan.stop()

--- a/tests/tests_rf/test_hvac_contradiction.py
+++ b/tests/tests_rf/test_hvac_contradiction.py
@@ -1,0 +1,308 @@
+# --- START OF FILE test_hvac_contradiction.py ---
+
+"""Unit tests for HvacTopologyHandler contradiction detection (issue 1000).
+
+Tests that a device classified as FAN that only sends non-FAN packets
+(RQ 31DA, I 22F1, RQ 2411) is detected as a contradiction and a
+TopologyChangedEvent is emitted suggesting reclassification to DIS.
+
+Also tests that ``_locked: true`` suppresses the reclassification event.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from ramses_rf.const import DevType
+from ramses_rf.enums import TopologyAction
+from ramses_rf.models import TopologyChangedEvent
+from ramses_rf.pipeline.topology_handlers.hvac import HvacTopologyHandler
+from ramses_tx.const import Code, Verb
+
+
+class _FakeHeader:
+    """Minimal header stub for Message."""
+
+    def __init__(self, verb: Verb, code: Code) -> None:
+        self.verb = verb
+        self.code = code
+
+
+class _FakeAddr:
+    """Minimal address stub for Message."""
+
+    def __init__(self, device_id: str) -> None:
+        self.id = device_id
+        self.type = None
+
+
+class _FakeMsg:
+    """Minimal Message stub for testing HvacTopologyHandler.consume()."""
+
+    def __init__(
+        self, src_id: str, dst_id: str, verb: Verb, code: Code
+    ) -> None:
+        self.header = _FakeHeader(verb, code)
+        self.src = _FakeAddr(src_id)
+        self.dst = _FakeAddr(dst_id)
+
+
+def _make_handler(
+    emitted: list[TopologyChangedEvent],
+    *,
+    enable_eavesdrop: bool = True,
+    device_class_lookup_cb: Any = None,
+) -> HvacTopologyHandler:
+    """Create an HvacTopologyHandler that captures emitted events."""
+
+    def _emit(event: TopologyChangedEvent) -> None:
+        emitted.append(event)
+
+    return HvacTopologyHandler(
+        _emit,
+        enable_eavesdrop=enable_eavesdrop,
+        device_class_lookup_cb=device_class_lookup_cb,
+    )
+
+
+def _make_lookup(class_map: dict[str, dict[str, Any]]) -> Any:
+    """Create a device_class_lookup_cb from a {device_id: traits} map."""
+
+    def _lookup(device_id: str) -> dict[str, Any] | None:
+        return class_map.get(device_id)
+
+    return _lookup
+
+
+# --- Tests for contradiction detection ---
+
+
+def test_contradiction_detected_after_threshold() -> None:
+    """A FAN-classified device sending only non-FAN packets triggers DIS reclassification."""
+    emitted: list[TopologyChangedEvent] = []
+    lookup = _make_lookup(
+        {"37:169161": {"class": DevType.FAN, "locked": False}}
+    )
+    handler = _make_handler(emitted, device_class_lookup_cb=lookup)
+
+    # Inject 3 non-FAN packets (threshold is 3)
+    packets = [
+        _FakeMsg("37:169161", "32:153289", Verb.RQ, Code._31DA),
+        _FakeMsg("37:169161", "32:153289", Verb.I_, Code._22F1),
+        _FakeMsg("37:169161", "32:153289", Verb.RQ, Code._2411),
+    ]
+    for msg in packets:
+        handler.consume(msg)
+
+    # Should emit at least one UPDATE_DEVICE_CLASS event with DIS
+    contradiction_events = [
+        e
+        for e in emitted
+        if e.action == TopologyAction.UPDATE_DEVICE_CLASS
+        and e.causation == "Rule_HVAC_Contradiction_FAN_to_DIS"
+    ]
+    assert len(contradiction_events) > 0, (
+        f"Expected at least one contradiction event, got {len(contradiction_events)} "
+        f"(total events: {len(emitted)})"
+    )
+    assert contradiction_events[0].metadata["device_class"] == DevType.DIS
+    assert contradiction_events[0].device_id == "37:169161"
+
+
+def test_no_contradiction_when_fan_evidence_present() -> None:
+    """A FAN-classified device that also sends FAN packets should NOT trigger reclassification."""
+    emitted: list[TopologyChangedEvent] = []
+    lookup = _make_lookup(
+        {"37:169161": {"class": DevType.FAN, "locked": False}}
+    )
+    handler = _make_handler(emitted, device_class_lookup_cb=lookup)
+
+    # Mix of FAN and non-FAN packets
+    packets = [
+        _FakeMsg(
+            "37:169161", "32:153289", Verb.I_, Code._31DA
+        ),  # FAN evidence
+        _FakeMsg("37:169161", "32:153289", Verb.RQ, Code._31DA),  # non-FAN
+        _FakeMsg("37:169161", "32:153289", Verb.I_, Code._22F1),  # non-FAN
+        _FakeMsg("37:169161", "32:153289", Verb.RQ, Code._2411),  # non-FAN
+    ]
+    for msg in packets:
+        handler.consume(msg)
+
+    contradiction_events = [
+        e
+        for e in emitted
+        if e.causation == "Rule_HVAC_Contradiction_FAN_to_DIS"
+    ]
+    assert len(contradiction_events) == 0, (
+        f"Should not trigger contradiction when FAN evidence is present, "
+        f"got {len(contradiction_events)} events"
+    )
+
+
+def test_contradiction_below_threshold_no_event() -> None:
+    """Only 2 non-FAN packets (below threshold of 3) should not trigger reclassification."""
+    emitted: list[TopologyChangedEvent] = []
+    lookup = _make_lookup(
+        {"37:169161": {"class": DevType.FAN, "locked": False}}
+    )
+    handler = _make_handler(emitted, device_class_lookup_cb=lookup)
+
+    # Only 2 non-FAN packets (threshold is 3)
+    packets = [
+        _FakeMsg("37:169161", "32:153289", Verb.RQ, Code._31DA),
+        _FakeMsg("37:169161", "32:153289", Verb.I_, Code._22F1),
+    ]
+    for msg in packets:
+        handler.consume(msg)
+
+    contradiction_events = [
+        e
+        for e in emitted
+        if e.causation == "Rule_HVAC_Contradiction_FAN_to_DIS"
+    ]
+    assert len(contradiction_events) == 0
+
+
+def test_locked_suppresses_reclassification() -> None:
+    """A _locked FAN device should NOT trigger reclassification events."""
+    emitted: list[TopologyChangedEvent] = []
+    lookup = _make_lookup(
+        {"37:169161": {"class": DevType.FAN, "locked": True}}
+    )
+    handler = _make_handler(emitted, device_class_lookup_cb=lookup)
+
+    # 3 non-FAN packets — would normally trigger reclassification
+    packets = [
+        _FakeMsg("37:169161", "32:153289", Verb.RQ, Code._31DA),
+        _FakeMsg("37:169161", "32:153289", Verb.I_, Code._22F1),
+        _FakeMsg("37:169161", "32:153289", Verb.RQ, Code._2411),
+    ]
+    for msg in packets:
+        handler.consume(msg)
+
+    contradiction_events = [
+        e
+        for e in emitted
+        if e.causation == "Rule_HVAC_Contradiction_FAN_to_DIS"
+    ]
+    assert len(contradiction_events) == 0, (
+        f"Locked device should not emit reclassification events, "
+        f"got {len(contradiction_events)}"
+    )
+
+
+def test_rp_2411_is_fan_evidence() -> None:
+    """RP 2411 from a FAN-classified device counts as FAN evidence."""
+    emitted: list[TopologyChangedEvent] = []
+    lookup = _make_lookup(
+        {"37:169161": {"class": DevType.FAN, "locked": False}}
+    )
+    handler = _make_handler(emitted, device_class_lookup_cb=lookup)
+
+    # RP 2411 (FAN evidence) + 3 non-FAN packets
+    packets = [
+        _FakeMsg(
+            "37:169161", "32:153289", Verb.RP, Code._2411
+        ),  # FAN evidence
+        _FakeMsg("37:169161", "32:153289", Verb.RQ, Code._31DA),  # non-FAN
+        _FakeMsg("37:169161", "32:153289", Verb.I_, Code._22F1),  # non-FAN
+        _FakeMsg("37:169161", "32:153289", Verb.RQ, Code._2411),  # non-FAN
+    ]
+    for msg in packets:
+        handler.consume(msg)
+
+    contradiction_events = [
+        e
+        for e in emitted
+        if e.causation == "Rule_HVAC_Contradiction_FAN_to_DIS"
+    ]
+    assert len(contradiction_events) == 0, (
+        "RP 2411 is FAN evidence — should not trigger contradiction"
+    )
+
+
+def test_non_fan_device_no_contradiction() -> None:
+    """A device classified as REM (not FAN) should not trigger FAN→DIS contradiction."""
+    emitted: list[TopologyChangedEvent] = []
+    lookup = _make_lookup(
+        {"37:169161": {"class": DevType.REM, "locked": False}}
+    )
+    handler = _make_handler(emitted, device_class_lookup_cb=lookup)
+
+    packets = [
+        _FakeMsg("37:169161", "32:153289", Verb.RQ, Code._31DA),
+        _FakeMsg("37:169161", "32:153289", Verb.I_, Code._22F1),
+        _FakeMsg("37:169161", "32:153289", Verb.RQ, Code._2411),
+    ]
+    for msg in packets:
+        handler.consume(msg)
+
+    contradiction_events = [
+        e
+        for e in emitted
+        if e.causation == "Rule_HVAC_Contradiction_FAN_to_DIS"
+    ]
+    assert len(contradiction_events) == 0
+
+
+def test_warning_emitted_once_per_session(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """The WARNING log fires once, but the event continues to fire on each packet."""
+    import logging
+
+    emitted: list[TopologyChangedEvent] = []
+    lookup = _make_lookup(
+        {"37:169161": {"class": DevType.FAN, "locked": False}}
+    )
+    handler = _make_handler(emitted, device_class_lookup_cb=lookup)
+
+    with caplog.at_level(
+        logging.WARNING, logger="ramses_rf.pipeline.topology_handlers.hvac"
+    ):
+        # First batch of 3 non-FAN packets — triggers warning + first event
+        for msg in [
+            _FakeMsg("37:169161", "32:153289", Verb.RQ, Code._31DA),
+            _FakeMsg("37:169161", "32:153289", Verb.I_, Code._22F1),
+            _FakeMsg("37:169161", "32:153289", Verb.RQ, Code._2411),
+        ]:
+            handler.consume(msg)
+
+        warning_count_after_first = sum(
+            1 for r in caplog.records if r.levelno == logging.WARNING
+        )
+
+        # Second batch — should still emit events (idempotent SSOT update)
+        for msg in [
+            _FakeMsg("37:169161", "32:153289", Verb.RQ, Code._31DA),
+            _FakeMsg("37:169161", "32:153289", Verb.I_, Code._22F1),
+        ]:
+            handler.consume(msg)
+
+        warning_count_after_second = sum(
+            1 for r in caplog.records if r.levelno == logging.WARNING
+        )
+
+    # WARNING should only fire once (despite 5 total non-FAN packets)
+    assert warning_count_after_first == 1, (
+        f"Expected 1 WARNING after first batch, got {warning_count_after_first}"
+    )
+    assert warning_count_after_second == 1, (
+        f"WARNING should not repeat — expected 1, got {warning_count_after_second}"
+    )
+
+    # Events should continue to fire after the first warning
+    contradiction_events = [
+        e
+        for e in emitted
+        if e.causation == "Rule_HVAC_Contradiction_FAN_to_DIS"
+    ]
+    # 3 non-FAN packets in first batch (threshold=3, so event on packet 3)
+    # + 2 non-FAN packets in second batch (events on packets 4 and 5)
+    assert len(contradiction_events) >= 2, (
+        f"Events should continue to fire after first warning, "
+        f"got {len(contradiction_events)} total contradiction events"
+    )


### PR DESCRIPTION
## Summary

- Adds contradiction detection to `HvacTopologyHandler` that tracks per-device evidence (FAN vs non-FAN behaviour) and auto-reclassifies a device wrongly typed as FAN to DIS when the message patterns contradict the known_list class
- Wires up `_promote_device_class` (previously dead code) so the device object is actually swapped at runtime — not just the known_list config
- Adds a `device_class_lookup_cb` to the `TopologyHandler` base class, wired through `TopologyBuilder` → `Gateway`, so the handler can check the current device class (`msg.src.type` is only the address prefix, not the device class)

## Background

A device wrongly typed as FAN in the known_list would stay as FAN forever — the explicitly-defined class always takes precedence in the device factory (`devices/__init__.py:177`), bypassing auto-discovery. This caused `PacketInvalid` warnings and wrong entity creation (e.g. a DIS showing as a FAN with `fan_speed` sensors that never update).

The distinguishing behaviour between FAN and DIS/REM:

| Behaviour | FAN | DIS/REM |
|-----------|-----|---------|
| `I 31DA` (broadcast status) | Yes | No |
| `I 31D9` (broadcast fan rates) | Yes | No |
| `RP 31DA` (respond to status RQ) | Yes | No |
| `RQ 31DA` (ask for status) | No | Yes |
| `I 22F1` (send fan-mode commands) | No | Yes |

## How it works

1. The `HvacTopologyHandler` tracks per-device evidence counters: `fan` (for `I 31D9`, `I 31DA`, `RP 31DA` from src) and `non_fan` (for `RQ 31DA`, `I 22F1` from src)
2. After 3 non-FAN packets with zero FAN evidence, and the device's current class (looked up via callback) is `FAN`, a reclassification event is emitted with causation `Rule_HVAC_Contradiction_FAN_to_DIS`
3. `_handle_update_device_traits` updates the SSOT known_list, then (for contradiction events only) calls `_promote_device_class` to swap the device object from `HvacVentilator` to `HvacDisplayRemote`
4. A warning is logged: `Device X is typed as FAN but has only sent RQ 31DA (N packets) and never I/RP 31DA or I 31D9 — reclassifying as DIS`

Contradiction detection runs regardless of `enable_eavesdrop`, since it validates known_list accuracy rather than discovering unknown devices. Standard heuristic promotions remain gated by `enable_eavesdrop`.

## Other mismatched promotions

This is the first contradiction detection implementation in the codebase. The pattern (evidence tracking + threshold + reclassification) can be generalized to other device types if similar misclassification patterns are discovered. Currently:
- No other topology handlers have contradiction detection
- No general demotion logic exists (only promotion)
- The discovery scan engine (`discovery_scan.py`) is passive — it classifies but does not correct misclassifications
- `_promote_device_class` has no semantic validation (e.g. can promote 32: to DIS even though 32: is unambiguous FAN)

## Verified live

Tested with device 37:169161 (an Orcon RF15 Display that was wrongly typed as FAN in the known_list):
- After 3 `RQ 31DA`/`I 22F1` packets, the device was reclassified from FAN to DIS
- SSOT known_list updated: `class -> switch_display`
- Device object swapped: `HvacVentilator` → `HvacDisplayRemote`
- `PacketInvalid` warnings stopped

Refs: https://github.com/ramses-rf/ramses_cc/issues/1000

#### Test plan
- [x] All 2585 existing tests pass
- [x] mypy --strict clean on changed files
- [x] ruff check + ruff format pass
- [x] Verified live: 37:169161 reclassified from FAN to DIS at runtime
- [ ] (Optional) Add unit tests for the contradiction detection logic