### PR TITLE
feat: add REM→FAN directed packet inference for HVAC topology

### DIFF
--- a/src/ramses_rf/discovery_scan.py
+++ b/src/ramses_rf/discovery_scan.py
@@ -771,6 +771,34 @@ class DiscoveryScan:
                         code,
                         verb.strip(),
                     )
+                # REM→FAN inference (known device): a REM/CO2 sending a
+                # directed packet (W/RQ/I) to a FAN (32:) confirms
+                # binding.  More authoritative than FAN→REM — the REM
+                # only sends to the FAN it was 1FC9-paired with (not any
+                # FAN in range).  A directed I is proof because the REM
+                # addresses its paired FAN specifically; a broadcast I
+                # (dst = --:------) is filtered out by _is_valid_address.
+                elif (
+                    not is_hgi
+                    and not device.bound_to
+                    and is_source
+                    and destination
+                    and _is_valid_address(destination)
+                    and destination.startswith("32:")
+                    and verb in (Verb.W_, Verb.RQ, Verb.I_)
+                    and code in _HVAC_PARENT_INFERENCE_CODES
+                ):
+                    device.bound_to = destination
+                    device.confidence = "high"
+                    self._dirty = True
+                    _LOGGER.debug(
+                        "DiscoveryScan: HVAC bound_to %s -> %s (known device, "
+                        "REM→FAN, code=%s, verb=%s)",
+                        device_id,
+                        destination,
+                        code,
+                        verb.strip(),
+                    )
                 # DHW topology inference for known devices: directed interaction
                 # between a CTL (01:/23:) and a DHW sensor (07:) confirms binding.
                 elif (
@@ -945,6 +973,23 @@ class DiscoveryScan:
                 and code in _HVAC_PARENT_INFERENCE_CODES
             ):
                 device.bound_to = source
+            # REM→FAN inference (new device): a REM/CO2 sending a
+            # directed packet (W/RQ/I) to a FAN (32:) confirms binding.
+            # More authoritative than FAN→REM — the REM only sends to
+            # its 1FC9-paired FAN.  A directed I is proof (the REM
+            # addresses its paired FAN specifically); a broadcast I
+            # (dst = --:------) is filtered out by _is_valid_address.
+            elif (
+                not is_hgi
+                and is_source
+                and destination
+                and _is_valid_address(destination)
+                and destination.startswith("32:")
+                and verb in (Verb.W_, Verb.RQ, Verb.I_)
+                and code in _HVAC_PARENT_INFERENCE_CODES
+            ):
+                device.bound_to = destination
+                device.confidence = "high"
             # DHW topology inference: directed interaction between CTL and DHW sensor
             elif (
                 not is_hgi
@@ -1059,6 +1104,33 @@ class DiscoveryScan:
         ):
             device.bound_to = source
             changed = True
+        # REM→FAN inference (existing device): a REM/CO2 sending a
+        # directed packet (W/RQ/I) to a FAN (32:) confirms binding.
+        # More authoritative than FAN→REM — the REM only sends to
+        # its 1FC9-paired FAN.  A directed I is proof (the REM
+        # addresses its paired FAN specifically); a broadcast I
+        # (dst = --:------) is filtered out by _is_valid_address.
+        elif (
+            not is_hgi
+            and not device.bound_to
+            and is_source
+            and destination
+            and _is_valid_address(destination)
+            and destination.startswith("32:")
+            and verb in (Verb.W_, Verb.RQ, Verb.I_)
+            and code in _HVAC_PARENT_INFERENCE_CODES
+        ):
+            device.bound_to = destination
+            device.confidence = "high"
+            changed = True
+            _LOGGER.debug(
+                "DiscoveryScan: HVAC bound_to %s -> %s (REM→FAN, "
+                "code=%s, verb=%s)",
+                device_id,
+                destination,
+                code,
+                verb.strip(),
+            )
         # DHW topology inference for existing devices
         elif (
             not is_hgi

--- a/tests/tests_rf/test_discovery_scan.py
+++ b/tests/tests_rf/test_discovery_scan.py
@@ -1774,10 +1774,18 @@ CO2_37 = "37:126776"  # CO2 sensor that also sends 31E0
 class TestHvacParentInference:
     """Tests for inferring bound_to from HVAC operational traffic.
 
-    A REM sending 22F1 to a FAN is NOT proof of binding — the REM could
-    be a neighbour's remote broadcasting.  The real proof is when the
-    FAN **answers** the REM (RP from 32: to the REM).  This confirms
-    the FAN acknowledges the REM as a paired remote.
+    Two inference directions:
+
+    1. **FAN→REM**: a FAN (32:) sending a directed I/RP to a REM/CO2
+       confirms binding — the FAN is the controller communicating with
+       its paired remote.
+
+    2. **REM→FAN**: a REM/CO2 sending a directed packet (W/RQ/I) to a
+       FAN (32:) confirms binding.  This is more authoritative than
+       FAN→REM — the REM only sends to the FAN it was 1FC9-paired with
+       (not any FAN in range).  A directed I is proof (the REM addresses
+       its paired FAN specifically); a broadcast I (dst = --:------)
+       is NOT proof (the REM could be a neighbour's remote broadcasting).
 
     See schema_architecture.md: "How HVAC topology COULD be derived
     from traffic".
@@ -1785,11 +1793,14 @@ class TestHvacParentInference:
 
     async def test_fan_reply_infers_parent(self) -> None:
         """A FAN (32:) replying RP to a REM should set bound_to on the
-        REM."""
+        REM.  The REM's RQ to the FAN also sets bound_to (REM→FAN
+        inference) — a directed RQ is proof of binding because the REM
+        only queries its 1FC9-paired FAN."""
         scan = DiscoveryScan(gateway=make_mock_gateway())
         scan.start()
         try:
-            # REM sends RQ to FAN
+            # REM sends RQ to FAN — REM→FAN inference fires immediately
+            # (RQ is a directed query, not a broadcast)
             dto1 = make_dto(
                 src=REM_29,
                 dst=FAN_ID,
@@ -1800,9 +1811,10 @@ class TestHvacParentInference:
             scan._process_packet(dto1)
             dev = scan.get_device(REM_29)
             assert dev is not None
-            assert dev.bound_to is None  # not yet confirmed
+            assert dev.bound_to == FAN_ID  # REM→FAN inference
 
-            # FAN replies RP to REM — this confirms binding
+            # FAN replies RP to REM — FAN→REM inference would also set
+            # bound_to (but it's already set from the RQ above)
             dto2 = make_dto(
                 src=FAN_ID,
                 dst=REM_29,
@@ -1817,9 +1829,31 @@ class TestHvacParentInference:
         finally:
             scan.stop()
 
-    async def test_rem_sending_to_fan_does_not_infer(self) -> None:
-        """A REM sending I|22F1 to a FAN should NOT set bound_to — the
-        FAN hasn't confirmed the binding."""
+    async def test_rem_broadcast_to_fan_does_not_infer(self) -> None:
+        """A REM sending broadcast I|22F1 (dst = --:------) should NOT
+        set bound_to — a broadcast is not proof of binding (the REM
+        could be a neighbour's remote broadcasting)."""
+        scan = DiscoveryScan(gateway=make_mock_gateway())
+        scan.start()
+        try:
+            dto = make_dto(
+                src=REM_29,
+                dst="--:------",
+                code=Code._22F1,
+                verb=Verb.I_,
+                payload="000404",
+            )
+            scan._process_packet(dto)
+            dev = scan.get_device(REM_29)
+            assert dev is not None
+            assert dev.bound_to is None  # NOT confirmed (broadcast I)
+        finally:
+            scan.stop()
+
+    async def test_rem_directed_i_to_fan_infers_parent(self) -> None:
+        """A REM sending directed I|22F1 to a FAN (dst = 32:...) should
+        set bound_to — a directed I is proof because the REM addresses
+        its 1FC9-paired FAN specifically (not a broadcast)."""
         scan = DiscoveryScan(gateway=make_mock_gateway())
         scan.start()
         try:
@@ -1833,7 +1867,51 @@ class TestHvacParentInference:
             scan._process_packet(dto)
             dev = scan.get_device(REM_29)
             assert dev is not None
-            assert dev.bound_to is None  # NOT confirmed
+            assert dev.bound_to == FAN_ID  # directed I = proof
+            assert dev.confidence == "high"
+        finally:
+            scan.stop()
+
+    async def test_rem_w_to_fan_infers_parent(self) -> None:
+        """A REM sending W|22F1 to a FAN should set bound_to — a
+        directed W is proof of binding because the REM only sends
+        commands to its 1FC9-paired FAN."""
+        scan = DiscoveryScan(gateway=make_mock_gateway())
+        scan.start()
+        try:
+            dto = make_dto(
+                src=REM_29,
+                dst=FAN_ID,
+                code=Code._22F1,
+                verb=Verb.W_,
+                payload="000404",
+            )
+            scan._process_packet(dto)
+            dev = scan.get_device(REM_29)
+            assert dev is not None
+            assert dev.bound_to == FAN_ID  # REM→FAN inference (directed W)
+            assert dev.confidence == "high"
+        finally:
+            scan.stop()
+
+    async def test_rem_rq_to_fan_infers_parent(self) -> None:
+        """A REM sending RQ|2411 to a FAN should set bound_to — a
+        directed RQ is proof of binding (same as W)."""
+        scan = DiscoveryScan(gateway=make_mock_gateway())
+        scan.start()
+        try:
+            dto = make_dto(
+                src=REM_29,
+                dst=FAN_ID,
+                code=Code._2411,
+                verb=Verb.RQ,
+                payload="00",
+            )
+            scan._process_packet(dto)
+            dev = scan.get_device(REM_29)
+            assert dev is not None
+            assert dev.bound_to == FAN_ID  # REM→FAN inference (directed RQ)
+            assert dev.confidence == "high"
         finally:
             scan.stop()
 


### PR DESCRIPTION
## Summary

- Adds REM→FAN `bound_to` detection in `discovery_scan.py` — when a REM/CO2 sends a **directed** packet (W/RQ/I) to a FAN (32:), the scan engine sets `bound_to` on the REM/CO2, confirming the HVAC parent binding
- This is the reverse direction of the existing FAN→REM inference (FAN sending I/RP to REM)
- More authoritative than FAN→REM: after 1FC9 pairing, the REM only sends to its paired FAN (not any FAN in range)
- A **directed** I is proof (the REM addresses its paired FAN specifically); a **broadcast** I (dst = `--:------`) is filtered out by `_is_valid_address` and does not trigger inference

## Background

See `phase4_plan.md` Step 6e — "REM→FAN (remote→controller, future enhancement)":

> When a REM (37:) sends a directed W or RQ packet to a FAN (32:) — e.g. the user presses "low speed" and the REM sends `W 22F1` to its bound FAN — the dst FAN is the parent. This is **more authoritative** than FAN→REM because the REM only sends to the FAN it was 1FC9-paired with (not any FAN in range).

This PR also extends the detection to directed `I` packets (not just W/RQ), because after 1FC9 pairing a REM sending a directed I to its FAN is equally proof of binding — the REM addresses its paired FAN specifically. Only broadcast I is excluded.

## What changed

3 locations in `discovery_scan.py` (mirroring the existing FAN→REM detection):
1. **Known device path** (line ~667): REM→FAN check added as `elif` after FAN→REM
2. **New device path** (line ~794): REM→FAN check added as `elif` after FAN→REM
3. **Existing device path** (line ~925): REM→FAN check added as `elif` after FAN→REM

All 3 use the same condition:
```python
is_source                          # this device is the sender (REM)
and destination.startswith("32:")  # dst is a FAN
and verb in (W_, RQ, I_)           # directed packet (broadcast filtered by _is_valid_address)
and code in _HVAC_PARENT_INFERENCE_CODES  # HVAC operational code
```

REM→FAN inference sets `confidence = "high"` (same as DHW inference), because the REM's directed packet is authoritative — it knows its FAN from the 1FC9 hardware handshake.

## Tests

- `test_rem_w_to_fan_infers_parent`: W|22F1 → `bound_to` set, high confidence
- `test_rem_rq_to_fan_infers_parent`: RQ|2411 → `bound_to` set, high confidence
- `test_rem_directed_i_to_fan_infers_parent`: directed I|22F1 → `bound_to` set
- `test_rem_broadcast_to_fan_does_not_infer`: broadcast I (dst=`--:------`) → no `bound_to`
- `test_fan_reply_infers_parent`: updated — RQ from REM now triggers REM→FAN immediately (was: expected `bound_to is None` after RQ)
- Class docstring updated to document both inference directions

All 2588 ramses_rf tests pass (3 skipped). ha_sim_test R01/R11/R62 pass (15/16, 1 pre-existing failure on R02 unrelated to this change).

#### Test plan

- [x] All 2588 ramses_rf tests pass
- [x] 4 new unit tests for REM→FAN inference
- [x] ha_sim_test R01, R11, R62 pass (15/16, 1 pre-existing R02 failure)
- [ ] R65 (HVAC belongs-to) — pre-existing failure on clean master, depends on PR 1089/1004 (contradiction detection) which are not merged yet