### PR TITLE
fix: normalise RSSI to signed dBm in packet parser

### DIFF
--- a/src/ramses_tx/packet.py
+++ b/src/ramses_tx/packet.py
@@ -23,6 +23,42 @@ from .typing import HeaderT, PayloadT
 _LOGGER = logging.getLogger(__name__)
 PKT_LOGGER = getLogger(f"{__name__}_log", packet_log=True)
 
+# evofw3/ramses_esp output unsigned positive (10–138, negated CC1101
+# signed byte).  Values > 138 are signed-as-unsigned from custom
+# firmware (e.g. 202 = -54 dBm).  See ramses-rf/ramses_cc#1046.
+_RSSI_UNSIGNED_MAX = 138
+
+
+def _normalise_rssi(raw: str) -> str:
+    """Normalise an RSSI string to signed dBm.
+
+    Accepts three input formats and returns signed dBm:
+
+    - ``074`` (unsigned positive, evofw3/ramses_esp/HGI80) → ``-74``
+    - ``202`` (signed-as-unsigned, custom firmware) → ``-54``
+    - ``-54`` (already signed dBm) → ``-54``
+
+    Sentinel values (``...``, ``---``, ``///``) are returned as-is.
+
+    :param raw: 3-character RSSI string from the raw packet line.
+    :returns: Normalised RSSI string in signed dBm.
+    """
+    if not raw or raw in ("...", "---", "///"):
+        return raw
+    with contextlib.suppress(ValueError):
+        val = int(raw)
+        if val == 0:
+            return "..."
+        if val > _RSSI_UNSIGNED_MAX:
+            # Signed-as-unsigned (custom firmware): 202 → -54
+            return str(val - 256)
+        if val >= 0:
+            # Unsigned positive (evofw3/ramses_esp/HGI80): 074 → -74
+            return str(-val)
+        # Already signed dBm
+        return raw
+    return raw
+
 
 class Packet:
     """Stateful L3 transport envelope wrapping an immutable PacketDTO.
@@ -221,9 +257,13 @@ class Packet:
         if (
             len(line) >= 4
             and line[3] == " "
-            and (line[:3].isdigit() or line[:3] in ("...", "---", "///"))
+            and (
+                line[:3].isdigit()
+                or line[:3] in ("...", "---", "///")
+                or (line[0] == "-" and line[1:3].isdigit())
+            )
         ):
-            rssi = line[:3]
+            rssi = _normalise_rssi(line[:3])
             raw_line_body = line[4:]
         else:
             rssi = "..."
@@ -794,9 +834,21 @@ class Packet:
 
         rssi_val = state.get("rssi")
         try:
-            rssi = f"{int(rssi_val):03d}" if rssi_val is not None else "..."
+            rssi_int = int(rssi_val) if rssi_val is not None else None
         except (ValueError, TypeError):
+            rssi_int = None
+
+        if rssi_int is None or rssi_int == 0:
             rssi = "..."
+        elif rssi_int > _RSSI_UNSIGNED_MAX:
+            # Signed-as-unsigned (custom firmware): 202 → -54
+            rssi = str(rssi_int - 256)
+        elif rssi_int > 0:
+            # Unsigned positive (evofw3/ramses_esp/HGI80): 74 → -74
+            rssi = str(-rssi_int)
+        else:
+            # Already signed dBm (negative)
+            rssi = str(rssi_int)
 
         frame_body = state.get("frame") or state.get("raw_packet", "")
         raw_line = f"{rssi[:3].ljust(3)} {frame_body}"
@@ -822,7 +874,9 @@ class Packet:
                 )
             dto = PacketDTO(
                 timestamp=dt.fromisoformat(raw["timestamp"]),
-                rssi=raw.get("rssi", ""),
+                rssi=str(raw.get("rssi", ""))
+                if raw.get("rssi") is not None
+                else "",
                 verb=raw.get("verb", ""),
                 seq=raw.get("seq", ""),
                 addr1=raw.get("addr1", ""),

--- a/tests/tests_rf/test_gateway.py
+++ b/tests/tests_rf/test_gateway.py
@@ -226,7 +226,7 @@ async def test_gateway_restore_cached_packets_dto() -> None:
         # Mock the packet returned by from_dict to bypass strict frame regex
         mock_packet = MagicMock()
         mock_packet.__class__.__name__ = "Packet"
-        mock_packet.rssi = "045"
+        mock_packet.rssi = "-45"
         mock_packet._frame = (
             "I --- 01:145038 --:------ 01:145038 1F09 003 0004B5"
         )
@@ -235,7 +235,7 @@ async def test_gateway_restore_cached_packets_dto() -> None:
         # Simulate the new dictionary format provided by ramses_cc
         packets = {
             "2023-01-01T12:00:00.000000Z": {
-                "rssi": 45,
+                "rssi": -45,
                 "frame": "I --- 01:145038 --:------ 01:145038 1F09 003 0004B5",
             }
         }
@@ -271,7 +271,7 @@ async def test_gateway_restore_cached_packets_naive_dtm() -> None:
 
         mock_packet = MagicMock()
         mock_packet.__class__.__name__ = "Packet"
-        mock_packet.rssi = "045"
+        mock_packet.rssi = "-45"
         mock_packet._frame = (
             "I --- 01:145038 --:------ 01:145038 1F09 003 0004B5"
         )
@@ -280,7 +280,7 @@ async def test_gateway_restore_cached_packets_naive_dtm() -> None:
         # Naive datetime (no Z, no offset) as written by older cache files
         packets = {
             "2023-01-01T12:00:00.000000": {
-                "rssi": 45,
+                "rssi": -45,
                 "frame": "I --- 01:145038 --:------ 01:145038 1F09 003 0004B5",
             }
         }

--- a/tests/tests_rf/test_hcc100_cooling.py
+++ b/tests/tests_rf/test_hcc100_cooling.py
@@ -380,7 +380,7 @@ async def test_gateway_cached_packet_restore_hcc100_active_cooling() -> None:
 
         cached_packets = {
             "2026-08-15T12:00:00.000000Z": {
-                "rssi": 45,
+                "rssi": -45,
                 "frame": f" I --- {ctl_id} --:------ {ctl_id} 2D49 003 00C800",
             },
         }
@@ -409,7 +409,7 @@ async def test_gateway_cached_packet_restore_hcc100_inactive_cooling() -> None:
 
         cached_packets = {
             "2026-08-15T12:00:00.000000Z": {
-                "rssi": 45,
+                "rssi": -45,
                 "frame": f" I --- {ctl_id} --:------ {ctl_id} 2D49 003 010000",
             },
         }

--- a/tests/tests_tx/test_dtos.py
+++ b/tests/tests_tx/test_dtos.py
@@ -23,7 +23,7 @@ def test_packet_to_dto_populates_all_fields_accurately() -> None:
     # Assert: Verify all primitive strings are accurately separated
     assert isinstance(dto, PacketDTO)
     assert dto.timestamp == test_dtm
-    assert dto.rssi == "045"
+    assert dto.rssi == "-45"
     assert dto.verb == Verb.RQ
     assert dto.seq == ""
     assert dto.addr1 == "18:000730"
@@ -60,7 +60,7 @@ def test_packet_dto_is_tx_default_and_custom() -> None:
     # Act: Construct default inbound DTO and custom outbound DTO
     inbound_dto = PacketDTO(
         timestamp=test_dtm,
-        rssi="045",
+        rssi="-45",
         verb=Verb.RQ,
         seq="",
         addr1="18:000730",
@@ -72,7 +72,7 @@ def test_packet_dto_is_tx_default_and_custom() -> None:
     )
     outbound_dto = PacketDTO(
         timestamp=test_dtm,
-        rssi="045",
+        rssi="-45",
         verb=Verb.RQ,
         seq="",
         addr1="18:000730",

--- a/tests/tests_tx/test_engine.py
+++ b/tests/tests_tx/test_engine.py
@@ -23,7 +23,7 @@ def mock_dto() -> PacketDTO:
     # Create a fresh mock packet DTO for tests
     return PacketDTO(
         timestamp=dt.now(),
-        rssi="045",
+        rssi="-45",
         verb=Verb.RQ,
         seq="---",
         addr1="18:006402",
@@ -254,7 +254,7 @@ async def test_engine_drop_msg(
     # The drop handler safely drops messages and logs them
     dto = PacketDTO(
         timestamp=dt.now(),
-        rssi="045",
+        rssi="-45",
         verb=Verb.RQ,
         seq="---",
         addr1="18:006402",

--- a/tests/tests_tx/test_message.py
+++ b/tests/tests_tx/test_message.py
@@ -56,7 +56,7 @@ def test_message_attributes(patch_parsers: Any) -> None:
     message = Message(packet.to_dto())
 
     # Validate physical attributes
-    assert message.rssi == "045"
+    assert message.rssi == "-45"
     assert message.dtm == dtm
 
     # Validate payload properties
@@ -79,7 +79,7 @@ def test_message_parsing_and_rssi(patch_parsers: Any) -> None:
     packet = Packet(dtm, FRAME_STR_2)
     message = Message(packet.to_dto())
 
-    assert message.rssi == "095"
+    assert message.rssi == "-95"
     assert message.verb == Verb.I_
     assert message.code == Code._1F09
     assert message.len == 3

--- a/tests/tests_tx/test_packet.py
+++ b/tests/tests_tx/test_packet.py
@@ -38,7 +38,7 @@ def test_packet_properties() -> None:
     packet = Packet(DTM, VALID_FRAME_I, comment="A test comment")
 
     assert packet.dtm == DTM
-    assert packet.rssi == "045"
+    assert packet.rssi == "-45"
     assert packet.comment == "A test comment"
     assert packet.error_text == ""
     assert packet.verb == Verb.I_
@@ -89,22 +89,22 @@ def test_packet_constructors() -> None:
     # Test from_dict with legacy string (backward compatibility)
     packet_dict = Packet.from_dict(dtm_str, f"{VALID_FRAME_I} # my comment")
     assert packet_dict.dtm == DTM
-    assert packet_dict.rssi == "045"
+    assert packet_dict.rssi == "-45"
     assert packet_dict.comment == "my comment"
 
     # Test canonical from_raw_line factory
     packet_line = Packet.from_raw_line(DTM, VALID_FRAME_I)
-    assert packet_line.rssi == "045"
+    assert packet_line.rssi == "-45"
     assert packet_line.verb == Verb.I_
 
     # Test from_file (delegates to from_raw_line)
     packet_file_valid = Packet.from_file(dtm_str, VALID_FRAME_I)
-    assert packet_file_valid.rssi == "045"
+    assert packet_file_valid.rssi == "-45"
     assert packet_file_valid.verb == Verb.I_
 
     # Test from_port (delegates to from_raw_line)
     packet_port = Packet.from_port(DTM, VALID_FRAME_I)
-    assert packet_port.rssi == "045"
+    assert packet_port.rssi == "-45"
 
     # Test _from_cmd
     cmd = MockCommand()
@@ -132,8 +132,8 @@ def test_packet_dto_serialization() -> None:
     assert packet_dict["verb"] == Verb.I_
     assert packet_dict["code"] == Code._1F09
     assert (
-        packet_dict["rssi"] == 45
-    )  # Intentionally mapped to int for legacy downstream compatibility
+        packet_dict["rssi"] == -45
+    )  # Signed dBm (normalised from unsigned 045)
     assert (
         packet_dict["frame"]
         == " I --- 01:145038 --:------ 01:145038 1F09 003 0004B5"
@@ -149,7 +149,7 @@ def test_packet_dto_serialization() -> None:
 
     assert restored_packet.dtm == DTM.astimezone()
     assert (
-        restored_packet.rssi == "045"
+        restored_packet.rssi == "-45"
     )  # Automatically padded back to 3 chars
     assert restored_packet.verb == Verb.I_
     assert restored_packet._frame == packet._frame
@@ -166,7 +166,7 @@ def test_to_json_from_json_parity() -> None:
     # 2. Test from_json (Deserialization back to Packet)
     restored_packet = Packet.from_json(json_bytes)
     assert restored_packet.dtm == DTM.astimezone()
-    assert restored_packet.rssi == "045"
+    assert restored_packet.rssi == "-45"
     assert restored_packet.verb == Verb.I_
     assert restored_packet._frame == packet._frame
 
@@ -183,7 +183,7 @@ def test_from_dict_raw_packet_dict_format() -> None:
     # Simulate what lifecycle.get_state saves: msg.dto.source_packets[0].__dict__
     raw_packet_dict: dict[str, object] = {
         "raw_packet": " I --- 01:145038 --:------ 01:145038 1F09 003 0004B5",
-        "rssi": "045",
+        "rssi": "-45",
         "verb": Verb.I_,
         "seq": "---",
         "device_id_1": "01:145038",
@@ -195,7 +195,7 @@ def test_from_dict_raw_packet_dict_format() -> None:
     }
 
     packet = Packet.from_dict(dtm_str, raw_packet_dict)
-    assert packet.rssi == "045"
+    assert packet.rssi == "-45"
     assert packet.verb == Verb.I_
     assert packet.code == Code._1F09
     assert (
@@ -269,3 +269,65 @@ def test_packet_heartbeat_payload_bypass() -> None:
     # As explicitly designed to preserve legacy test suite behavior, _has_payload remains
     # False (as it fails the strict regex), but the packet instantiation survives.
     assert packet._has_payload is False
+
+
+def test_rssi_normalisation() -> None:
+    """Test that RSSI values are normalised to signed dBm.
+
+    Covers three input formats (issue ramses-rf/ramses_cc#1046):
+
+    - Unsigned positive (evofw3/ramses_esp/HGI80): ``074`` → ``-74``
+    - Signed-as-unsigned (custom firmware): ``202`` → ``-54``
+    - Already signed dBm: ``-54`` → ``-54``
+
+    :return: None
+    """
+    from ramses_tx.packet import _normalise_rssi
+
+    # Sentinels pass through
+    assert _normalise_rssi("...") == "..."
+    assert _normalise_rssi("---") == "---"
+    assert _normalise_rssi("///") == "///"
+    assert _normalise_rssi("") == ""
+
+    # Unsigned positive (evofw3/HGI80): 074 → -74
+    assert _normalise_rssi("074") == "-74"
+    assert _normalise_rssi("045") == "-45"
+    assert _normalise_rssi("095") == "-95"
+    assert _normalise_rssi("138") == "-138"
+
+    # Signed-as-unsigned (custom firmware): 202 → -54
+    assert _normalise_rssi("202") == "-54"
+    assert _normalise_rssi("200") == "-56"
+    assert _normalise_rssi("256") == "0"
+
+    # Already signed dBm: -54 → -54
+    assert _normalise_rssi("-54") == "-54"
+    assert _normalise_rssi("-72") == "-72"
+
+    # Zero → no signal sentinel
+    assert _normalise_rssi("000") == "..."
+
+
+def test_rssi_signed_in_raw_line() -> None:
+    """Test that signed RSSI values are accepted in raw packet lines.
+
+    Custom firmware may output ``-54`` (with minus sign) instead of
+    the standard unsigned ``074``.  The parser must accept both.
+
+    :return: None
+    """
+    # Signed RSSI in raw line
+    frame = "-54  I --- 01:145038 --:------ 01:145038 1F09 003 0004B5"
+    packet = Packet(DTM, frame)
+    assert packet.rssi == "-54"
+
+    # Unsigned positive in raw line (normalised to signed)
+    frame2 = "074  I --- 01:145038 --:------ 01:145038 1F09 003 0004B5"
+    packet2 = Packet(DTM, frame2)
+    assert packet2.rssi == "-74"
+
+    # Signed-as-unsigned in raw line (normalised to signed)
+    frame3 = "202  I --- 01:145038 --:------ 01:145038 1F09 003 0004B5"
+    packet3 = Packet(DTM, frame3)
+    assert packet3.rssi == "-54"


### PR DESCRIPTION
## Summary

- Normalise RSSI to signed dBm at parse time, accepting all three input formats:
  - Unsigned positive (evofw3/ramses_esp/HGI80): `074` → `-74`
  - Signed-as-unsigned (custom firmware): `202` → `-54`
  - Already signed dBm: `-54` → `-54`
- Zero (`000`) is treated as no signal (`...`)
- Values above 138 (evofw3's theoretical max) are auto-detected as signed-as-unsigned

This aligns with the `PacketDTO` target format in the architecture blueprint (issue 639: `rssi: str  # e.g., "-72"`).

The parser previously only accepted 3 unsigned digits, rejecting signed values from custom gateway firmware (e.g. ESP-IDF reimplementations that output the raw CC1101 signed byte).

Prerequisite for the RSSI communication quality tracker (ramses-rf/ramses_cc#1047), which needs consistent units for threshold comparison.

See: https://github.com/ramses-rf/ramses_cc/issues/1046

#### Test plan

- [x] `pytest tests/tests_tx/` — 311 passed
- [x] `pytest tests/tests_rf/` — 2242 passed, 3 skipped
- [x] `pytest tests/` (full suite) — 2632 passed, 3 skipped
- [x] `ruff check` + `mypy --strict` — clean
- [x] `ha_sim_test R89` — 5/5 passed
- [x] New unit tests: `test_rssi_normalisation`, `test_rssi_signed_in_raw_line`