### PR TITLE
fix: defer known_list check when MQTT bridge HGI ID is unknown

### DIFF
--- a/src/ramses_tx/protocol/base.py
+++ b/src/ramses_tx/protocol/base.py
@@ -556,13 +556,30 @@ class _DeviceIdFilterMixin(_BaseProtocol):
         return DeviceIdT(hgi or self._known_hgi or HGI_DEV_ADDR.id)
 
     def _set_active_hgi(
-        self, device_id: DeviceIdT, by_signature: bool = False
+        self, device_id: DeviceIdT | None, by_signature: bool = False
     ) -> None:
         """Set the Active Gateway (HGI) device_id.
 
         Send a warning if the include list is configured incorrectly.
+
+        If device_id is None (MQTT bridge where the HGI ID isn't known
+        yet — the ramses_esp hasn't sent its "online" LWT message), no
+        warning is emitted.  The transport will update SZ_ACTIVE_HGI
+        when the real ID arrives, and the hgi_id property reads it from
+        there.  See issue 1002.
         """
         assert self._active_hgi is None  # should only be called once
+
+        # MQTT bridges: HGI ID not known yet (ramses_esp hasn't sent
+        # its "online" LWT message).  Defer the check — the transport
+        # will update SZ_ACTIVE_HGI when the real ID arrives.
+        if device_id is None:
+            _LOGGER.debug(
+                "Active gateway ID not yet known (MQTT bridge?), "
+                "deferring known_list check until the device sends "
+                "its online message"
+            )
+            return
 
         msg = f"The active gateway '{device_id}: {{ class: HGI }}' "
         msg += "(by signature)" if by_signature else "(by filter)"
@@ -599,6 +616,15 @@ class _DeviceIdFilterMixin(_BaseProtocol):
         In any one packet, an excluded device_id 'trumps' an included
         device_id.
         """
+        # Deferred HGI check: if _set_active_hgi was called with None
+        # (MQTT bridge, HGI ID not known yet), check now whether the
+        # transport has learned the real HGI ID.  This runs the
+        # known_list check that was skipped during connection_made.
+        # See issue 1002.
+        if self._active_hgi is None and self._transport and not sending:
+            real_hgi = self._transport.get_extra_info(SZ_ACTIVE_HGI)
+            if real_hgi is not None:
+                self._set_active_hgi(real_hgi)
 
         def warn_foreign_hgi(device_id: DeviceIdT) -> None:
             current_date = dt.now().date()

--- a/tests/tests_tx/protocol/test_base.py
+++ b/tests/tests_tx/protocol/test_base.py
@@ -1,7 +1,7 @@
 """Tests for the RAMSES-II base protocol layer."""
 
 import logging
-from typing import Any
+from typing import Any, cast
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -229,6 +229,64 @@ async def test_is_wanted_addrs_hgi_dev_addr_still_blocked(
         protocol._is_wanted_addrs(DeviceIdT("01:216136"), HGI_DEV_ADDR.id)
         is False
     )
+
+
+async def test_set_active_hgi_none_no_warning(
+    protocol: DummyProtocol,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """_set_active_hgi(None) should not emit a warning (issue 1002).
+
+    MQTT bridges (ramses_esp) don't know the HGI ID at connection time
+    — the ID arrives later via the "online" LWT message.  Calling
+    _set_active_hgi(None) should silently defer, not warn about
+    'None: { class: HGI }' not being in the known_list.
+    """
+    with caplog.at_level(logging.WARNING):
+        protocol._set_active_hgi(None)
+    assert protocol._active_hgi is None  # not set
+    assert not any("None" in r.message for r in caplog.records)
+    assert not any("SHOULD be in" in r.message for r in caplog.records)
+
+
+async def test_set_active_hgi_none_then_deferred_check(
+    protocol: DummyProtocol,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Deferred HGI check fires when transport learns the real ID (issue 1002).
+
+    After _set_active_hgi(None), _is_wanted_addrs should detect the real
+    HGI ID from the transport's extra info and run the known_list check.
+    """
+    from ramses_tx.const import SZ_ACTIVE_HGI
+
+    # Simulate MQTT bridge: _set_active_hgi(None) at connection time
+    protocol._set_active_hgi(None)
+    assert protocol._active_hgi is None
+
+    # Simulate the transport learning the real HGI ID from the online msg
+    protocol._transport = MagicMock()
+    protocol._transport.get_extra_info = MagicMock(
+        side_effect=lambda key: (
+            DeviceIdT("18:130140") if key == SZ_ACTIVE_HGI else None
+        )
+    )
+    protocol._include = [DeviceIdT("01:111111")]
+    protocol.enforce_include = True
+
+    # First call to _is_wanted_addrs should trigger the deferred check
+    with caplog.at_level(logging.WARNING):
+        protocol._is_wanted_addrs(
+            DeviceIdT("01:111111"), DeviceIdT("01:222222")
+        )
+
+    # _active_hgi should now be set — mypy can't track the side effect
+    # through _is_wanted_addrs, so we cast to narrow the type
+    hgi = cast(DeviceIdT, protocol._active_hgi)
+    assert hgi == DeviceIdT("18:130140")
+    # And the warning about the HGI not being in known_list should fire
+    assert any("18:130140" in r.message for r in caplog.records)
+    assert any("SHOULD be in" in r.message for r in caplog.records)
 
 
 # --- INBOUND PACKET TESTS (_packet_received) ---


### PR DESCRIPTION
## Summary

- `_set_active_hgi(None)` now silently defers instead of warning about `'None: { class: HGI }'` not being in the known_list
- `_is_wanted_addrs` checks if the transport has learned the real HGI ID since the initial `None`, and runs the deferred known_list check on the first inbound packet
- MQTT bridges (ramses_esp) don't know the HGI device ID at connection time — the ID arrives later via the "online" LWT message or the first data packet on `/rx`

Fixes https://github.com/ramses-rf/ramses_cc/issues/1002

#### Test plan

- [x] All 2599 ramses_rf tests pass
- [x] `test_set_active_hgi_none_no_warning`: verifies no warning for `None`
- [x] `test_set_active_hgi_none_then_deferred_check`: verifies the deferred check fires when the transport learns the real HGI ID