### PR TITLE
fix: BDR/JIM/JST relays go unavailable after 1 hour (issue 1010)

### DIFF
--- a/src/ramses_rf/const.py
+++ b/src/ramses_rf/const.py
@@ -325,6 +325,9 @@ WB_STATUS_CODES: Final[dict[str, str]] = {
 
 # Device Availability Timeouts
 HEARTBEAT_TIMEOUT_DEFAULT = td(hours=1)
+HEARTBEAT_TIMEOUT_BDR = td(
+    hours=24
+)  # BDR91: mains relay, only transmits 3EF0 on state change
 HEARTBEAT_TIMEOUT_DHW = td(
     hours=24
 )  # CS92A: battery DHW sensor, polled every 24h by CTL

--- a/src/ramses_rf/devices/heat_actuators.py
+++ b/src/ramses_rf/devices/heat_actuators.py
@@ -2,10 +2,12 @@
 
 from __future__ import annotations
 
+from datetime import timedelta as td
 from typing import Any, Final
 
 from ramses_rf.const import (
     DOMAIN_TYPE_MAP,
+    HEARTBEAT_TIMEOUT_BDR,
     SZ_HEAT_DEMAND,
     SZ_RELAY_DEMAND,
     DevType,
@@ -158,6 +160,17 @@ class BdrSwitch(Actuator, RelayDemand):  # BDR (13):
     _SLUG = DevType.BDR
     _STATE_ATTR = "active"
 
+    @property
+    def heartbeat_timeout(self) -> td:
+        """Return the timeout before the device is considered unavailable.
+
+        BDR91s are mains-powered relays that only transmit 3EF0 on state
+        changes (on/off).  When in a steady state they can go many hours
+        without sending any RF traffic, so the default 1-hour timeout is
+        far too short — use 24 hours (issue 1010).
+        """
+        return HEARTBEAT_TIMEOUT_BDR
+
     def __init__(
         self, *args: Any, traits: DeviceTraits | None = None, **kwargs: Any
     ) -> None:
@@ -231,6 +244,16 @@ class JimDevice(Actuator):  # BDR (08):
     _SLUG: str = DevType.JIM
     _STATE_ATTR: str | None = None
 
+    @property
+    def heartbeat_timeout(self) -> td:
+        """Return the timeout before the device is considered unavailable.
+
+        JIM actuators are relay-type devices that, like BDR91s, only
+        transmit on state changes and can go many hours without RF
+        traffic (issue 1010).
+        """
+        return HEARTBEAT_TIMEOUT_BDR
+
     def __init__(
         self, *args: Any, traits: DeviceTraits | None = None, **kwargs: Any
     ) -> None:
@@ -243,6 +266,16 @@ class JstDevice(RelayDemand):  # BDR (31):
 
     _SLUG: str = DevType.JST
     _STATE_ATTR: str | None = None
+
+    @property
+    def heartbeat_timeout(self) -> td:
+        """Return the timeout before the device is considered unavailable.
+
+        JST relays are relay-type devices that, like BDR91s, only
+        transmit on state changes and can go many hours without RF
+        traffic (issue 1010).
+        """
+        return HEARTBEAT_TIMEOUT_BDR
 
     def __init__(
         self, *args: Any, traits: DeviceTraits | None = None, **kwargs: Any


### PR DESCRIPTION
see https://github.com/ramses-rf/ramses_cc/issues/1010

## Summary

BDR91s (and similar relay-type actuators: JIM `08:`, JST `31:`) are mains-powered relays that only transmit `3EF0` on state changes (on/off). When in a steady state they can go many hours without sending any RF traffic — the logs in https://github.com/ramses-rf/ramses_cc/issues/1010 show gaps of 4–6 hours between messages.

The default `heartbeat_timeout` of 1 hour is far too short for these devices. After 1 hour without a transmission, `is_available` returns `False` and the entity goes unavailable in HA, even though the relay is working normally.

This PR adds `HEARTBEAT_TIMEOUT_BDR` (24h) to `const.py` and overrides `heartbeat_timeout` in `BdrSwitch`, `JimDevice`, and `JstDevice` to use it.

This follows the same pattern used for DHW sensors (issue 925), OTB gateways, HVAC remotes, and other devices that transmit infrequently.

### Log analysis

From the issue's logs, all `3EF0` payloads from the three BDRs are `0000FF` (off) — no value jumps or anomalies. The problem is purely the heartbeat timeout:

- `13:101694` (DHW BDR): 6h 23min gap (00:57 → 07:20)
- `13:062068` (upstairs BDR): 4h 12min gap (03:28 → 07:40)
- `13:213343` (downstairs BDR): only hourly RQ polls from CTL, almost no I broadcasts

#### Test plan

- [x] `ruff check` + `ruff format` pass
- [x] All 2602 ramses_rf tests pass (3 skipped)
- [ ] ha_sim_test regression (if needed)