### PR TITLE
fix: only stamp parent zone index for UFH zones in 30C9 fake (issue 929)

### DIFF
--- a/src/ramses_rf/devices/heat_sensors.py
+++ b/src/ramses_rf/devices/heat_sensors.py
@@ -8,7 +8,7 @@ from datetime import timedelta as td
 from typing import Any, Final
 
 from ramses_rf.const import HEARTBEAT_TIMEOUT_DHW, SZ_TEMPERATURE, DevType
-from ramses_rf.enums import Action
+from ramses_rf.enums import Action, ZoneRole
 from ramses_rf.messages import Message
 from ramses_rf.models import DeviceTraits
 from ramses_tx import Packet
@@ -99,8 +99,14 @@ class Temperature(DeviceHeat):  # 30C9
         # Determine the zone_index from the parent zone (if bound) so that
         # UFH zone sensors emit 30C9 with the correct zone_index.  Without
         # this, the fake always sends index 00 and the UFC ignores it.
+        # Only UFH zones need the parent's zone index — standard evohome
+        # CTL zones (RAD/ELE/MIX/VAL) must send "00" (issue 929).
         zone_index = "00"
-        if self._parent is not None and hasattr(self._parent, "index"):
+        if (
+            self._parent is not None
+            and hasattr(self._parent, "index")
+            and getattr(self._parent, "_SLUG", None) == ZoneRole.UFH
+        ):
             zone_index = self._parent.index
         return await send_fake_intent(
             self,


### PR DESCRIPTION
## Summary
- The `set_temperature` method in `heat_sensors.py` was stamping `self._parent.index` into the 30C9 payload for ALL parent-bound zones, but standard evohome CTL zones (RAD/ELE/MIX/VAL) require `zone_index="00"`.
- Only UFH zones (`ZoneRole.UFH`) need the parent's zone index — the UFC uses it to route the temperature to the correct underfloor circuit.
- This caused `PacketPayloadInvalid: Packet idx is 0X, but expecting no idx (00) (0xAB)` errors for all faked THM sensors on standard CTL zones.

Root cause: commit 5b9abbe4 (2026-07-22) introduced the parent index stamping but did not restrict it to UFH zones.

Fix: only use `self._parent.index` when `self._parent._SLUG == ZoneRole.UFH`.

#### Test plan
- [x] ramses_rf unit tests pass (2615 passed, 3 skipped)
- [x] R69 ha-sim test verifies 30C9 payload starts with `00` for CTL zones
- [ ] No regressions in eavesdrop schema tests

Fixes https://github.com/ramses-rf/ramses_cc/issues/929