### PR TITLE
Revert "fix: BDR active state falls back to relay_demand when BDR is silent (1113)"

### DIFF
--- a/src/ramses_rf/devices/heat_actuators.py
+++ b/src/ramses_rf/devices/heat_actuators.py
@@ -177,43 +177,12 @@ class BdrSwitch(Actuator, RelayDemand):  # BDR (13):
         """Initialize the BDR switch device."""
         super().__init__(*args, traits=traits, **kwargs)
 
-    @property
-    def active(self) -> bool | None:  # 3EF0, 3EF1, 0008
-        """Return the actuator's current state.
-
-        Two sources are considered, and the most recently updated one
-        wins:
-
-        - ``act_state.modulation_level`` (from 3EF0/3EF1 packets sent
-          by the BDR itself)
-        - ``demand_state.relay_demand`` (from 0008 packets sent by the
-          CTL and routed to the BDR by the ingestion pipeline)
-
-        BDR91s only broadcast 3EF0 I when turning ON, not when turning
-        OFF, and don't respond to 3EF1 RQ.  When the BDR goes silent,
-        ``act_state`` stays stale.  By comparing ``last_updated``
-        timestamps, the CTL's 0008 relay demand takes over once it is
-        newer than the last 3EF0/3EF1 (issue 1042).
-        """
+    async def active(self) -> bool | None:  # 3EF0, 3EF1
+        """Return the actuator's current state."""
         state = getattr(self, "act_state", None)
-        demand = getattr(self, "demand_state", None)
-
-        mod = state.modulation_level if state else None
-        rel = demand.relay_demand if demand else None
-
-        if mod is None and rel is None:
-            return None
-        if mod is None:
-            return bool(rel)
-        if rel is None:
-            return bool(mod)
-
-        # Both present — prefer the most recently updated
-        state_t = getattr(state, "last_updated", None)
-        demand_t = getattr(demand, "last_updated", None)
-        if demand_t and state_t and demand_t > state_t:
-            return bool(rel)
-        return bool(mod)
+        if state and state.modulation_level is not None:
+            return bool(state.modulation_level)
+        return None
 
     async def relay_demand(self) -> float | None:
         """Return the relay demand of the BDR91."""
@@ -265,7 +234,7 @@ class BdrSwitch(Actuator, RelayDemand):  # BDR (13):
         base_status = await super().status()
         return {
             **base_status,
-            self.ACTIVE: self.active,
+            self.ACTIVE: await self.active(),
         }
 
 

--- a/src/ramses_rf/pipeline/ingestion.py
+++ b/src/ramses_rf/pipeline/ingestion.py
@@ -407,23 +407,6 @@ class StateProjector:
                             tcs.id,
                             err,
                         )
-                    # Also route 0008 FC to the BDR (appliance_control)
-                    # so its demand_state.relay_demand is hydrated.
-                    # BDR91s only broadcast 3EF0 I when turning ON, not
-                    # when turning OFF, and don't respond to 3EF1 RQ —
-                    # so without this, the BDR's active state gets stuck
-                    # at the last 3EF0 I value (issue 1042).
-                    if msg.code == Code._0008:
-                        bdr = getattr(tcs, "appliance_control", None)
-                        if bdr is not None and bdr is not src_dev:
-                            try:
-                                self._update_demand_state(bdr, payload, msg)
-                            except Exception as err:
-                                _LOGGER.error(
-                                    "CQRS extraction failed for BDR %s: %s",
-                                    bdr.id,
-                                    err,
-                                )
                 elif (
                     domain_val in ("FA", "F9")
                     and getattr(tcs, "dhw", None) is not None
@@ -436,26 +419,6 @@ class StateProjector:
                             tcs.dhw.id,
                             err,
                         )
-                    # Also route 0008 FA/F9 to the valve BDR (if any)
-                    # so its demand_state.relay_demand is hydrated.
-                    # Same rationale as the FC/appliance_control case
-                    # above (issue 1042): valve BDRs may go silent and
-                    # the CTL's 0008 is the only signal.
-                    if msg.code == Code._0008:
-                        valve = (
-                            getattr(tcs, "hotwater_valve", None)
-                            if domain_val == "FA"
-                            else getattr(tcs, "heating_valve", None)
-                        )
-                        if valve is not None and valve is not src_dev:
-                            try:
-                                self._update_demand_state(valve, payload, msg)
-                            except Exception as err:
-                                _LOGGER.error(
-                                    "CQRS extraction failed for valve %s: %s",
-                                    valve.id,
-                                    err,
-                                )
 
             # Route DHW opcodes (1260/10A0/1F41) to the DhwZone.
             # These payloads carry no zone_index/domain_id, so the block above

--- a/tests/tests_rf/__snapshots__/test_regression_rf.ambr
+++ b/tests/tests_rf/__snapshots__/test_regression_rf.ambr
@@ -3118,7 +3118,6 @@
         'zone_index': None,
       }),
       dict({
-        'active': False,
         'battery_low': None,
         'id': '13:032648',
         'is_alive': None,


### PR DESCRIPTION
Reverts ramses-rf/ramses_rf#1113 as discussed