### PR TITLE
fix: suppress TX echo duplicates in CallbackTransport and `Packet._from_cmd` (issue 1041)

### DIFF
--- a/src/ramses_tx/packet.py
+++ b/src/ramses_tx/packet.py
@@ -693,7 +693,13 @@ class Packet:
             f"{command.verb.strip():>2} --- {command.addr1} {command.addr2} {command.addr3} "
             f"{command.code} {int(len(command.payload) / 2):03d} {command.payload}"
         )
-        return cls.from_raw_line(dtm, f"... {raw_line}")
+        # is_echo=True suppresses PKT_LOGGER output in _validate — this
+        # Packet is an internal helper for computing tx_header, not an
+        # actual packet reception, so it must not appear in the packet log.
+        # Without this, every access to CommandDTO.tx_header (which happens
+        # per-incoming-packet in WantEcho.packet_rcvd) logs a spurious
+        # "... RQ" entry (issue 1041).
+        return cls.from_raw_line(dtm, f"... {raw_line}", is_echo=True)
 
     def to_dto(self) -> PacketDTO:
         """Return the internal immutable PacketDTO object in O(1) time.

--- a/src/ramses_tx/transport/callback.py
+++ b/src/ramses_tx/transport/callback.py
@@ -74,23 +74,19 @@ class CallbackTransport(_FullTransport, _CallbackTransportAbstractor):
         if config.autostart:
             self.resume_reading()
 
-    async def write_frame(
-        self, frame: str, disable_tx_limits: bool = False
-    ) -> None:
-        """Process a frame for transmission by passing it to external writer.
+    async def _write_frame(self, frame: str) -> None:
+        """Send frame via the external io_writer callback.
+
+        Overrides _FullTransport._write_frame so that the parent's
+        write_frame() handles _log_tx_packet, _track_transmit_rate, and
+        echo detection — ensuring MQTT transports get the same TX logging
+        and echo suppression as serial transports (issue 1041).
 
         :param frame: The raw string frame to be transmitted.
         :type frame: str
-        :param disable_tx_limits: Flag to bypass transmit rate limits.
-        :type disable_tx_limits: bool
-        :returns: None
-        :rtype: None
-        :raises exc.TransportError: If sending disabled or io_writer fails.
+        :raises exc.TransportError: If io_writer is closed or fails.
         :raises asyncio.CancelledError: If the write task is cancelled.
         """
-        if self._disable_sending:
-            raise exc.TransportError("Sending has been disabled")
-
         if self._io_writer is None:
             raise exc.TransportError("Transport has been closed")
 
@@ -104,10 +100,6 @@ class CallbackTransport(_FullTransport, _CallbackTransportAbstractor):
         except Exception as err:
             _LOGGER.error("External writer failed to send frame: %s", err)
             raise exc.TransportError(f"External writer failed: {err}") from err
-
-    async def _write_frame(self, frame: str) -> None:
-        """Wait for the frame to be written by the external writer."""
-        await self.write_frame(frame)
 
     def receive_frame(self, frame: str, dtm: str | None = None) -> None:
         """Ingest a frame from the external source (Read Path).

--- a/tests/tests_tx/test_transport_callback.py
+++ b/tests/tests_tx/test_transport_callback.py
@@ -37,6 +37,20 @@ class TestCallbackTransport(unittest.IsolatedAsyncioTestCase):
         # Check if the injected writer was called with the exact frame
         self.mock_writer.assert_awaited_once_with(test_frame)
 
+    async def test_write_frame_logs_tx_packet(self) -> None:
+        """Verify write_frame logs the TX packet for echo detection (issue 1041)."""
+        test_frame = "RQ --- 18:000730 01:195932 --:------ 1F41 001 00"
+
+        await self.transport.write_frame(test_frame)
+
+        # After write_frame, the tx_key should be recorded in _recent_tx_counts
+        # so that _is_recent_tx() can detect echoes
+        self.assertGreater(
+            len(self.transport._recent_tx_counts),
+            0,
+            "TX packet key was not recorded for echo detection",
+        )
+
     async def test_receive_frame_respects_circuit_breaker(self) -> None:
         """Verify inbound frames are gated by pause/resume state."""
         test_frame = "059 RP --- 01:195932 04:017982 --:------ 313F 009 00FC2300C4150C07E9"
@@ -64,10 +78,13 @@ class TestCallbackTransport(unittest.IsolatedAsyncioTestCase):
 
     async def test_write_error_handling(self) -> None:
         """Verify writer exceptions are wrapped in TransportError."""
+        # Use a valid frame so _log_tx_packet doesn't reject it before
+        # reaching _write_frame where the writer error occurs
+        test_frame = "RQ --- 18:000730 01:195932 --:------ 1F41 001 00"
         self.mock_writer.side_effect = Exception("MQTT Connection Lost")
 
         with self.assertRaises(exc.TransportError):
-            await self.transport.write_frame("test_frame")
+            await self.transport.write_frame(test_frame)
 
     async def test_gateway_integration(self) -> None:
         """Verify the Gateway accepts the transport via IoC."""
@@ -148,12 +165,14 @@ class TestCallbackTransport(unittest.IsolatedAsyncioTestCase):
         self,
     ) -> None:
         """Verify asyncio.CancelledError is re-raised during task cancellation."""
-        # Arrange
+        # Arrange — use a valid frame so _log_tx_packet succeeds before
+        # _write_frame triggers the CancelledError
+        test_frame = "RQ --- 18:000730 01:195932 --:------ 1F41 001 00"
         self.mock_writer.side_effect = asyncio.CancelledError()
 
         # Act & Assert
         with self.assertRaises(asyncio.CancelledError):
-            await self.transport.write_frame("test_frame")
+            await self.transport.write_frame(test_frame)
 
     async def test_receive_frame_handles_malformed_packets_gracefully(
         self,


### PR DESCRIPTION
## Summary

- Remove `CallbackTransport.write_frame` override so it inherits `_FullTransport.write_frame`, which calls `_log_tx_packet` with `is_tx=True` and enables echo detection via `_is_recent_tx`. Move the `io_writer` delegation to `_write_frame` (where it belongs in the template method pattern).
- Set `is_echo=True` on `Packet._from_cmd` so the internal helper used by `CommandDTO.tx_header` no longer emits spurious `PKT_LOGGER` entries every time the FSM's `WantEcho` state accesses `tx_header` while waiting for an echo.

These two fixes together eliminate the duplicate `... RQ` entries reported in issue 1041 for MQTT/callback transports. The `Packet._from_cmd` fix applies to all transport types (serial, MQTT, callback, Zigbee).

## Context

- Issue: https://github.com/ramses-rf/ramses_cc/issues/1041
- The existing fix (PR 957) for serial transport did not apply to MQTT because `CallbackTransport` overrode `write_frame` and bypassed `_log_tx_packet`.
- The `Packet._from_cmd` spurious logging was the primary source of `...` RQ duplicates: each incoming packet during the echo wait window triggered a `tx_header` access, which created a new `Packet` via `_from_cmd` and logged it.

## Test plan

- [x] ramses_rf unit tests: 2630 passed, 3 skipped
- [x] ha_sim_test R88 (TX echo suppression): 6/6 PASS
- [x] Full ha_sim_test single-container: 383/395 passed (12 pre-existing failures in R16/R81)
- [x] Full ha_sim_test 3-parallel: 384/388 passed (4 pre-existing failures in R07/R15 under parallel load)
- [x] Verified on `hass` instance (MQTT transport): zero `...` RQ duplicates after restart