### PR TITLE
fix: 000A zone config ingestion + 1026 relay/heat/tpi CQRS gaps

### DIFF
--- a/src/ramses_rf/dispatcher.py
+++ b/src/ramses_rf/dispatcher.py
@@ -23,6 +23,7 @@ from .state_projector import (
     _update_schedule_state,
     _update_system_state,
     _update_temperature_state,
+    _update_zone_state,
     process_state_updates,
 )
 from .validators import instantiate_devices, validate_addresses, validate_slugs
@@ -51,6 +52,7 @@ __all__ = [
     "_update_schedule_state",
     "_update_system_state",
     "_update_temperature_state",
+    "_update_zone_state",
     "detect_array_fragment",
     "instantiate_devices",
     "process_msg",

--- a/src/ramses_rf/gateway.py
+++ b/src/ramses_rf/gateway.py
@@ -516,18 +516,13 @@ class Gateway(GatewayLifecycle, GatewayInterface):
             )
             await self._topology_builder.consume(core_msg)
 
+        await process_msg(self, app_msg)
+
         # Phase 2.95 CQRS Strangler Bridge: Because the Phase 2.99 Async Queue Cutover
         # is currently paused, we must feed the CQRS StateProjector synchronously
         # here so the PR 2 Read-Models get properly hydrated in production.
-        # NOTE: Must run BEFORE process_msg so the CQRS read-model dicts are
-        # populated before SIGNAL_UPDATE is dispatched (which triggers HA
-        # entities to resolve async properties like relay_demands/heat_demands/
-        # tpi_params).  If process_msg runs first, the async properties resolve
-        # to None and the 30s cooldown prevents re-resolution (issue 1102).
         if self.state_projector is not None:
             self.state_projector.process_message_state(app_msg)
-
-        await process_msg(self, app_msg)
 
     def add_msg_handler(
         self,

--- a/src/ramses_rf/gateway.py
+++ b/src/ramses_rf/gateway.py
@@ -516,13 +516,18 @@ class Gateway(GatewayLifecycle, GatewayInterface):
             )
             await self._topology_builder.consume(core_msg)
 
-        await process_msg(self, app_msg)
-
         # Phase 2.95 CQRS Strangler Bridge: Because the Phase 2.99 Async Queue Cutover
         # is currently paused, we must feed the CQRS StateProjector synchronously
         # here so the PR 2 Read-Models get properly hydrated in production.
+        # NOTE: Must run BEFORE process_msg so the CQRS read-model dicts are
+        # populated before SIGNAL_UPDATE is dispatched (which triggers HA
+        # entities to resolve async properties like relay_demands/heat_demands/
+        # tpi_params).  If process_msg runs first, the async properties resolve
+        # to None and the 30s cooldown prevents re-resolution (issue 1102).
         if self.state_projector is not None:
             self.state_projector.process_message_state(app_msg)
+
+        await process_msg(self, app_msg)
 
     def add_msg_handler(
         self,

--- a/src/ramses_rf/payloads/heating.py
+++ b/src/ramses_rf/payloads/heating.py
@@ -1273,7 +1273,14 @@ class ZoneConfigPayload(PayloadBase):
         :rtype: dict[str, Any]
         """
         bitmap = self.zone_flags
+        # zone_index is included so that _resolve_logical_targets in
+        # state_projector.py can route the payload to the correct zone.
+        # Without it, 000A packets are never ingested (issue 1102).
+        index = self.zone_index
+        if isinstance(index, int):
+            index = f"{index:02X}"
         return {
+            SZ_ZONE_INDEX: index,
             "min_temp": self.min_temp,
             "max_temp": self.max_temp,
             "local_override": not bool(bitmap & 1),
@@ -2105,7 +2112,14 @@ class RelayDemand2BPayload(RelayDemandPayload):
         :returns: Decoded relay demand dictionary.
         :rtype: dict[str, Any]
         """
-        return {"relay_demand": self.demand_percent}
+        # domain_index is included so that _update_demand_state can
+        # populate the TCS's per-domain _relay_demands dict (issue 1102).
+        idx = self.domain_or_zone_index
+        domain = "FC" if idx == 0xFC else f"{idx:02X}"
+        return {
+            SZ_DOMAIN_INDEX: domain,
+            "relay_demand": self.demand_percent,
+        }
 
 
 # Update VARIANTS property after variants are defined

--- a/src/ramses_rf/pipeline/ingestion.py
+++ b/src/ramses_rf/pipeline/ingestion.py
@@ -54,11 +54,16 @@ from ramses_rf.const import (
     SZ_INDOOR_HUMIDITY,
     SZ_INDOOR_TEMP,
     SZ_LANGUAGE,
+    SZ_LOCAL_OVERRIDE,
     SZ_MAX_REL_MODULATION,
+    SZ_MAX_TEMP,
+    SZ_MIN_TEMP,
     SZ_MINUTES,
     SZ_MODE,
     SZ_MODULATION_LEVEL,
+    SZ_MULTIROOM_MODE,
     SZ_NAME,
+    SZ_OPENWINDOW_FUNCTION,
     SZ_OUTDOOR_HUMIDITY,
     SZ_OUTDOOR_TEMP,
     SZ_OVERRUN,
@@ -963,7 +968,7 @@ class StateProjector:
         self, target: Any, p: dict[str, Any], msg: Message
     ) -> None:
         """Translate demand opcodes into DemandState."""
-        if msg.code not in (Code._3150, Code._0008, Code._0009):
+        if msg.code not in (Code._3150, Code._0008, Code._0009, Code._1100):
             return
 
         updates: dict[str, Any] = {}
@@ -1004,6 +1009,22 @@ class StateProjector:
         elif msg.code == Code._0009 and "failsafe_enabled" in p:
             updates[SZ_RELAY_FAILSAFE] = p["failsafe_enabled"]
 
+        # 1100 (TPI params) — populate the TCS's _tpi_params dict (issue 1102).
+        # TPI params don't fit into DemandState; they're stored per-domain on
+        # the TCS and read by tcs.tpi_params.  Handled before the `if not
+        # updates` guard because 1100 has no demand fields.
+        if msg.code == Code._1100 and "cycle_rate" in p:
+            tcs_for_tpi = getattr(target, "tcs", None) or (
+                target if slug in ("CTL", "BDR") else None
+            )
+            if tcs_for_tpi is not None:
+                tpi_dict = getattr(tcs_for_tpi, "_tpi_params", None)
+                if tpi_dict is not None:
+                    domain = (
+                        p.get(SZ_DOMAIN_INDEX) or p.get("domain_id") or "FC"
+                    )
+                    tpi_dict[domain] = p
+
         if not updates:
             return
 
@@ -1023,6 +1044,21 @@ class StateProjector:
         )
         if hasattr(target, "apply_state_update"):
             target.apply_state_update(event)
+
+        # Populate the TCS's per-domain demand dicts (issue 1102 / ramses_cc#1026).
+        tcs = getattr(target, "tcs", None) or (
+            target if slug in ("CTL", "UFC") else None
+        )
+        if tcs is not None:
+            domain = p.get(SZ_DOMAIN_INDEX) or p.get("domain_id")
+            if domain and SZ_RELAY_DEMAND in p:
+                relay_dict = getattr(tcs, "_relay_demands", None)
+                if relay_dict is not None:
+                    relay_dict[domain] = msg
+            if domain and SZ_HEAT_DEMAND in p and slug in ("CTL", "UFC"):
+                heat_dict = getattr(tcs, "_heat_demands", None)
+                if heat_dict is not None:
+                    heat_dict[domain] = msg
 
     def _update_ufh_state(
         self, target: Any, p: dict[str, Any], msg: Message
@@ -1167,6 +1203,8 @@ class StateProjector:
 
         Handles:
         - 0004 (zone_name): updates zone_state.name
+        - 000A (zone_config): updates min_temp, max_temp, local_override,
+          openwindow_function, multiroom_mode (issue 1102)
         - 2349 (zone_mode): updates zone_state.mode, setpoint, until
         - 2309 (setpoint): updates zone_state.setpoint
         """
@@ -1175,6 +1213,18 @@ class StateProjector:
         if msg.code == Code._0004:
             if SZ_NAME in p:
                 updates[SZ_NAME] = str(p[SZ_NAME])
+
+        elif msg.code == Code._000A:
+            if SZ_MIN_TEMP in p:
+                updates[SZ_MIN_TEMP] = p[SZ_MIN_TEMP]
+            if SZ_MAX_TEMP in p:
+                updates[SZ_MAX_TEMP] = p[SZ_MAX_TEMP]
+            if SZ_LOCAL_OVERRIDE in p:
+                updates[SZ_LOCAL_OVERRIDE] = p[SZ_LOCAL_OVERRIDE]
+            if SZ_OPENWINDOW_FUNCTION in p:
+                updates[SZ_OPENWINDOW_FUNCTION] = p[SZ_OPENWINDOW_FUNCTION]
+            if SZ_MULTIROOM_MODE in p:
+                updates[SZ_MULTIROOM_MODE] = p[SZ_MULTIROOM_MODE]
 
         elif msg.code == Code._2349:
             if SZ_MODE in p:

--- a/src/ramses_rf/pipeline/polling.py
+++ b/src/ramses_rf/pipeline/polling.py
@@ -45,6 +45,11 @@ DEFAULT_POLLING_SCHEDULES: Final[dict[str, dict[Code | str, int | None]]] = {
         Code._1F41: INTERVAL_HOURLY,  # DHW System Mode / Operating State
         Code._2E04: INTERVAL_DAILY,  # Evohome System Mode
         Code._313F: INTERVAL_EVERY_12_HOURS,  # System Time & Date Sync
+        # 1100 (TPI params) — the CTL does not broadcast 1100; it must be
+        # polled.  Without polling, tcs.tpi_params returns None (issue 1102
+        # / ramses_cc#1026).  12h interval: TPI params are set during
+        # installation and rarely change.
+        Code._1100: INTERVAL_EVERY_12_HOURS,  # TPI Params
         # 0004 (zone name) is polled per-zone, not per-device — see
         # update_device_tasks for the zone-level expansion.  The interval
         # here is a marker; actual tasks are keyed by (device_id, "0004",

--- a/src/ramses_rf/state_projector.py
+++ b/src/ramses_rf/state_projector.py
@@ -39,8 +39,14 @@ from .const import (
     SZ_INDOOR_HUMIDITY,
     SZ_INDOOR_TEMP,
     SZ_LANGUAGE,
+    SZ_LOCAL_OVERRIDE,
+    SZ_MAX_TEMP,
+    SZ_MIN_TEMP,
     SZ_MINUTES,
     SZ_MODE,
+    SZ_MULTIROOM_MODE,
+    SZ_NAME,
+    SZ_OPENWINDOW_FUNCTION,
     SZ_OUTDOOR_HUMIDITY,
     SZ_OUTDOOR_TEMP,
     SZ_OVERRUN,
@@ -632,6 +638,73 @@ def _update_temperature_state(
     target.apply_state_update(event)
 
 
+def _update_zone_state(target: Any, p: dict[str, Any], msg: Message) -> None:
+    """Translate zone configuration opcodes into ZoneState.
+
+    Handles:
+    - 0004 (zone_name): updates zone_state.name
+    - 000A (zone_config): updates min_temp, max_temp, local_override,
+      openwindow_function, multiroom_mode (issue 1102)
+    - 2349 (zone_mode): updates mode, setpoint, until
+    - 2309 (setpoint): updates setpoint
+
+    :param target: Target zone entity to update.
+    :type target: Any
+    :param p: Parsed payload dictionary.
+    :type p: dict[str, Any]
+    :param msg: Message envelope.
+    :type msg: Message
+    """
+    zone_state = getattr(target, "zone_state", None)
+    if zone_state is None or not dataclasses.is_dataclass(zone_state):
+        return
+
+    updates: dict[str, Any] = {}
+
+    if msg.code == Code._0004:
+        if SZ_NAME in p:
+            updates[SZ_NAME] = str(p[SZ_NAME])
+
+    elif msg.code == Code._000A:
+        if SZ_MIN_TEMP in p:
+            updates[SZ_MIN_TEMP] = p[SZ_MIN_TEMP]
+        if SZ_MAX_TEMP in p:
+            updates[SZ_MAX_TEMP] = p[SZ_MAX_TEMP]
+        if SZ_LOCAL_OVERRIDE in p:
+            updates[SZ_LOCAL_OVERRIDE] = p[SZ_LOCAL_OVERRIDE]
+        if SZ_OPENWINDOW_FUNCTION in p:
+            updates[SZ_OPENWINDOW_FUNCTION] = p[SZ_OPENWINDOW_FUNCTION]
+        if SZ_MULTIROOM_MODE in p:
+            updates[SZ_MULTIROOM_MODE] = p[SZ_MULTIROOM_MODE]
+
+    elif msg.code == Code._2349:
+        if SZ_MODE in p:
+            updates[SZ_MODE] = p[SZ_MODE]
+        if SZ_SETPOINT in p:
+            updates[SZ_SETPOINT] = p[SZ_SETPOINT]
+        if SZ_UNTIL in p:
+            updates[SZ_UNTIL] = p[SZ_UNTIL]
+
+    elif msg.code == Code._2309:
+        if SZ_SETPOINT in p:
+            updates[SZ_SETPOINT] = p[SZ_SETPOINT]
+
+    else:
+        return
+
+    if not updates:
+        return
+
+    new_state = dataclasses.replace(target.zone_state, **updates)
+    event = StateUpdatedEvent(
+        entity_id=getattr(target, "id", "unknown"),
+        state=new_state,
+        correlation_id=getattr(msg, "correlation_id", uuid.uuid4()),
+        causation_id=getattr(msg, "message_id", uuid.uuid4()),
+    )
+    target.apply_state_update(event)
+
+
 def _update_demand_state(target: Any, p: dict[str, Any], msg: Message) -> None:
     """Translate demand data into a frozen StateUpdatedEvent.
 
@@ -673,6 +746,19 @@ def _update_demand_state(target: Any, p: dict[str, Any], msg: Message) -> None:
     if getattr(msg, "code", None) == Code._0009 and "failsafe_enabled" in p:
         updates["relay_failsafe"] = p["failsafe_enabled"]
 
+    # 1100 (TPI params) — populate the TCS's _tpi_params dict (issue 1102).
+    # TPI params don't fit into DemandState; they're stored per-domain on the
+    # TCS and read by tcs.tpi_params.
+    if msg.code == Code._1100 and "cycle_rate" in p:
+        tcs_for_tpi = getattr(target, "tcs", None) or (
+            target if slug in ("CTL", "BDR") else None
+        )
+        if tcs_for_tpi is not None:
+            tpi_dict = getattr(tcs_for_tpi, "_tpi_params", None)
+            if tpi_dict is not None:
+                domain = p.get(SZ_DOMAIN_INDEX) or p.get("domain_id") or "FC"
+                tpi_dict[domain] = p
+
     if not updates:
         return
 
@@ -684,6 +770,25 @@ def _update_demand_state(target: Any, p: dict[str, Any], msg: Message) -> None:
         causation_id=getattr(msg, "message_id", uuid.uuid4()),
     )
     target.apply_state_update(event)
+
+    # Populate the TCS's per-domain demand dicts (issue 1102 / ramses_cc#1026).
+    # The legacy _handle_msg stored 0008/3150 messages keyed by domain/zone
+    # index in _relay_demands/_heat_demands.  The CQRS DemandState only tracks
+    # a single heat_demand/relay_demand, so the per-domain dicts were never
+    # populated after the legacy handler was removed.
+    tcs = getattr(target, "tcs", None) or (
+        target if slug in ("CTL", "UFC") else None
+    )
+    if tcs is not None:
+        domain = p.get(SZ_DOMAIN_INDEX) or p.get("domain_id")
+        if domain and SZ_RELAY_DEMAND in p:
+            relay_dict = getattr(tcs, "_relay_demands", None)
+            if relay_dict is not None:
+                relay_dict[domain] = msg
+        if domain and SZ_HEAT_DEMAND in p and slug in ("CTL", "UFC"):
+            heat_dict = getattr(tcs, "_heat_demands", None)
+            if heat_dict is not None:
+                heat_dict[domain] = msg
 
 
 def _update_faultlog_state(
@@ -879,6 +984,7 @@ async def process_state_updates(gateway: Gateway, msg: Message) -> None:
             _update_system_state(target, payload, msg)
             _update_hvac_state(target, payload, msg)
             _update_dhw_state(target, payload, msg)
+            _update_zone_state(target, payload, msg)
             _update_temperature_state(target, payload, msg)
             _update_demand_state(target, payload, msg)
             _update_faultlog_state(target, payload, msg)

--- a/src/ramses_rf/systems/tcs.py
+++ b/src/ramses_rf/systems/tcs.py
@@ -7,7 +7,7 @@ import asyncio
 import logging
 from datetime import datetime as dt, timedelta as td
 from types import SimpleNamespace
-from typing import TYPE_CHECKING, Any, NoReturn, TypeVar
+from typing import TYPE_CHECKING, Any, NoReturn, TypeVar, cast
 
 from ramses_rf.address import HGI_DEV_ADDR, Address
 from ramses_rf.commands.core import Command as Intent_
@@ -125,6 +125,11 @@ class SystemBase(Parent, Entity):  # 3B00 (multi-relay)
     # TODO: check (code so complex, not sure if this is true)
     childs: list[Device]  # type: ignore[assignment]
 
+    # Populated by the CQRS state projector (issue 1102).  Declared here
+    # because tpi_params property is on SystemBase but the dict is only
+    # initialised in System.__init__.
+    _tpi_params: dict[str, Any] = {}
+
     def __init__(self, controller: Controller) -> None:
         """Initialise the TCS base class.
 
@@ -185,14 +190,17 @@ class SystemBase(Parent, Entity):  # 3B00 (multi-relay)
         # The legacy entity_state.get_value(Code._1100) path is deprecated.
         if self._tpi_params:
             for params in self._tpi_params.values():
-                return {
-                    "cycle_rate": params.get("cycle_rate"),
-                    "min_on_time": params.get("min_on_time"),
-                    "min_off_time": params.get("min_off_time"),
-                    "proportional_band_width": params.get(
-                        "proportional_band_width"
-                    ),
-                }
+                return cast(
+                    PayDictT._1100,
+                    {
+                        "cycle_rate": params.get("cycle_rate"),
+                        "min_on_time": params.get("min_on_time"),
+                        "min_off_time": params.get("min_off_time"),
+                        "proportional_band_width": params.get(
+                            "proportional_band_width"
+                        ),
+                    },
+                )
         return None
 
     async def heat_demand(self) -> float | None:  # 3150/FC

--- a/src/ramses_rf/systems/tcs.py
+++ b/src/ramses_rf/systems/tcs.py
@@ -181,7 +181,19 @@ class SystemBase(Parent, Entity):  # 3B00 (multi-relay)
         :returns: The TPI parameters dictionary, if available.
         :rtype: PayDictT._1100 | None
         """
-        return await self.entity_state.get_value(Code._1100)
+        # Read from the CQRS-populated dict (issue 1102 / ramses_cc#1026).
+        # The legacy entity_state.get_value(Code._1100) path is deprecated.
+        if self._tpi_params:
+            for params in self._tpi_params.values():
+                return {
+                    "cycle_rate": params.get("cycle_rate"),
+                    "min_on_time": params.get("min_on_time"),
+                    "min_off_time": params.get("min_off_time"),
+                    "proportional_band_width": params.get(
+                        "proportional_band_width"
+                    ),
+                }
+        return None
 
     async def heat_demand(self) -> float | None:  # 3150/FC
         """Return the current heat demand for the system.
@@ -848,6 +860,7 @@ class System(StoredHw, Datetime, Logbook, SystemBase):
         self._heat_demands: dict[str, Any] = {}
         self._relay_demands: dict[str, Any] = {}
         self._relay_failsafes: dict[str, Any] = {}
+        self._tpi_params: dict[str, Any] = {}  # 1100, keyed by domain_id
 
     def _update_schema(self, **schema: Any) -> None:
         """Update a CH/DHW system with new schema attrs.

--- a/tests/tests_rf/pipeline/test_state_projector.py
+++ b/tests/tests_rf/pipeline/test_state_projector.py
@@ -99,6 +99,7 @@ class FakeDevice:
         self.opentherm_state: OpenThermState = OpenThermState()
         self.act_state: ActuatorState = ActuatorState()
         self.hvac_state: HvacState = HvacState()
+        self.demand_state: Any = None  # set by tests that need it
         self.tcs: Any | None = None
         self.events: list[StateUpdatedEvent] = []
 
@@ -849,7 +850,7 @@ def test_0008_relay_demand_populates_tcs_dict() -> None:
     class FakeTcsWithDicts:
         id = "01:216136"
         appliance_control = None
-        zone_by_index = {}
+        zone_by_index: dict[str, Any] = {}
         _heat_demands: dict[str, Any] = {}
         _relay_demands: dict[str, Any] = {}
         _tpi_params: dict[str, Any] = {}
@@ -893,7 +894,7 @@ def test_1100_tpi_params_populates_tcs_dict() -> None:
     class FakeTcsWithTpi:
         id = "01:216136"
         appliance_control = None
-        zone_by_index = {}
+        zone_by_index: dict[str, Any] = {}
         _heat_demands: dict[str, Any] = {}
         _relay_demands: dict[str, Any] = {}
         _tpi_params: dict[str, Any] = {}

--- a/tests/tests_rf/pipeline/test_state_projector.py
+++ b/tests/tests_rf/pipeline/test_state_projector.py
@@ -14,8 +14,14 @@ from typing import Any
 from ramses_rf.const import (
     SZ_COOLING_DEMAND,
     SZ_DOMAIN_INDEX,
+    SZ_LOCAL_OVERRIDE,
+    SZ_MAX_TEMP,
+    SZ_MIN_TEMP,
     SZ_MODULATION_LEVEL,
+    SZ_MULTIROOM_MODE,
+    SZ_OPENWINDOW_FUNCTION,
     SZ_REL_MODULATION_LEVEL,
+    SZ_RELAY_DEMAND,
     SZ_REMAINING_DAYS,
     SZ_SETPOINT,
     SZ_ZONE_INDEX,
@@ -760,3 +766,162 @@ def test_issue_989_interleaved_packet_sequence_no_zone_00_oscillation() -> (
         worker.process_message_state(msg)
         # Assert: Throughout the entire sequence, Zone 00 setpoint NEVER oscillates
         assert zone_00.temp_state.setpoint == 5.0
+
+
+def test_000A_zone_config_updates_zone_state() -> None:
+    """000A (zone config) populates ZoneState.min_temp/max_temp (issue 1102).
+
+    The CTL broadcasts 000A with zone config arrays.  Without a zone_index
+    in to_dict() and a zone state handler, ZoneState.min_temp/max_temp were
+    permanently None and ramses_cc fell back to hardcoded 5/35°C.
+    """
+    ctl_dev = FakeDevice()
+    ctl_dev.id = "01:216136"
+    ctl_dev._SLUG = DevType.CTL
+
+    zone_03 = FakeZone("01:216136_03")
+    mock_tcs = type(
+        "FakeTcs",
+        (),
+        {
+            "id": "01:216136",
+            "appliance_control": None,
+            "zone_by_index": {"03": zone_03},
+        },
+    )()
+    registry = FakeRegistry(ctl_dev)
+    registry.systems = [mock_tcs]
+    gwy_adapter = FakeGatewayAdapter(registry)
+    queue: asyncio.Queue[Message] = asyncio.Queue()
+    worker = StateProjector(gwy_adapter, queue)
+
+    msg = MockMessage(
+        code=Code._000A,
+        verb=Verb.I_,
+        payload={
+            SZ_ZONE_INDEX: "03",
+            SZ_MIN_TEMP: 5.0,
+            SZ_MAX_TEMP: 35.0,
+            SZ_LOCAL_OVERRIDE: True,
+            SZ_OPENWINDOW_FUNCTION: True,
+            SZ_MULTIROOM_MODE: False,
+        },
+        src_id="01:216136",
+        dst_id="--:------",
+    )
+    worker.process_message_state(msg)
+
+    assert zone_03.zone_state.min_temp == 5.0
+    assert zone_03.zone_state.max_temp == 35.0
+    assert zone_03.zone_state.local_override is True
+    assert zone_03.zone_state.openwindow_function is True
+    assert zone_03.zone_state.multiroom_mode is False
+
+
+def test_000A_to_dict_includes_zone_index() -> None:
+    """ZoneConfigPayload.to_dict() must include zone_index for routing (issue 1102)."""
+    from ramses_rf.payloads.heating import ZoneConfigPayload
+
+    p = ZoneConfigPayload(
+        zone_index=0x0B, zone_flags=0x00, min_temp=5.0, max_temp=35.0
+    )
+    d = p.to_dict()
+    assert SZ_ZONE_INDEX in d, "zone_index must be in to_dict for routing"
+    assert d[SZ_ZONE_INDEX] == "0B"
+    assert d[SZ_MIN_TEMP] == 5.0
+    assert d[SZ_MAX_TEMP] == 35.0
+
+
+def test_0008_relay_demand_populates_tcs_dict() -> None:
+    """0008 relay demand populates TCS._relay_demands per domain (issue 1102 / ramses_cc#1026).
+
+    The legacy _handle_msg stored 0008 messages keyed by domain in
+    _relay_demands.  After the CQRS migration, the dict was never
+    populated, so tcs.relay_demands always returned None.
+    """
+    from ramses_rf.models import DemandState
+
+    ctl_dev = FakeDevice()
+    ctl_dev.id = "01:216136"
+    ctl_dev._SLUG = DevType.CTL
+    ctl_dev.demand_state = DemandState()
+
+    class FakeTcsWithDicts:
+        id = "01:216136"
+        appliance_control = None
+        zone_by_index = {}
+        _heat_demands: dict[str, Any] = {}
+        _relay_demands: dict[str, Any] = {}
+        _tpi_params: dict[str, Any] = {}
+
+    mock_tcs = FakeTcsWithDicts()
+    ctl_dev.tcs = mock_tcs
+    registry = FakeRegistry(ctl_dev)
+    registry.systems = [mock_tcs]
+    gwy_adapter = FakeGatewayAdapter(registry)
+    queue: asyncio.Queue[Message] = asyncio.Queue()
+    worker = StateProjector(gwy_adapter, queue)
+
+    msg = MockMessage(
+        code=Code._0008,
+        verb=Verb.I_,
+        payload={SZ_DOMAIN_INDEX: "FC", SZ_RELAY_DEMAND: 50.0},
+        src_id="01:216136",
+        dst_id="--:------",
+    )
+    worker.process_message_state(msg)
+
+    assert "FC" in mock_tcs._relay_demands, (
+        "TCS._relay_demands should be populated with FC domain"
+    )
+
+
+def test_1100_tpi_params_populates_tcs_dict() -> None:
+    """1100 TPI params populate TCS._tpi_params dict (issue 1102 / ramses_cc#1026).
+
+    tcs.tpi_params was using the deprecated entity_state.get_value(Code._1100)
+    which is never hydrated.  Now it reads from _tpi_params populated by
+    the CQRS handler.
+    """
+    from ramses_rf.models import DemandState
+
+    ctl_dev = FakeDevice()
+    ctl_dev.id = "01:216136"
+    ctl_dev._SLUG = DevType.CTL
+    ctl_dev.demand_state = DemandState()
+
+    class FakeTcsWithTpi:
+        id = "01:216136"
+        appliance_control = None
+        zone_by_index = {}
+        _heat_demands: dict[str, Any] = {}
+        _relay_demands: dict[str, Any] = {}
+        _tpi_params: dict[str, Any] = {}
+
+    mock_tcs = FakeTcsWithTpi()
+    ctl_dev.tcs = mock_tcs
+    registry = FakeRegistry(ctl_dev)
+    registry.systems = [mock_tcs]
+    gwy_adapter = FakeGatewayAdapter(registry)
+    queue: asyncio.Queue[Message] = asyncio.Queue()
+    worker = StateProjector(gwy_adapter, queue)
+
+    msg = MockMessage(
+        code=Code._1100,
+        verb=Verb.I_,
+        payload={
+            SZ_DOMAIN_INDEX: "FC",
+            "cycle_rate": 6,
+            "min_on_time": 1.0,
+            "min_off_time": 1.0,
+            "proportional_band_width": None,
+        },
+        src_id="01:216136",
+        dst_id="--:------",
+    )
+    worker.process_message_state(msg)
+
+    assert "FC" in mock_tcs._tpi_params, (
+        "TCS._tpi_params should be populated with FC domain"
+    )
+    assert mock_tcs._tpi_params["FC"]["cycle_rate"] == 6

--- a/tests/tests_rf/test_polling_manager.py
+++ b/tests/tests_rf/test_polling_manager.py
@@ -323,11 +323,12 @@ def test_polling_manager_ctl_without_tcs_creates_device_level_0004(
     active_keys = poller.update_device_tasks(ctl_dev)
 
     # ASSERT
-    # 7 device-level tasks: 10E0, 1F41, 2E04, 313F, 0004, 2349, 30C9
-    assert len(active_keys) == 7
+    # 8 device-level tasks: 10E0, 1F41, 2E04, 313F, 1100, 0004, 2349, 30C9
+    assert len(active_keys) == 8
     assert ("01:111111", Code._0004) in active_keys
     assert ("01:111111", Code._2349) in active_keys
     assert ("01:111111", Code._30C9) in active_keys
+    assert ("01:111111", Code._1100) in active_keys
     # No zone-level keys (3-tuples)
     assert all(len(k) == 2 for k in active_keys)
 
@@ -364,11 +365,11 @@ def test_polling_manager_ctl_with_zones_expands_0004_2349_and_30C9_per_zone(
     active_keys = poller.update_device_tasks(ctl_dev)
 
     # ASSERT
-    # 4 device-level tasks (10E0, 1F41, 2E04, 313F)
+    # 5 device-level tasks (10E0, 1F41, 2E04, 313F, 1100)
     # + 2 zone-level 0004 tasks + 2 zone-level 2349 tasks + 2 zone-level 30C9 tasks
     device_level = {k for k in active_keys if len(k) == 2}
     zone_level = {k for k in active_keys if len(k) == 3}
-    assert len(device_level) == 4
+    assert len(device_level) == 5
     assert len(zone_level) == 6
 
     # Zone-level keys for 0004


### PR DESCRIPTION
## Summary

Three CQRS state hydration gaps left by the Phase 2.x strangler fig migration. The legacy `_handle_msg` that populated dict-based state was removed, but the CQRS `state_projector.py` handlers were never added for these codes.

### 1. 000A (zone config) — not ingested at all

- `ZoneConfigPayload.to_dict()` was missing `zone_index`, so `_resolve_logical_targets` could not route the payload to a zone
- No `_update_zone_state` handler existed in `state_projector.py`
- **Impact:** `Zone.config()` always returned `None`, ramses_cc fell back to hardcoded 5/35°C for climate min/max temp sliders
- **Fix:** Add `zone_index` to `to_dict()`, add `_update_zone_state` handler for 000A/0004/2349/2309 in both `state_projector.py` and `pipeline/ingestion.py`

### 2. 0008/3150 (relay/heat demands) — ramses_cc issue 1026

- `TCS._relay_demands`/`_heat_demands` dicts were initialized empty but never populated (legacy `_handle_msg` removed)
- CQRS `_update_demand_state` only updates `DemandState` (single float), not the per-domain dicts that `thermal_demands`/`relay_demands` read from
- **Fix:** Populate `_relay_demands`/`_heat_demands` from the CQRS handler; also add `domain_index` to `RelayDemand2BPayload.to_dict()`

### 3. 1100 (TPI params) — ramses_cc issue 1026

- `tcs.tpi_params` used `entity_state.get_value(Code._1100)` (legacy SQLite), never hydrated, no CQRS handler, not polled
- **Fix:** Add `_tpi_params` dict to TCS, populate from CQRS handler, migrate `tpi_params` to read from it, add 1100 to CTL polling schedule (12h interval)

## Test plan

- [x] ramses_rf: 2233 tests pass (4 new tests added)
- [x] ramses_cc: 1369 tests pass (3 snapshots updated — HGI no longer gets 10E0 polling task)
- [x] R84 recipe passes
- [ ] Live verification with real Evohome system

Issue: https://github.com/ramses-rf/ramses_rf/issues/1102
Related: https://github.com/ramses-rf/ramses_cc/issues/1026