### PR TITLE
fix: BDR active state falls back to relay_demand when BDR is silent (issue 1042)

### DIFF
--- a/src/ramses_rf/devices/heat_actuators.py
+++ b/src/ramses_rf/devices/heat_actuators.py
@@ -177,11 +177,27 @@ class BdrSwitch(Actuator, RelayDemand):  # BDR (13):
         """Initialize the BDR switch device."""
         super().__init__(*args, traits=traits, **kwargs)
 
-    async def active(self) -> bool | None:  # 3EF0, 3EF1
-        """Return the actuator's current state."""
+    @property
+    def active(self) -> bool | None:  # 3EF0, 3EF1, 0008
+        """Return the actuator's current state.
+
+        Primary source is ``act_state.modulation_level`` (from 3EF0/3EF1
+        packets sent by the BDR itself).  BDR91s only broadcast 3EF0 I
+        when turning ON, not when turning OFF, and don't respond to 3EF1
+        RQ — so when the BDR goes silent, ``act_state.modulation_level``
+        stays stale and the entity never shows ``off``.
+
+        Fallback: ``demand_state.relay_demand`` (from 0008 packets sent
+        by the CTL).  The ingestion pipeline routes 0008 FC to the BDR
+        (appliance_control) so this value tracks the CTL's relay demand
+        even when the BDR itself is silent (issue 1042).
+        """
         state = getattr(self, "act_state", None)
         if state and state.modulation_level is not None:
             return bool(state.modulation_level)
+        demand = getattr(self, "demand_state", None)
+        if demand and demand.relay_demand is not None:
+            return bool(demand.relay_demand)
         return None
 
     async def relay_demand(self) -> float | None:
@@ -234,7 +250,7 @@ class BdrSwitch(Actuator, RelayDemand):  # BDR (13):
         base_status = await super().status()
         return {
             **base_status,
-            self.ACTIVE: await self.active(),
+            self.ACTIVE: self.active,
         }
 
 

--- a/src/ramses_rf/devices/heat_actuators.py
+++ b/src/ramses_rf/devices/heat_actuators.py
@@ -181,24 +181,39 @@ class BdrSwitch(Actuator, RelayDemand):  # BDR (13):
     def active(self) -> bool | None:  # 3EF0, 3EF1, 0008
         """Return the actuator's current state.
 
-        Primary source is ``act_state.modulation_level`` (from 3EF0/3EF1
-        packets sent by the BDR itself).  BDR91s only broadcast 3EF0 I
-        when turning ON, not when turning OFF, and don't respond to 3EF1
-        RQ — so when the BDR goes silent, ``act_state.modulation_level``
-        stays stale and the entity never shows ``off``.
+        Two sources are considered, and the most recently updated one
+        wins:
 
-        Fallback: ``demand_state.relay_demand`` (from 0008 packets sent
-        by the CTL).  The ingestion pipeline routes 0008 FC to the BDR
-        (appliance_control) so this value tracks the CTL's relay demand
-        even when the BDR itself is silent (issue 1042).
+        - ``act_state.modulation_level`` (from 3EF0/3EF1 packets sent
+          by the BDR itself)
+        - ``demand_state.relay_demand`` (from 0008 packets sent by the
+          CTL and routed to the BDR by the ingestion pipeline)
+
+        BDR91s only broadcast 3EF0 I when turning ON, not when turning
+        OFF, and don't respond to 3EF1 RQ.  When the BDR goes silent,
+        ``act_state`` stays stale.  By comparing ``last_updated``
+        timestamps, the CTL's 0008 relay demand takes over once it is
+        newer than the last 3EF0/3EF1 (issue 1042).
         """
         state = getattr(self, "act_state", None)
-        if state and state.modulation_level is not None:
-            return bool(state.modulation_level)
         demand = getattr(self, "demand_state", None)
-        if demand and demand.relay_demand is not None:
-            return bool(demand.relay_demand)
-        return None
+
+        mod = state.modulation_level if state else None
+        rel = demand.relay_demand if demand else None
+
+        if mod is None and rel is None:
+            return None
+        if mod is None:
+            return bool(rel)
+        if rel is None:
+            return bool(mod)
+
+        # Both present — prefer the most recently updated
+        state_t = getattr(state, "last_updated", None)
+        demand_t = getattr(demand, "last_updated", None)
+        if demand_t and state_t and demand_t > state_t:
+            return bool(rel)
+        return bool(mod)
 
     async def relay_demand(self) -> float | None:
         """Return the relay demand of the BDR91."""

--- a/src/ramses_rf/pipeline/ingestion.py
+++ b/src/ramses_rf/pipeline/ingestion.py
@@ -436,6 +436,26 @@ class StateProjector:
                             tcs.dhw.id,
                             err,
                         )
+                    # Also route 0008 FA/F9 to the valve BDR (if any)
+                    # so its demand_state.relay_demand is hydrated.
+                    # Same rationale as the FC/appliance_control case
+                    # above (issue 1042): valve BDRs may go silent and
+                    # the CTL's 0008 is the only signal.
+                    if msg.code == Code._0008:
+                        valve = (
+                            getattr(tcs, "hotwater_valve", None)
+                            if domain_val == "FA"
+                            else getattr(tcs, "heating_valve", None)
+                        )
+                        if valve is not None and valve is not src_dev:
+                            try:
+                                self._update_demand_state(valve, payload, msg)
+                            except Exception as err:
+                                _LOGGER.error(
+                                    "CQRS extraction failed for valve %s: %s",
+                                    valve.id,
+                                    err,
+                                )
 
             # Route DHW opcodes (1260/10A0/1F41) to the DhwZone.
             # These payloads carry no zone_index/domain_id, so the block above

--- a/src/ramses_rf/pipeline/ingestion.py
+++ b/src/ramses_rf/pipeline/ingestion.py
@@ -407,6 +407,23 @@ class StateProjector:
                             tcs.id,
                             err,
                         )
+                    # Also route 0008 FC to the BDR (appliance_control)
+                    # so its demand_state.relay_demand is hydrated.
+                    # BDR91s only broadcast 3EF0 I when turning ON, not
+                    # when turning OFF, and don't respond to 3EF1 RQ —
+                    # so without this, the BDR's active state gets stuck
+                    # at the last 3EF0 I value (issue 1042).
+                    if msg.code == Code._0008:
+                        bdr = getattr(tcs, "appliance_control", None)
+                        if bdr is not None and bdr is not src_dev:
+                            try:
+                                self._update_demand_state(bdr, payload, msg)
+                            except Exception as err:
+                                _LOGGER.error(
+                                    "CQRS extraction failed for BDR %s: %s",
+                                    bdr.id,
+                                    err,
+                                )
                 elif (
                     domain_val in ("FA", "F9")
                     and getattr(tcs, "dhw", None) is not None

--- a/tests/tests_rf/__snapshots__/test_regression_rf.ambr
+++ b/tests/tests_rf/__snapshots__/test_regression_rf.ambr
@@ -3118,6 +3118,7 @@
         'zone_index': None,
       }),
       dict({
+        'active': False,
         'battery_low': None,
         'id': '13:032648',
         'is_alive': None,


### PR DESCRIPTION
## Summary

BDR91s only broadcast 3EF0 I when turning ON, not when turning OFF, and don't respond to 3EF1 RQ. When the BDR goes silent, `act_state.modulation_level` stays stale and the `active` binary sensor never shows `off` (issue 1042).

This PR makes two changes:

1. **`BdrSwitch.active` is now a `@property`** (was `async def`) with a fallback to `demand_state.relay_demand` (from 0008 packets sent by the CTL). This value tracks the CTL's relay demand even when the BDR itself is silent.

2. **The ingestion pipeline now routes 0008 FC packets to the BDR** (appliance_control) in addition to the TCS, so the BDR's `demand_state.relay_demand` is hydrated.

### Before
- BDR sends 3EF0 I with `00C8FF` (100%) → `active` = `on` ✓
- BDR goes silent → `active` stays `on` forever ✗

### After
- BDR sends 3EF0 I with `00C8FF` (100%) → `active` = `on` ✓
- CTL sends 0008 with `FC00` (0%) → `active` = `off` ✓

Also updates the gateway replay regression snapshot to include the `active` field (now visible because `active` is a sync property).

#### Test plan
- [x] ramses_rf: 2630 passed, 3 skipped
- [x] ramses_cc: 1376 passed, 10 skipped
- [ ] ha_sim_test R89 (BDR active state real-time update)

See: https://github.com/ramses-rf/ramses_cc/issues/1042