### PR TITLE
fix: suppress Foreign gateway warning for known HGIs (issue 1020)

### DIFF
--- a/src/ramses_tx/protocol/base.py
+++ b/src/ramses_tx/protocol/base.py
@@ -659,6 +659,12 @@ class _DeviceIdFilterMixin(_BaseProtocol):
             if dev_id[:2] == "18" and dev_id != HGI_DEV_ADDR.id:
                 if dev_id == self._active_hgi:
                     continue
+                # A known/configured HGI (e.g. a second gateway declared
+                # in the known_list, which the discovery_scan config schema
+                # permits) is not a Foreign gateway — suppress the noise
+                # warning for it (issue 1020).
+                if dev_id in self._include:
+                    continue
                 if self._active_hgi:
                     warn_foreign_hgi(dev_id)
                 continue

--- a/tests/tests_tx/protocol/test_base.py
+++ b/tests/tests_tx/protocol/test_base.py
@@ -215,6 +215,52 @@ async def test_is_wanted_addrs_foreign_hgi_not_blocked(
     )
 
 
+async def test_is_wanted_addrs_known_hgi_no_foreign_warning(
+    protocol: DummyProtocol,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A known/configured HGI must not be flagged as a Foreign gateway.
+
+    The discovery_scan config schema permits multiple HGIs to be declared
+    in the known_list.  A second HGI that is in the known_list is not
+    foreign — it is a declared gateway — so the 'potentially a Foreign
+    gateway' warning must be suppressed for it (issue 1020).
+    """
+    protocol._active_hgi = DeviceIdT("18:130140")
+    protocol._include = [DeviceIdT("18:154951")]  # second, known HGI
+
+    with caplog.at_level(logging.WARNING):
+        result = protocol._is_wanted_addrs(
+            DeviceIdT("18:154951"), DeviceIdT("01:216136")
+        )
+
+    # Known HGIs are never blocked (foreign-HGI exemption still applies)
+    assert result is True
+    # And no Foreign gateway warning should be emitted for a known HGI
+    assert not any("Foreign gateway" in r.message for r in caplog.records)
+
+
+async def test_is_wanted_addrs_unknown_hgi_still_warns(
+    protocol: DummyProtocol,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """An unknown HGI (not in the known_list) still triggers the warning.
+
+    Only HGIs declared in the known_list are suppressed (issue 1020); a
+    genuinely unknown 18: device should still produce the Foreign gateway
+    warning so the user can decide whether to configure it.
+    """
+    protocol._active_hgi = DeviceIdT("18:130140")
+    protocol._include = []  # 18:154951 is not known
+
+    with caplog.at_level(logging.WARNING):
+        protocol._is_wanted_addrs(
+            DeviceIdT("18:154951"), DeviceIdT("01:216136")
+        )
+
+    assert any("Foreign gateway" in r.message for r in caplog.records)
+
+
 async def test_is_wanted_addrs_hgi_dev_addr_still_blocked(
     protocol: DummyProtocol,
 ) -> None:


### PR DESCRIPTION
## Summary
- Suppress the "potentially a Foreign gateway" warning in `_is_wanted_addrs` when the `18:` device is declared in the known_list (`_include`).
- The discovery_scan config schema permits multiple HGIs to be declared, so a second configured HGI is not foreign — it is a declared gateway.
- The foreign-HGI exemption (never block `18:` traffic) is preserved; only the warning is suppressed for known HGIs. Genuinely unknown `18:` devices still warn so the user can decide whether to configure them.

Refs: ramses-rf/ramses_cc#1020

#### Test plan
- [x] `test_is_wanted_addrs_known_hgi_no_foreign_warning` — a known HGI produces no warning and is not blocked
- [x] `test_is_wanted_addrs_unknown_hgi_still_warns` — an unknown HGI still warns
- [x] `ruff check`, `ruff format`, `mypy --strict`, pre-commit hooks all pass
- [x] Full `tests/tests_tx/protocol/test_base.py` suite (24 tests) passes