### PR TITLE
fix: restore per-zone `2349` zone mode polling

### DIFF
--- a/src/ramses_rf/pipeline/polling.py
+++ b/src/ramses_rf/pipeline/polling.py
@@ -33,6 +33,7 @@ INTERVAL_HOURLY: Final[int] = 3600  # 1 hour in seconds
 INTERVAL_EVERY_6_HOURS: Final[int] = 21600  # 6 hours in seconds
 INTERVAL_EVERY_12_HOURS: Final[int] = 43200  # 12 hours in seconds
 INTERVAL_DAILY: Final[int] = 86400  # 24 hours in seconds
+INTERVAL_ZONE_TEMP: Final[int] = 900  # 15 minutes — zone temperature polling
 
 # Master default polling schedules table for all device classes.
 # Battery-powered devices (TRV, THM, DHW, REM, HUM) set intervals to None
@@ -50,6 +51,13 @@ DEFAULT_POLLING_SCHEDULES: Final[dict[str, dict[Code | str, int | None]]] = {
         # zone_index).  Issue 947: zone names lost after cache clear because
         # the CTL does not broadcast 0004 unless queried.
         Code._0004: INTERVAL_EVERY_6_HOURS,  # Zone Name (per-zone, expanded below)
+        # 30C9 (zone temperature) is polled per-zone for zones that have no
+        # dedicated sensor — see update_device_tasks for the zone-level
+        # expansion and sensor filter.  Issue 1013: multi-room zones without
+        # a sensor are absent from the CTL's 30C9 broadcast array, so the
+        # eavesdropper cannot learn a representative TRV sensor without
+        # active polling to supply zone.temperature().
+        Code._30C9: INTERVAL_ZONE_TEMP,  # Zone Temperature (per-zone, filtered)
     },
     # Boiler Relay / Switch
     DevType.BDR: {
@@ -229,6 +237,17 @@ class PollingManager:
         zone-name polling that was lost when the legacy DiscoveryService
         was removed (issue 947 / ramses-rf/ramses_cc#947).
 
+        For CTL devices with zones, the ``30C9`` (zone temperature) code is
+        expanded into one task per zone **that has no dedicated sensor**,
+        keyed by ``(device_id, "30C9", zone_index)``.  This restores the
+        per-zone temperature polling that was lost when the legacy
+        DiscoveryService was removed (issue 1013).  Multi-room zones
+        without a sensor are absent from the CTL's 30C9 broadcast array,
+        so the eavesdropper cannot learn a representative TRV sensor
+        without active polling to supply ``zone.temperature()``.  Once a
+        sensor is learned, the task is pruned on the next refresh — the
+        CTL's broadcast array covers that zone again.
+
         For OTB devices, the ``3220`` (OpenTherm Data ID) code is
         expanded into individual tasks per Data ID, keyed by
         ``(device_id, "3220", data_id_hex)``.  This queries status
@@ -244,14 +263,31 @@ class PollingManager:
         now = dt.now(UTC)
         active_keys: set[tuple[str, ...]] = set()
 
-        # Collect zone indices for per-zone code expansion (0004).
+        # Collect zone indices for per-zone code expansion (0004, 30C9).
         # CTL devices have a .tcs attribute with .zones list.
+        tcs = getattr(device, "tcs", None)
         zone_indexs: list[str] = []
-        if Code._0004 in schedule:
-            tcs = getattr(device, "tcs", None)
-            if tcs is not None:
-                zones = getattr(tcs, "zones", [])
-                zone_indexs = [z.index for z in zones if hasattr(z, "index")]
+        if (
+            Code._0004 in schedule or Code._30C9 in schedule
+        ) and tcs is not None:
+            zones = getattr(tcs, "zones", [])
+            zone_indexs = [z.index for z in zones if hasattr(z, "index")]
+
+        # For 30C9, only poll zones that have no dedicated sensor — zones
+        # with a sensor receive their temperature via the CTL's 30C9
+        # broadcast array.  Multi-room zones (no sensor) are absent from
+        # that array, so we must poll to enable eavesdropper sensor learning.
+        zone_indexs_no_sensor: list[str] = []
+        if Code._30C9 in schedule and tcs is not None:
+            zone_by_index = getattr(tcs, "zone_by_index", {})
+            for zi in zone_indexs:
+                zone = zone_by_index.get(zi)
+                if (
+                    zone is not None
+                    and getattr(zone, "sensor", None) is not None
+                ):
+                    continue  # zone has a sensor — CTL broadcasts its temp
+                zone_indexs_no_sensor.append(zi)
 
         slug = getattr(device, "_SLUG", None)
 
@@ -262,6 +298,23 @@ class PollingManager:
                     zkey = (device.id, code, zone_index)
                     active_keys.add(zkey)
                     payload = f"{zone_index}00"
+                    if zkey not in self._tasks:
+                        self._tasks[zkey] = PollingTask(
+                            device_id=device.id,
+                            code=code,
+                            interval=interval,
+                            next_due=now + td(seconds=interval),
+                            payload=payload,
+                        )
+                    else:
+                        self._tasks[zkey].interval = interval
+                        self._tasks[zkey].payload = payload
+            elif code == Code._30C9 and zone_indexs_no_sensor:
+                # Expand into per-zone tasks (only zones without a sensor)
+                for zone_index in zone_indexs_no_sensor:
+                    zkey = (device.id, code, zone_index)
+                    active_keys.add(zkey)
+                    payload = f"{zone_index}"  # 30C9 RQ payload is 1 byte
                     if zkey not in self._tasks:
                         self._tasks[zkey] = PollingTask(
                             device_id=device.id,

--- a/src/ramses_rf/pipeline/polling.py
+++ b/src/ramses_rf/pipeline/polling.py
@@ -58,6 +58,13 @@ DEFAULT_POLLING_SCHEDULES: Final[dict[str, dict[Code | str, int | None]]] = {
         # eavesdropper cannot learn a representative TRV sensor without
         # active polling to supply zone.temperature().
         Code._30C9: INTERVAL_ZONE_TEMP,  # Zone Temperature (per-zone, filtered)
+        # 2349 (zone mode) is polled per-zone — the CTL does not broadcast
+        # 2349; it sends it only as I directed to an HGI or as RP in
+        # response to an RQ.  Without polling, zone.mode() returns None
+        # and the zone climate entity cannot display the operating mode
+        # (auto / permanent override / temporary override).  The setpoint
+        # is also in 2349, but 2309 (which IS broadcast) covers that.
+        Code._2349: INTERVAL_ZONE_TEMP,  # Zone Mode (per-zone, all zones)
     },
     # Boiler Relay / Switch
     DevType.BDR: {
@@ -237,6 +244,13 @@ class PollingManager:
         zone-name polling that was lost when the legacy DiscoveryService
         was removed (issue 947 / ramses-rf/ramses_cc#947).
 
+        For CTL devices with zones, the ``2349`` (zone mode) code is
+        expanded into one task per zone, keyed by
+        ``(device_id, "2349", zone_index)``.  The CTL does not broadcast
+        2349 — it sends it only as I directed to an HGI or as RP in
+        response to an RQ.  Without polling, ``zone.mode()`` returns None
+        and the zone climate entity cannot display the operating mode.
+
         For CTL devices with zones, the ``30C9`` (zone temperature) code is
         expanded into one task per zone **that has no dedicated sensor**,
         keyed by ``(device_id, "30C9", zone_index)``.  This restores the
@@ -263,12 +277,14 @@ class PollingManager:
         now = dt.now(UTC)
         active_keys: set[tuple[str, ...]] = set()
 
-        # Collect zone indices for per-zone code expansion (0004, 30C9).
+        # Collect zone indices for per-zone code expansion (0004, 2349, 30C9).
         # CTL devices have a .tcs attribute with .zones list.
         tcs = getattr(device, "tcs", None)
         zone_indexs: list[str] = []
         if (
-            Code._0004 in schedule or Code._30C9 in schedule
+            Code._0004 in schedule
+            or Code._2349 in schedule
+            or Code._30C9 in schedule
         ) and tcs is not None:
             zones = getattr(tcs, "zones", [])
             zone_indexs = [z.index for z in zones if hasattr(z, "index")]
@@ -294,6 +310,25 @@ class PollingManager:
         for code, interval in schedule.items():
             if code == Code._0004 and zone_indexs:
                 # Expand into per-zone tasks
+                for zone_index in zone_indexs:
+                    zkey = (device.id, code, zone_index)
+                    active_keys.add(zkey)
+                    payload = f"{zone_index}00"
+                    if zkey not in self._tasks:
+                        self._tasks[zkey] = PollingTask(
+                            device_id=device.id,
+                            code=code,
+                            interval=interval,
+                            next_due=now + td(seconds=interval),
+                            payload=payload,
+                        )
+                    else:
+                        self._tasks[zkey].interval = interval
+                        self._tasks[zkey].payload = payload
+            elif code == Code._2349 and zone_indexs:
+                # Expand into per-zone tasks (all zones — mode is needed
+                # regardless of whether the zone has a sensor).  2349 RQ
+                # payload is 2 bytes (zone_index + "00"), same as 0004.
                 for zone_index in zone_indexs:
                     zkey = (device.id, code, zone_index)
                     active_keys.add(zkey)

--- a/tests/tests_rf/test_polling_manager.py
+++ b/tests/tests_rf/test_polling_manager.py
@@ -312,8 +312,8 @@ def test_polling_manager_ctl_without_tcs_creates_device_level_0004(
 ) -> None:
     """CTL without a TCS (no zones) gets a single device-level 0004 task.
 
-    The MockDevice has no .tcs attribute, so 0004 and 30C9 are not expanded
-    into per-zone tasks.  This verifies the fallback path.
+    The MockDevice has no .tcs attribute, so 0004, 2349, and 30C9 are not
+    expanded into per-zone tasks.  This verifies the fallback path.
     """
     # ARRANGE
     poller = PollingManager(mock_gateway, shadow_mode=True)
@@ -323,20 +323,23 @@ def test_polling_manager_ctl_without_tcs_creates_device_level_0004(
     active_keys = poller.update_device_tasks(ctl_dev)
 
     # ASSERT
-    # 6 device-level tasks: 10E0, 1F41, 2E04, 313F, 0004, 30C9
-    assert len(active_keys) == 6
+    # 7 device-level tasks: 10E0, 1F41, 2E04, 313F, 0004, 2349, 30C9
+    assert len(active_keys) == 7
     assert ("01:111111", Code._0004) in active_keys
+    assert ("01:111111", Code._2349) in active_keys
     assert ("01:111111", Code._30C9) in active_keys
     # No zone-level keys (3-tuples)
     assert all(len(k) == 2 for k in active_keys)
 
 
-def test_polling_manager_ctl_with_zones_expands_0004_and_30C9_per_zone(
+def test_polling_manager_ctl_with_zones_expands_0004_2349_and_30C9_per_zone(
     mock_gateway: MagicMock,
 ) -> None:
-    """CTL with a TCS and zones gets per-zone 0004 and 30C9 polling tasks.
+    """CTL with a TCS and zones gets per-zone 0004, 2349, and 30C9 tasks.
 
     0004 (zone name) is expanded for all zones (issue 947).
+    2349 (zone mode) is expanded for all zones — the CTL does not
+    broadcast 2349, so polling is the only way to get zone mode.
     30C9 (zone temperature) is expanded for zones without a sensor
     (issue 1013).  In this test, the mock zones have no sensor, so all
     zones get 30C9 tasks.
@@ -362,15 +365,19 @@ def test_polling_manager_ctl_with_zones_expands_0004_and_30C9_per_zone(
 
     # ASSERT
     # 4 device-level tasks (10E0, 1F41, 2E04, 313F)
-    # + 2 zone-level 0004 tasks + 2 zone-level 30C9 tasks
+    # + 2 zone-level 0004 tasks + 2 zone-level 2349 tasks + 2 zone-level 30C9 tasks
     device_level = {k for k in active_keys if len(k) == 2}
     zone_level = {k for k in active_keys if len(k) == 3}
     assert len(device_level) == 4
-    assert len(zone_level) == 4
+    assert len(zone_level) == 6
 
     # Zone-level keys for 0004
     assert ("01:111111", Code._0004, "03") in zone_level
     assert ("01:111111", Code._0004, "07") in zone_level
+
+    # Zone-level keys for 2349
+    assert ("01:111111", Code._2349, "03") in zone_level
+    assert ("01:111111", Code._2349, "07") in zone_level
 
     # Zone-level keys for 30C9
     assert ("01:111111", Code._30C9, "03") in zone_level
@@ -384,6 +391,15 @@ def test_polling_manager_ctl_with_zones_expands_0004_and_30C9_per_zone(
     task_07 = poller._tasks[("01:111111", Code._0004, "07")]
     assert task_07.payload == "0700"
     assert task_07.code == Code._0004
+
+    # Verify the 2349 tasks have the correct payload (zone_index + "00")
+    task_2349_03 = poller._tasks[("01:111111", Code._2349, "03")]
+    assert task_2349_03.payload == "0300"
+    assert task_2349_03.code == Code._2349
+
+    task_2349_07 = poller._tasks[("01:111111", Code._2349, "07")]
+    assert task_2349_07.payload == "0700"
+    assert task_2349_07.code == Code._2349
 
     # Verify the 30C9 tasks have the correct payload (zone_index only, 1 byte)
     task_30c9_03 = poller._tasks[("01:111111", Code._30C9, "03")]
@@ -488,6 +504,11 @@ def test_polling_manager_30C9_skips_zones_with_sensor(
     assert ("01:111111", Code._0004, "03") in zone_level
     assert ("01:111111", Code._0004, "07") in zone_level
 
+    # 2349 is polled for all zones (no sensor filter — mode is needed
+    # regardless of whether the zone has a sensor)
+    assert ("01:111111", Code._2349, "03") in zone_level
+    assert ("01:111111", Code._2349, "07") in zone_level
+
     # 30C9 is polled only for zone_07 (no sensor)
     assert ("01:111111", Code._30C9, "03") not in zone_level
     assert ("01:111111", Code._30C9, "07") in zone_level
@@ -549,6 +570,59 @@ async def test_polling_manager_30C9_zone_uses_payload_in_cmd(
             break
     else:
         pytest.fail("No 30C9 command was sent")
+
+
+@pytest.mark.asyncio
+async def test_polling_manager_2349_zone_uses_payload_in_cmd(
+    mock_gateway: MagicMock,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When polling 2349 for a zone, the RQ payload is zone_index + "00" (2 bytes).
+
+    The legacy Command.get_zone_mode used payload f"{zone_idx:02X}00" (2 bytes),
+    same as 0004 (zone name).  The PollingManager must do the same.
+    """
+    # ARRANGE
+    monkeypatch.setattr("asyncio.sleep", AsyncMock())
+    poller = PollingManager(mock_gateway, shadow_mode=False)
+    ctl_dev = MockDevice(mock_gateway, "01:111111", slug="CTL")
+
+    # Mock a TCS with one zone (2349 is polled for ALL zones, sensor or not)
+    zone_0B = MagicMock()
+    zone_0B.index = "0B"
+    zone_0B.sensor = MagicMock()  # has a sensor — 2349 still polled
+    mock_tcs = MagicMock()
+    mock_tcs.zones = [zone_0B]
+    mock_tcs.zone_by_index = {"0B": zone_0B}
+    ctl_dev.tcs = mock_tcs
+
+    mock_gateway.device_registry.devices = [ctl_dev]
+    poller.update_device_tasks(ctl_dev)
+
+    # Fast-forward all tasks to trigger due commands
+    past = dt.now(UTC) - td(seconds=10)
+    for task in poller.get_scheduled_cmds():
+        task.next_due = past
+
+    # ACT
+    await poller.poll_due_commands()
+
+    # ASSERT: find the 2349 call and check its payload
+    sent_codes = [
+        call.args[0].code
+        for call in mock_gateway.async_send_cmd.call_args_list
+    ]
+    assert Code._2349 in sent_codes
+
+    for call in mock_gateway.async_send_cmd.call_args_list:
+        dto: CommandDTO = call.args[0]
+        if dto.code == Code._2349:
+            assert dto.payload == "0B00", (
+                f"Expected 2349 payload '0B00' for zone 0B, got '{dto.payload}'"
+            )
+            break
+    else:
+        pytest.fail("No 2349 command was sent")
 
 
 @pytest.mark.asyncio

--- a/tests/tests_rf/test_polling_manager.py
+++ b/tests/tests_rf/test_polling_manager.py
@@ -312,8 +312,8 @@ def test_polling_manager_ctl_without_tcs_creates_device_level_0004(
 ) -> None:
     """CTL without a TCS (no zones) gets a single device-level 0004 task.
 
-    The MockDevice has no .tcs attribute, so 0004 is not expanded into
-    per-zone tasks.  This verifies the fallback path.
+    The MockDevice has no .tcs attribute, so 0004 and 30C9 are not expanded
+    into per-zone tasks.  This verifies the fallback path.
     """
     # ARRANGE
     poller = PollingManager(mock_gateway, shadow_mode=True)
@@ -323,49 +323,58 @@ def test_polling_manager_ctl_without_tcs_creates_device_level_0004(
     active_keys = poller.update_device_tasks(ctl_dev)
 
     # ASSERT
-    # 5 device-level tasks: 10E0, 1F41, 2E04, 313F, 0004
-    assert len(active_keys) == 5
+    # 6 device-level tasks: 10E0, 1F41, 2E04, 313F, 0004, 30C9
+    assert len(active_keys) == 6
     assert ("01:111111", Code._0004) in active_keys
+    assert ("01:111111", Code._30C9) in active_keys
     # No zone-level keys (3-tuples)
     assert all(len(k) == 2 for k in active_keys)
 
 
-def test_polling_manager_ctl_with_zones_expands_0004_per_zone(
+def test_polling_manager_ctl_with_zones_expands_0004_and_30C9_per_zone(
     mock_gateway: MagicMock,
 ) -> None:
-    """CTL with a TCS and zones gets per-zone 0004 polling tasks.
+    """CTL with a TCS and zones gets per-zone 0004 and 30C9 polling tasks.
 
-    This restores the per-zone zone-name polling that was lost when the
-    legacy DiscoveryService was removed (issue 947 /
-    ramses-rf/ramses_cc#947).  Each zone gets its own 0004 task with
-    the zone_index in the payload.
+    0004 (zone name) is expanded for all zones (issue 947).
+    30C9 (zone temperature) is expanded for zones without a sensor
+    (issue 1013).  In this test, the mock zones have no sensor, so all
+    zones get 30C9 tasks.
     """
     # ARRANGE
     poller = PollingManager(mock_gateway, shadow_mode=True)
     ctl_dev = MockDevice(mock_gateway, "01:111111", slug="CTL")
 
-    # Mock a TCS with zones
+    # Mock a TCS with zones (no sensor → 30C9 will be polled)
     zone_03 = MagicMock()
     zone_03.index = "03"
+    zone_03.sensor = None
     zone_07 = MagicMock()
     zone_07.index = "07"
+    zone_07.sensor = None
     mock_tcs = MagicMock()
     mock_tcs.zones = [zone_03, zone_07]
+    mock_tcs.zone_by_index = {"03": zone_03, "07": zone_07}
     ctl_dev.tcs = mock_tcs
 
     # ACT
     active_keys = poller.update_device_tasks(ctl_dev)
 
     # ASSERT
-    # 4 device-level tasks (10E0, 1F41, 2E04, 313F) + 2 zone-level 0004 tasks
+    # 4 device-level tasks (10E0, 1F41, 2E04, 313F)
+    # + 2 zone-level 0004 tasks + 2 zone-level 30C9 tasks
     device_level = {k for k in active_keys if len(k) == 2}
     zone_level = {k for k in active_keys if len(k) == 3}
     assert len(device_level) == 4
-    assert len(zone_level) == 2
+    assert len(zone_level) == 4
 
-    # Zone-level keys are (device_id, "0004", zone_index)
+    # Zone-level keys for 0004
     assert ("01:111111", Code._0004, "03") in zone_level
     assert ("01:111111", Code._0004, "07") in zone_level
+
+    # Zone-level keys for 30C9
+    assert ("01:111111", Code._30C9, "03") in zone_level
+    assert ("01:111111", Code._30C9, "07") in zone_level
 
     # Verify the 0004 tasks have the correct payload (zone_index + "00")
     task_03 = poller._tasks[("01:111111", Code._0004, "03")]
@@ -375,6 +384,15 @@ def test_polling_manager_ctl_with_zones_expands_0004_per_zone(
     task_07 = poller._tasks[("01:111111", Code._0004, "07")]
     assert task_07.payload == "0700"
     assert task_07.code == Code._0004
+
+    # Verify the 30C9 tasks have the correct payload (zone_index only, 1 byte)
+    task_30c9_03 = poller._tasks[("01:111111", Code._30C9, "03")]
+    assert task_30c9_03.payload == "03"
+    assert task_30c9_03.code == Code._30C9
+
+    task_30c9_07 = poller._tasks[("01:111111", Code._30C9, "07")]
+    assert task_30c9_07.payload == "07"
+    assert task_30c9_07.code == Code._30C9
 
     # Device-level tasks have no payload (default "00" in build_rq_cmd)
     task_10e0 = poller._tasks[("01:111111", Code._10E0)]
@@ -430,6 +448,107 @@ async def test_polling_manager_0004_zone_uses_payload_in_cmd(
                 f"Expected 0004 payload '0500' for zone 05, got '{dto.payload}'"
             )
             break
+
+
+def test_polling_manager_30C9_skips_zones_with_sensor(
+    mock_gateway: MagicMock,
+) -> None:
+    """30C9 polling is only created for zones without a dedicated sensor.
+
+    Zones with a sensor receive their temperature via the CTL's 30C9
+    broadcast array, so polling them is redundant.  This test verifies
+    the sensor filter in update_device_tasks (issue 1013).
+    """
+    # ARRANGE
+    poller = PollingManager(mock_gateway, shadow_mode=True)
+    ctl_dev = MockDevice(mock_gateway, "01:111111", slug="CTL")
+
+    # zone_03 has a sensor → should NOT get 30C9 polling
+    zone_03 = MagicMock()
+    zone_03.index = "03"
+    zone_03.sensor = MagicMock()  # non-None sensor
+
+    # zone_07 has no sensor → SHOULD get 30C9 polling
+    zone_07 = MagicMock()
+    zone_07.index = "07"
+    zone_07.sensor = None
+
+    mock_tcs = MagicMock()
+    mock_tcs.zones = [zone_03, zone_07]
+    mock_tcs.zone_by_index = {"03": zone_03, "07": zone_07}
+    ctl_dev.tcs = mock_tcs
+
+    # ACT
+    active_keys = poller.update_device_tasks(ctl_dev)
+
+    # ASSERT
+    zone_level = {k for k in active_keys if len(k) == 3}
+
+    # 0004 is polled for all zones (no sensor filter)
+    assert ("01:111111", Code._0004, "03") in zone_level
+    assert ("01:111111", Code._0004, "07") in zone_level
+
+    # 30C9 is polled only for zone_07 (no sensor)
+    assert ("01:111111", Code._30C9, "03") not in zone_level
+    assert ("01:111111", Code._30C9, "07") in zone_level
+
+    # Verify the 30C9 task payload is 1 byte (zone_index only)
+    task_30c9_07 = poller._tasks[("01:111111", Code._30C9, "07")]
+    assert task_30c9_07.payload == "07"
+
+
+@pytest.mark.asyncio
+async def test_polling_manager_30C9_zone_uses_payload_in_cmd(
+    mock_gateway: MagicMock,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When polling 30C9 for a zone, the RQ payload is the zone_index (1 byte).
+
+    The legacy Command.get_zone_temp used payload f"{zone_idx:02X}" (1 byte).
+    The PollingManager must do the same — payload "00" would only query
+    zone 00, not the target zone.
+    """
+    # ARRANGE
+    monkeypatch.setattr("asyncio.sleep", AsyncMock())
+    poller = PollingManager(mock_gateway, shadow_mode=False)
+    ctl_dev = MockDevice(mock_gateway, "01:111111", slug="CTL")
+
+    # Mock a TCS with one zone (no sensor → 30C9 will be polled)
+    zone_0B = MagicMock()
+    zone_0B.index = "0B"
+    zone_0B.sensor = None
+    mock_tcs = MagicMock()
+    mock_tcs.zones = [zone_0B]
+    mock_tcs.zone_by_index = {"0B": zone_0B}
+    ctl_dev.tcs = mock_tcs
+
+    mock_gateway.device_registry.devices = [ctl_dev]
+    poller.update_device_tasks(ctl_dev)
+
+    # Fast-forward all tasks to trigger due commands
+    past = dt.now(UTC) - td(seconds=10)
+    for task in poller.get_scheduled_cmds():
+        task.next_due = past
+
+    # ACT
+    await poller.poll_due_commands()
+
+    # ASSERT: find the 30C9 call and check its payload
+    sent_codes = [
+        call.args[0].code
+        for call in mock_gateway.async_send_cmd.call_args_list
+    ]
+    assert Code._30C9 in sent_codes
+
+    for call in mock_gateway.async_send_cmd.call_args_list:
+        dto: CommandDTO = call.args[0]
+        if dto.code == Code._30C9:
+            assert dto.payload == "0B", (
+                f"Expected 30C9 payload '0B' for zone 0B, got '{dto.payload}'"
+            )
+            break
+    else:
+        pytest.fail("No 30C9 command was sent")
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- Restores per-zone `RQ 2349` (zone mode) polling in the `PollingManager`, which was lost when the legacy `DiscoveryService` was removed
- The CTL does not broadcast 2349 — it sends it only as `I` directed to an HGI or as `RP` in response to an `RQ`. Without polling, `zone.mode()` returns `None` and the zone climate entity cannot display the operating mode (auto / permanent override / temporary override)
- Mirrors the pattern established by PR 947 for `0004` (zone name) per-zone polling

### How it works

- Adds `Code._2349` to the CTL schedule at **15-minute intervals** (`INTERVAL_ZONE_TEMP = 900s`)
- Expands into per-zone tasks keyed by `(device_id, "2349", zone_index)` with a 2-byte payload (`zone_index + "00"`, matching the legacy `Command.get_zone_mode` format)
- **No sensor filter**: 2349 is polled for ALL zones — zone mode is independent of sensor assignment

### Why 15 minutes

- Zone mode changes are user-initiated and infrequent (auto → manual override, temporary override with duration)
- The setpoint is also in 2349, but 2309 (which IS broadcast by the CTL) covers the setpoint — 2349 is mainly needed for the mode itself
- The CTL is mains-powered, so no battery impact

### Analysis of other missing codes

| Code | Description | Broadcast by CTL? | Needs polling? |
|------|-------------|-------------------|----------------|
| 2349 | Zone mode | No — directed to HGI only | **Yes** (this PR) |
| 000A | Zone config | Yes (broadcast) | No — but ingestion bug (ZoneState.min_temp never populated) |
| 12B0 | Window state | No — TRVs broadcast it | No |
| 10A0 | DHW params | No — RQ/RP only | Low priority (DHW params rarely change) |

#### Test plan

- [x] Updated existing tests for the new 2349 task count (CTL without TCS, CTL with zones, sensor filter)
- [x] New test: `test_polling_manager_2349_zone_uses_payload_in_cmd` — verifies 2-byte payload `0B00` in sent command
- [x] New test: 2349 is polled for zones WITH a sensor (no sensor filter, unlike 30C9)
- [x] All 2229 ramses_rf tests pass (3 skipped)
- [x] R84 recipe passes (8/8) — no regressions
- [x] No unexpected ERROR/WARNING logs in ha-sim test run