### PR TITLE
fix: eavesdropping fails to discover TRV as zone sensor (issue 1010)

### DIFF
--- a/src/ramses_rf/eavesdropper.py
+++ b/src/ramses_rf/eavesdropper.py
@@ -612,10 +612,19 @@ class EavesdropEngine:
                 None,
             ):
                 d_temp = await device.temperature()
-                if d_temp is not None:
-                    if d_temp not in testable_sensors_map:
-                        testable_sensors_map[d_temp] = []
-                    testable_sensors_map[d_temp].append(device)
+                if d_temp is None:
+                    continue
+                # Only consider devices that broadcast 30C9 after the
+                # previous controller array — this ensures temporal
+                # correlation within the same polling cycle (issue 1010).
+                d_msgs = await device.entity_state.get_message_log_flat()
+                if Code._30C9 not in d_msgs:
+                    continue
+                if d_msgs[Code._30C9].dtm <= prev.dtm:
+                    continue
+                if d_temp not in testable_sensors_map:
+                    testable_sensors_map[d_temp] = []
+                testable_sensors_map[d_temp].append(device)
 
         unique_sensors: dict[float, Device] = {}
         for temp_val, candidate_devices in testable_sensors_map.items():
@@ -678,12 +687,19 @@ class EavesdropEngine:
     async def _eavesdrop_from_trv_broadcast(
         self, tcs: Any, msg: Message
     ) -> None:
-        """Correlate a new TRV temperature broadcast against known zones."""
+        """Correlate a new TRV temperature broadcast against known zones.
+
+        A TRV can be both an actuator and the designated zone sensor —
+        Evohome lets the user pick which TRV senses temperature for the
+        zone.  Therefore we must NOT skip TRVs that already have a parent
+        zone (issue 1010).
+        """
         if not isinstance(msg.payload, dict):
             return
 
+        # Skip devices that are already a sensor for another zone.
         device = self._gateway.device_registry.device_by_id.get(msg.src.id)
-        if device is not None and getattr(device, "_parent", None) is not None:
+        if device is not None and getattr(device, "_is_sensor", False):
             return
 
         trv_temp = msg.payload.get(SZ_TEMPERATURE)
@@ -697,6 +713,7 @@ class EavesdropEngine:
                 if zone_temp == trv_temp:
                     matching_zones.append(zone)
 
+        # COLLISION ABSTENTION: Bind only if exactly one zone matches
         if len(matching_zones) == 1:
             with contextlib.suppress(
                 exc.DeviceNotFoundError,

--- a/tests/tests_rf/data_driven/eavesdrop_schema/zone_sensors_003/schema_eavesdrop_on.json
+++ b/tests/tests_rf/data_driven/eavesdrop_schema/zone_sensors_003/schema_eavesdrop_on.json
@@ -44,6 +44,7 @@
             },
             "05": {
                 "class": "radiator_valve",
+                "sensor": "04:230315",
                 "actuators": [
                     "04:230315"
                 ]

--- a/tests/tests_rf/data_driven/eavesdrop_schema/zone_sensors_multi_trv_sensor/packet.log
+++ b/tests/tests_rf/data_driven/eavesdrop_schema/zone_sensors_multi_trv_sensor/packet.log
@@ -1,0 +1,34 @@
+# test: eavesdropping discovers the correct sensor TRV in a multi-TRV zone (issue 984)
+#
+# Zone 00 has two TRVs: 04:200001 (21.0C) and 04:200002 (19.5C)
+# The controller broadcasts 30C9 array showing zone 00 = 21.0C
+# Eavesdropping should bind 04:200001 as the zone sensor, not 04:200002
+#
+# This is the scenario from issue 984: a multi-TRV zone where one of the
+# TRVs is the designated sensor (not the CTL).
+
+# 000C: bind TRVs as actuators to zone 00 (6-byte format with sub_index 00)
+2022-07-08T05:00:00.000000 055 RP --- 01:200001 18:009048 --:------ 000C 012 000800130D41000800130D42
+
+# TRV temperature broadcasts (30C9, 2-byte format: just temperature)
+2022-07-08T05:10:00.000000 055  I --- 04:200001 --:------ 04:200001 30C9 002 0834  # 21.0C
+2022-07-08T05:10:01.000000 055  I --- 04:200002 --:------ 04:200002 30C9 002 07AE  # 19.5C
+
+# Controller broadcasts zone array (30C9, 3-byte per zone) — first array, prev=None
+2022-07-08T05:15:00.000000 067  I --- 01:200001 --:------ 01:200001 1F09 003 FF06EF
+2022-07-08T05:15:00.100000 067  I --- 01:200001 --:------ 01:200001 30C9 003 000834  # zone 00 = 21.0C
+
+# Second cycle — zone 00 temp unchanged (no eavesdrop trigger)
+2022-07-08T05:20:00.000000 067  I --- 01:200001 --:------ 01:200001 1F09 003 FF06EF
+2022-07-08T05:20:00.100000 067  I --- 01:200001 --:------ 01:200001 30C9 003 000834  # zone 00 = 21.0C (same)
+
+# TRV re-broadcasts within the second cycle (after prev.dtm at 05:15)
+2022-07-08T05:20:01.000000 055  I --- 04:200001 --:------ 04:200001 30C9 002 0834  # 21.0C
+2022-07-08T05:20:02.000000 055  I --- 04:200002 --:------ 04:200002 30C9 002 07AE  # 19.5C
+
+# Third cycle — zone 00 temp changes to 21.5C (triggers eavesdrop)
+2022-07-08T05:25:00.000000 067  I --- 01:200001 --:------ 01:200001 1F09 003 FF06EF
+2022-07-08T05:25:00.100000 067  I --- 01:200001 --:------ 01:200001 30C9 003 000866  # zone 00 = 21.5C
+
+# TRV 04:200001 broadcasts 21.5C (matching the changed zone temp, after prev.dtm at 05:20)
+2022-07-08T05:25:01.000000 055  I --- 04:200001 --:------ 04:200001 30C9 002 0866  # 21.5C

--- a/tests/tests_rf/data_driven/eavesdrop_schema/zone_sensors_multi_trv_sensor/schema_eavesdrop_off.json
+++ b/tests/tests_rf/data_driven/eavesdrop_schema/zone_sensors_multi_trv_sensor/schema_eavesdrop_off.json
@@ -1,0 +1,24 @@
+{
+    "main_tcs": "01:200001",
+    "01:200001": {
+        "system": {
+            "appliance_control": null
+        },
+        "orphans": [],
+        "stored_hotwater": {},
+        "underfloor_heating": {},
+        "zones": {
+            "00": {
+                "_name": null,
+                "class": "radiator_valve",
+                "sensor": null,
+                "actuators": [
+                    "04:200001",
+                    "04:200002"
+                ]
+            }
+        }
+    },
+    "orphans_heat": [],
+    "orphans_hvac": []
+}

--- a/tests/tests_rf/data_driven/eavesdrop_schema/zone_sensors_multi_trv_sensor/schema_eavesdrop_on.json
+++ b/tests/tests_rf/data_driven/eavesdrop_schema/zone_sensors_multi_trv_sensor/schema_eavesdrop_on.json
@@ -1,0 +1,24 @@
+{
+    "main_tcs": "01:200001",
+    "01:200001": {
+        "system": {
+            "appliance_control": null
+        },
+        "orphans": [],
+        "stored_hotwater": {},
+        "underfloor_heating": {},
+        "zones": {
+            "00": {
+                "_name": null,
+                "class": "radiator_valve",
+                "sensor": "04:200001",
+                "actuators": [
+                    "04:200001",
+                    "04:200002"
+                ]
+            }
+        }
+    },
+    "orphans_heat": [],
+    "orphans_hvac": []
+}


### PR DESCRIPTION
## Summary

Two regressions in the eavesdropping engine prevented it from correctly identifying which TRV is the designated zone sensor in multi-TRV zones. This was reported in https://github.com/ramses-rf/ramses_cc/issues/984#issuecomment-5356693367 — the old `working_schema` correctly identified the representative TRV, but the new discovery logic did not.

### Root causes

**1. `_eavesdrop_from_trv_broadcast` skipped TRVs already bound as actuators**

The refactored code added a check that skipped any TRV with a `_parent` (i.e. already bound as an actuator to a zone). But a TRV can be **both** an actuator and the zone sensor — Evohome lets the user pick which TRV senses temperature for the zone. This check was not present in the pre-refactor code.

**Fix:** Skip only devices that are already a sensor for another zone (check `_is_sensor`, not `_parent`).

**2. `_eavesdrop_from_controller_broadcast` lost the temporal filter**

The refactored code considered every device with any temperature, ignoring when that temperature was last broadcast. The pre-refactor code only considered devices that had broadcast 30C9 **after** the previous controller array — ensuring temporal correlation within the same polling cycle. Without this filter, stale temperatures can produce false matches or miss the correct sensor.

**Fix:** Restore the temporal filter — only consider devices whose most recent 30C9 was broadcast after `prev.dtm`.

### Test evidence

The existing test data (`zone_sensors_003`) already had this bug: zone 05 had a single TRV (`04:230315`) that broadcast 30C9 but was never discovered as the zone sensor. Every other single-TRV zone in the same test correctly had its TRV as both actuator and sensor — zone 05 was the only one missed because its TRV broadcast was processed after it was already bound as an actuator.

The expected schema has been updated to reflect the correct behaviour (zone 05 now has `sensor: 04:230315`).

#### Test plan

- [x] `ruff check` + `ruff format` pass
- [x] All 2602 ramses_rf tests pass (3 skipped)
- [x] All 14 eavesdrop schema tests pass
- [x] All 4 multi-TRV issue 976 tests pass
- [x] `zone_sensors_003` test now correctly expects zone 05 sensor = `04:230315`