### PR TITLE
fix: exclude gateway interfaces from polling

### DIFF
--- a/src/ramses_rf/pipeline/polling.py
+++ b/src/ramses_rf/pipeline/polling.py
@@ -195,11 +195,14 @@ class PollingManager:
         :returns: A dictionary mapping active command codes to interval seconds.
         :rtype: PollingIntervalsT
         """
+        slug = getattr(device, "_SLUG", "DEFAULT")
+        if slug == DevType.HGI:
+            return {}
+
         # Battery devices sleep and cannot receive RF requests; never poll them
         if device.is_battery:
             return {}
 
-        slug = getattr(device, "_SLUG", "DEFAULT")
         fallback_schedule = DEFAULT_POLLING_SCHEDULES.get(
             slug, DEFAULT_POLLING_SCHEDULES["DEFAULT"]
         )

--- a/tests/tests_rf/test_polling_manager.py
+++ b/tests/tests_rf/test_polling_manager.py
@@ -7,7 +7,7 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 
 from ramses_rf.config import GatewayConfig
-from ramses_rf.const import Code, Verb
+from ramses_rf.const import Code, DevType, Verb
 from ramses_rf.devices.dev_base import BatteryState, DeviceBase
 from ramses_rf.exceptions import RamsesException
 from ramses_rf.gateway import Gateway
@@ -111,6 +111,23 @@ def test_polling_manager_custom_trait_override(
     assert schedule[Code._1F41] == 1800
     assert schedule[Code._10E0] == 43200
     assert schedule[Code._313F] == DEFAULT_POLLING_SCHEDULES["CTL"][Code._313F]
+
+
+@pytest.mark.parametrize("device_id", ["18:130140", "18:072981"])
+def test_polling_manager_hgi_device_zero_polling(
+    mock_gateway: MagicMock, device_id: str
+) -> None:
+    hgi = MockDevice(
+        mock_gateway,
+        device_id,
+        slug=DevType.HGI,
+        traits=DeviceTraits(polling_interval={Code._10E0: 60}),
+    )
+    poller = PollingManager(mock_gateway, shadow_mode=False)
+
+    assert poller.resolve_schedule_for_device(hgi) == {}
+    assert poller.update_device_tasks(hgi) == set()
+    assert poller.get_scheduled_cmds() == []
 
 
 def test_polling_manager_battery_device_zero_polling(


### PR DESCRIPTION
## Summary

- return an empty polling schedule for all HGI devices, including the active local gateway and foreign gateways
- prevent explicit polling traits from overriding that invariant
- add regression coverage for local and foreign `18:` device IDs

## Findings

The polling manager had no `DevType.HGI` schedule, so HGI devices fell back to the default daily `10E0` poll. This explains why https://github.com/ramses-rf/ramses_cc/issues/1019 appeared after approximately 24 hours.

For an active HGI such as `18:130140`, `build_rq_cmd()` initially produced a request from the `18:000730` placeholder to `18:130140`. The protocol then patched the placeholder source to the active HGI before queueing, producing the invalid address set:

```text
18:130140 18:130140 --:------
```

Accessing `CommandDTO.tx_header` then raised `PacketInvalid` from the FSM callback. HGI devices are gateway interfaces rather than RF poll targets, so the fix prevents polling tasks from being created for any HGI instead of handling the malformed command later in the protocol.

## Test plan

- [x] Polling manager/API tests — 32 passed
- [x] Full test suite — 2606 passed, 3 skipped; 99 snapshots passed
- [x] Strict mypy on changed files
- [x] `prek run -a`

Repository-wide `mypy --strict .` still reports three pre-existing errors in unrelated files: `transport/file.py`, `payloads/helpers.py`, and `test_payload_dataclasses.py`.