### PR TITLE
feat: RSSI communication quality tracker (issue 1047)

### DIFF
--- a/src/ramses_rf/devices/dev_base.py
+++ b/src/ramses_rf/devices/dev_base.py
@@ -32,6 +32,7 @@ from ramses_rf.models import (
     PowerState,
     TemperatureState,
 )
+from ramses_rf.models.state_signal import CommunicationQuality, compute_quality
 from ramses_rf.schemas import (
     SZ_ALIAS,
     SZ_CLASS,
@@ -158,6 +159,26 @@ class DeviceBase(Entity):
             now = dt.now()
 
         return bool((now - self._last_msg_dtm) <= self.heartbeat_timeout)
+
+    @property
+    def communication_quality(self) -> CommunicationQuality | None:
+        """Return the device's communication quality snapshot, or None.
+
+        Computes ``best_rssi`` across all HGI RSSI trackers and
+        staleness from the device's last message timestamp.  Returns
+        ``None`` if the gateway has no RSSI tracker (e.g. during
+        tests without a real gateway).
+
+        :return: Communication quality snapshot, or ``None``.
+        :rtype: CommunicationQuality | None
+        """
+        gwy = getattr(self, "_gateway", None)
+        if gwy is None:
+            return None
+        tracker = getattr(gwy, "_rssi_tracker", None)
+        if tracker is None:
+            return None
+        return compute_quality(str(self.id), [tracker])
 
     def _update_traits(self, traits: DeviceTraits) -> None:
         """Update a device with new schema attributes.

--- a/src/ramses_rf/gateway.py
+++ b/src/ramses_rf/gateway.py
@@ -23,6 +23,7 @@ from ramses_tx.const import (
 )
 from ramses_tx.dtos import PacketDTO
 from ramses_tx.exceptions import PacketInvalid, ProtocolSendFailed
+from ramses_tx.rssi_tracker import RssiTracker
 from ramses_tx.schemas import (
     SZ_BLOCK_LIST,
     SZ_ENFORCE_KNOWN_LIST,
@@ -203,6 +204,10 @@ class Gateway(GatewayLifecycle, GatewayInterface):
             on_topology_changed_cb=self._on_topology_changed,
         )
 
+        # RSSI tracker for this HGI (transport layer, per issue 1047).
+        # One tracker per gateway/HGI; multi-HGI support will add more.
+        self._rssi_tracker: RssiTracker = RssiTracker()
+
         # Instantiate the new asynchronous Topology Builder engine
         self._topology_builder = TopologyBuilder(
             emit_event_cb=self._device_registry.handle_topology_event,
@@ -275,6 +280,15 @@ class Gateway(GatewayLifecycle, GatewayInterface):
     def device_registry(self) -> DeviceRegistryInterface:
         """Return the active device registry instance."""
         return self._device_registry
+
+    @property
+    def rssi_tracker(self) -> RssiTracker:
+        """Return the RSSI tracker for this HGI (transport layer).
+
+        Tracks the last N RSSI readings per device heard by this
+        gateway's receiver (issue 1047).
+        """
+        return self._rssi_tracker
 
     @property
     def conversation_manager(self) -> ConversationManager:

--- a/src/ramses_rf/models/state_signal.py
+++ b/src/ramses_rf/models/state_signal.py
@@ -1,0 +1,141 @@
+"""Communication quality read-model (domain layer, per device).
+
+Computes per-device communication quality from transport-layer RSSI
+data.  The domain layer queries the HGI-side ``RssiTracker`` to
+determine ``best_rssi`` — the strongest recent signal across all
+HGIs that have heard the device.
+
+This is a **read model**, not stored state: it is computed on demand
+from the transport-layer RSSI trackers.  The domain entity holds a
+reference to the tracker(s) and computes quality lazily.
+
+Staleness (time since last transmission) is also tracked here, as it
+is a domain concern — the device entity knows when it was last heard.
+
+See: https://github.com/ramses-rf/ramses_cc/issues/1047
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import UTC, datetime as dt
+from typing import TYPE_CHECKING, Final
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+    from ramses_tx.rssi_tracker import RssiTracker
+
+
+# RSSI thresholds in dBm (signed, after issue 1046 normalisation).
+# These are advisory — callers may use their own thresholds.
+RSSI_STRONG: Final[int] = -60  # >= -60 dBm: close to HGI
+RSSI_NORMAL: Final[int] = -75  # -60 to -75: typical Evohome distances
+RSSI_WEAK: Final[int] = -95  # -75 to -95: weak but usable
+# < -95: very weak, likely to miss transmissions
+
+# Staleness thresholds (seconds).
+STALE_WARN_SECONDS: Final[int] = 300  # 5 min: no recent transmission
+STALE_CRITICAL_SECONDS: Final[int] = 1800  # 30 min: likely comms issue
+
+
+@dataclass(frozen=True, slots=True)
+class CommunicationQuality:
+    """Snapshot of a device's communication quality.
+
+    Computed from transport-layer RSSI trackers and the device's last
+    message timestamp.  This is an immutable snapshot — create a new
+    instance each time quality is evaluated.
+
+    :param best_rssi: Strongest recent RSSI across all HGIs (dBm),
+        or ``None`` if no HGI has heard the device.
+    :param last_seen: Timestamp of the most recent packet from this
+        device across all HGIs, or ``None``.
+    :param rssi_quality: Qualitative label: ``"strong"``, ``"normal"``,
+        ``"weak"``, ``"very_weak"``, or ``"unknown"``.
+    :param is_stale: True if the device has not been heard recently.
+    :param staleness_seconds: Seconds since last transmission, or
+        ``None`` if never heard.
+    """
+
+    best_rssi: int | None
+    last_seen: dt | None
+    rssi_quality: str
+    is_stale: bool
+    staleness_seconds: float | None
+
+
+def _rssi_quality_label(rssi: int | None) -> str:
+    """Map an RSSI value to a qualitative label.
+
+    :param rssi: RSSI in dBm (negative), or ``None``.
+    :returns: One of ``"strong"``, ``"normal"``, ``"weak"``,
+        ``"very_weak"``, or ``"unknown"``.
+    """
+    if rssi is None:
+        return "unknown"
+    if rssi >= RSSI_STRONG:
+        return "strong"
+    if rssi >= RSSI_NORMAL:
+        return "normal"
+    if rssi >= RSSI_WEAK:
+        return "weak"
+    return "very_weak"
+
+
+def compute_quality(
+    device_id: str,
+    trackers: Sequence[RssiTracker],
+    *,
+    now: dt | None = None,
+    stale_warn_seconds: int = STALE_WARN_SECONDS,
+) -> CommunicationQuality:
+    """Compute communication quality for a device across all HGIs.
+
+    Queries each HGI's ``RssiTracker`` for the best recent RSSI for
+    the device, then takes the best (strongest) across all HGIs.
+    Staleness is determined from the most recent timestamp across
+    all trackers.
+
+    :param device_id: The device to evaluate.
+    :param trackers: RSSI trackers from all active HGIs.
+    :param now: Reference timestamp (defaults to current UTC).
+    :param stale_warn_seconds: Seconds of silence before staleness
+        warning.
+    :returns: An immutable ``CommunicationQuality`` snapshot.
+    """
+    if now is None:
+        now = dt.now(UTC)
+
+    best_rssi: int | None = None
+    last_seen: dt | None = None
+
+    for tracker in trackers:
+        rssi = tracker.best_rssi_for(device_id)
+        if rssi is not None:
+            if best_rssi is None or rssi > best_rssi:
+                best_rssi = rssi
+
+        seen = tracker.last_seen(device_id)
+        if seen is not None:
+            if last_seen is None or seen > last_seen:
+                last_seen = seen
+
+    staleness_seconds: float | None = None
+    is_stale = False
+    if last_seen is not None:
+        # Handle both tz-aware and tz-naive timestamps
+        if last_seen.tzinfo is not None:
+            delta = now - last_seen
+        else:
+            delta = now.replace(tzinfo=None) - last_seen
+        staleness_seconds = delta.total_seconds()
+        is_stale = staleness_seconds > stale_warn_seconds
+
+    return CommunicationQuality(
+        best_rssi=best_rssi,
+        last_seen=last_seen,
+        rssi_quality=_rssi_quality_label(best_rssi),
+        is_stale=is_stale,
+        staleness_seconds=staleness_seconds,
+    )

--- a/src/ramses_rf/state_projector.py
+++ b/src/ramses_rf/state_projector.py
@@ -951,6 +951,13 @@ async def process_state_updates(gateway: Gateway, msg: Message) -> None:
             ):
                 bm.rcvd_msg(msg)
 
+    # Record RSSI for the source device in the HGI's tracker
+    # (issue 1047: transport-layer RSSI tracking per HGI).
+    if tracker := getattr(gateway, "_rssi_tracker", None):
+        src_id = getattr(msg.src, "id", None)
+        if src_id and msg.rssi and msg.rssi not in ("...", "---", "///"):
+            tracker.record(src_id, msg.rssi, msg.dtm)
+
     if not isinstance(msg.payload, (dict, list)):
         return
 

--- a/src/ramses_tx/rssi_tracker.py
+++ b/src/ramses_tx/rssi_tracker.py
@@ -1,0 +1,136 @@
+"""RSSI tracking per HGI (transport layer).
+
+Tracks the last N RSSI readings per device that the HGI (gateway's
+CC1101 receiver) has heard.  RSSI is a L1/L2 measurement made by the
+receiver, not the sender, so it lives on the transport side.
+
+The tracker maintains a small ring buffer per device (default 3
+readings).  This is intentionally **not** a running average or EMA —
+a flat window of the last N readings is predictable, time-agnostic,
+and handles both degradation and recovery cleanly.
+
+See: https://github.com/ramses-rf/ramses_cc/issues/1047
+"""
+
+from __future__ import annotations
+
+from collections import deque
+from datetime import datetime as dt
+from typing import Final
+
+# Default window size — last N RSSI readings per device.
+# A small window (3) balances responsiveness with noise immunity.
+DEFAULT_WINDOW_SIZE: Final[int] = 3
+
+# Sentinel RSSI values that carry no signal information.
+_RSSI_SENTINELS: Final[frozenset[str]] = frozenset({"", "...", "---", "///"})
+
+
+class RssiTracker:
+    """Per-HGI RSSI tracker maintaining the last N readings per device.
+
+    Lives on the transport side (one instance per HGI/gateway).  The
+    domain layer queries ``best_rssi_for(device_id)`` to compute
+    communication quality across all HGIs.
+
+    :param window_size: Number of recent readings to retain per device.
+    """
+
+    __slots__ = ("_window_size", "_readings")
+
+    def __init__(self, window_size: int = DEFAULT_WINDOW_SIZE) -> None:
+        """Initialise the tracker.
+
+        :param window_size: Readings to keep per device (default 3).
+        """
+        if window_size < 1:
+            raise ValueError("window_size must be >= 1")
+        self._window_size: int = window_size
+        # device_id -> deque of (rssi_dBm, timestamp)
+        self._readings: dict[str, deque[tuple[int, dt]]] = {}
+
+    def record(self, device_id: str, rssi: str | int, timestamp: dt) -> None:
+        """Record an RSSI reading for a device.
+
+        Silently ignores sentinel values (``...``, ``---``, etc.) and
+        unparsable strings — these carry no signal information.
+
+        :param device_id: The device that was heard (source address).
+        :param rssi: RSSI value as string (from PacketDTO) or int.
+        :param timestamp: When the packet was received.
+        """
+        dBm = _parse_rssi(rssi)
+        if dBm is None:
+            return
+
+        buf = self._readings.get(device_id)
+        if buf is None:
+            buf = deque(maxlen=self._window_size)
+            self._readings[device_id] = buf
+        buf.append((dBm, timestamp))
+
+    def best_rssi_for(self, device_id: str) -> int | None:
+        """Return the strongest (highest) RSSI from the last N readings.
+
+        :param device_id: The device to query.
+        :returns: Best RSSI in dBm (negative), or ``None`` if no
+            readings exist for the device.
+        """
+        buf = self._readings.get(device_id)
+        if not buf:
+            return None
+        return max(rssi for rssi, _ in buf)
+
+    def last_seen(self, device_id: str) -> dt | None:
+        """Return the timestamp of the most recent reading for a device.
+
+        :param device_id: The device to query.
+        :returns: Timestamp of last reading, or ``None``.
+        """
+        buf = self._readings.get(device_id)
+        if not buf:
+            return None
+        return buf[-1][1]
+
+    def readings_for(self, device_id: str) -> list[int]:
+        """Return the raw list of recent RSSI readings for a device.
+
+        :param device_id: The device to query.
+        :returns: List of recent RSSI values in dBm (oldest first),
+            or an empty list.
+        """
+        buf = self._readings.get(device_id)
+        if not buf:
+            return []
+        return [rssi for rssi, _ in buf]
+
+    def known_devices(self) -> frozenset[str]:
+        """Return the set of device IDs that have at least one reading.
+
+        :returns: Frozenset of device IDs with recorded RSSI data.
+        """
+        return frozenset(self._readings)
+
+    def clear(self) -> None:
+        """Clear all recorded readings."""
+        self._readings.clear()
+
+
+def _parse_rssi(rssi: str | int) -> int | None:
+    """Parse an RSSI value to signed dBm int.
+
+    Accepts signed dBm (already normalised by ``packet.py``) as either
+    a string (``"-74"``) or int (``-74``).  Sentinel values and
+    unparsable strings return ``None``.
+
+    :param rssi: RSSI value from PacketDTO or caller.
+    :returns: Signed dBm int, or ``None`` if no signal info.
+    """
+    if isinstance(rssi, int):
+        return rssi
+    if not isinstance(rssi, str) or rssi in _RSSI_SENTINELS:
+        return None
+    try:
+        return int(rssi)
+    except ValueError:
+        return None

--- a/tests/tests_rf/test_communication_quality.py
+++ b/tests/tests_rf/test_communication_quality.py
@@ -1,0 +1,246 @@
+"""Tests for the CommunicationQuality read-model (domain layer).
+
+See: https://github.com/ramses-rf/ramses_cc/issues/1047
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime as dt, timedelta as td
+
+from ramses_rf.models.state_signal import (
+    RSSI_NORMAL,
+    RSSI_STRONG,
+    RSSI_WEAK,
+    STALE_WARN_SECONDS,
+    CommunicationQuality,
+    compute_quality,
+)
+from ramses_tx.rssi_tracker import RssiTracker
+
+
+class TestComputeQuality:
+    """Unit tests for compute_quality."""
+
+    def test_single_hgi_strong_signal(self) -> None:
+        """Strong RSSI from one HGI → strong quality."""
+        now = dt(2026, 1, 1, 12, 0, 0, tzinfo=UTC)
+        tracker = RssiTracker()
+        tracker.record("04:123456", "-55", now)
+
+        q = compute_quality("04:123456", [tracker], now=now)
+        assert q.best_rssi == -55
+        assert q.rssi_quality == "strong"
+        assert q.is_stale is False
+        assert q.staleness_seconds == 0.0
+        assert q.last_seen == now
+
+    def test_single_hgi_normal_signal(self) -> None:
+        """Normal RSSI → normal quality."""
+        now = dt(2026, 1, 1, 12, 0, 0, tzinfo=UTC)
+        tracker = RssiTracker()
+        tracker.record("04:123456", "-70", now)
+
+        q = compute_quality("04:123456", [tracker], now=now)
+        assert q.best_rssi == -70
+        assert q.rssi_quality == "normal"
+
+    def test_single_hgi_weak_signal(self) -> None:
+        """Weak RSSI → weak quality."""
+        now = dt(2026, 1, 1, 12, 0, 0, tzinfo=UTC)
+        tracker = RssiTracker()
+        tracker.record("04:123456", "-90", now)
+
+        q = compute_quality("04:123456", [tracker], now=now)
+        assert q.best_rssi == -90
+        assert q.rssi_quality == "weak"
+
+    def test_single_hgi_very_weak_signal(self) -> None:
+        """Very weak RSSI → very_weak quality."""
+        now = dt(2026, 1, 1, 12, 0, 0, tzinfo=UTC)
+        tracker = RssiTracker()
+        tracker.record("04:123456", "-110", now)
+
+        q = compute_quality("04:123456", [tracker], now=now)
+        assert q.best_rssi == -110
+        assert q.rssi_quality == "very_weak"
+
+    def test_no_data(self) -> None:
+        """No readings → unknown quality, no staleness."""
+        now = dt(2026, 1, 1, 12, 0, 0, tzinfo=UTC)
+        tracker = RssiTracker()
+
+        q = compute_quality("04:123456", [tracker], now=now)
+        assert q.best_rssi is None
+        assert q.rssi_quality == "unknown"
+        assert q.is_stale is False
+        assert q.staleness_seconds is None
+        assert q.last_seen is None
+
+    def test_multi_hgi_best_across_all(self) -> None:
+        """Best RSSI across multiple HGIs is the strongest."""
+        now = dt(2026, 1, 1, 12, 0, 0, tzinfo=UTC)
+        tracker_a = RssiTracker()
+        tracker_b = RssiTracker()
+
+        # HGI A hears device weakly
+        tracker_a.record("04:123456", "-90", now)
+        tracker_a.record("04:123456", "-88", now)
+
+        # HGI B hears device strongly
+        tracker_b.record("04:123456", "-55", now)
+        tracker_b.record("04:123456", "-57", now)
+
+        q = compute_quality("04:123456", [tracker_a, tracker_b], now=now)
+        assert q.best_rssi == -55  # best across both HGIs
+        assert q.rssi_quality == "strong"
+
+    def test_multi_hgi_one_weak_one_strong(self) -> None:
+        """One HGI weak, one strong → no warning (best wins)."""
+        now = dt(2026, 1, 1, 12, 0, 0, tzinfo=UTC)
+        tracker_a = RssiTracker()
+        tracker_b = RssiTracker()
+
+        tracker_a.record("04:123456", "-100", now)
+        tracker_b.record("04:123456", "-60", now)
+
+        q = compute_quality("04:123456", [tracker_a, tracker_b], now=now)
+        assert q.best_rssi == -60
+        assert q.rssi_quality == "strong"
+
+    def test_multi_hgi_all_weak(self) -> None:
+        """All HGIs weak → warning (best is still weak)."""
+        now = dt(2026, 1, 1, 12, 0, 0, tzinfo=UTC)
+        tracker_a = RssiTracker()
+        tracker_b = RssiTracker()
+
+        tracker_a.record("04:123456", "-100", now)
+        tracker_b.record("04:123456", "-98", now)
+
+        q = compute_quality("04:123456", [tracker_a, tracker_b], now=now)
+        assert q.best_rssi == -98
+        assert q.rssi_quality == "very_weak"
+
+    def test_staleness_fresh(self) -> None:
+        """Recent packet → not stale."""
+        now = dt(2026, 1, 1, 12, 0, 0, tzinfo=UTC)
+        tracker = RssiTracker()
+        tracker.record("04:123456", "-70", now)
+
+        q = compute_quality("04:123456", [tracker], now=now)
+        assert q.is_stale is False
+        assert q.staleness_seconds == 0.0
+
+    def test_staleness_stale(self) -> None:
+        """Old packet → stale."""
+        now = dt(2026, 1, 1, 12, 0, 0, tzinfo=UTC)
+        old = now - td(seconds=STALE_WARN_SECONDS + 60)
+
+        tracker = RssiTracker()
+        tracker.record("04:123456", "-70", old)
+
+        q = compute_quality("04:123456", [tracker], now=now)
+        assert q.is_stale is True
+        assert q.staleness_seconds is not None
+        assert q.staleness_seconds > STALE_WARN_SECONDS
+
+    def test_staleness_custom_threshold(self) -> None:
+        """Custom stale threshold works."""
+        now = dt(2026, 1, 1, 12, 0, 0, tzinfo=UTC)
+        recent = now - td(seconds=60)
+
+        tracker = RssiTracker()
+        tracker.record("04:123456", "-70", recent)
+
+        # Default threshold (300s) → not stale
+        q = compute_quality("04:123456", [tracker], now=now)
+        assert q.is_stale is False
+
+        # Custom threshold (30s) → stale
+        q = compute_quality(
+            "04:123456", [tracker], now=now, stale_warn_seconds=30
+        )
+        assert q.is_stale is True
+
+    def test_last_seen_multi_hgi(self) -> None:
+        """last_seen is the most recent across all HGIs."""
+        t1 = dt(2026, 1, 1, 12, 0, 0, tzinfo=UTC)
+        t2 = dt(2026, 1, 1, 12, 5, 0, tzinfo=UTC)
+        t3 = dt(2026, 1, 1, 12, 10, 0, tzinfo=UTC)
+
+        tracker_a = RssiTracker()
+        tracker_b = RssiTracker()
+
+        tracker_a.record("04:123456", "-70", t1)
+        tracker_a.record("04:123456", "-72", t3)
+        tracker_b.record("04:123456", "-80", t2)
+
+        q = compute_quality("04:123456", [tracker_a, tracker_b], now=t3)
+        assert q.last_seen == t3
+
+    def test_immutable_snapshot(self) -> None:
+        """CommunicationQuality is frozen."""
+        now = dt(2026, 1, 1, 12, 0, 0, tzinfo=UTC)
+        tracker = RssiTracker()
+        tracker.record("04:123456", "-70", now)
+
+        q = compute_quality("04:123456", [tracker], now=now)
+        assert isinstance(q, CommunicationQuality)
+
+        # Frozen dataclass — can't set attributes
+        import dataclasses
+
+        assert dataclasses.is_dataclass(q)
+        # frozen=True raises FrozenInstanceError on setattr
+        try:
+            q.best_rssi = -50  # type: ignore[misc]
+            raise AssertionError("Should have raised FrozenInstanceError")
+        except AttributeError:
+            pass  # Expected
+
+    def test_empty_trackers(self) -> None:
+        """No trackers at all → unknown quality."""
+        now = dt(2026, 1, 1, 12, 0, 0, tzinfo=UTC)
+        q = compute_quality("04:123456", [], now=now)
+        assert q.best_rssi is None
+        assert q.rssi_quality == "unknown"
+        assert q.is_stale is False
+
+    def test_threshold_boundaries(self) -> None:
+        """Test exact threshold boundaries."""
+        now = dt(2026, 1, 1, 12, 0, 0, tzinfo=UTC)
+
+        # Exactly RSSI_STRONG (-60) → strong
+        tracker = RssiTracker()
+        tracker.record("04:123456", str(RSSI_STRONG), now)
+        q = compute_quality("04:123456", [tracker], now=now)
+        assert q.rssi_quality == "strong"
+
+        # RSSI_STRONG - 1 (-61) → normal
+        tracker2 = RssiTracker()
+        tracker2.record("04:123456", str(RSSI_STRONG - 1), now)
+        q2 = compute_quality("04:123456", [tracker2], now=now)
+        assert q2.rssi_quality == "normal"
+
+        # Exactly RSSI_NORMAL (-75) → normal
+        tracker3 = RssiTracker()
+        tracker3.record("04:123456", str(RSSI_NORMAL), now)
+        q3 = compute_quality("04:123456", [tracker3], now=now)
+        assert q3.rssi_quality == "normal"
+
+        # RSSI_NORMAL - 1 (-76) → weak
+        tracker4 = RssiTracker()
+        tracker4.record("04:123456", str(RSSI_NORMAL - 1), now)
+        q4 = compute_quality("04:123456", [tracker4], now=now)
+        assert q4.rssi_quality == "weak"
+
+        # Exactly RSSI_WEAK (-95) → weak
+        tracker5 = RssiTracker()
+        tracker5.record("04:123456", str(RSSI_WEAK), now)
+        q5 = compute_quality("04:123456", [tracker5], now=now)
+        assert q5.rssi_quality == "weak"
+
+        # RSSI_WEAK - 1 (-96) → very_weak
+        tracker6 = RssiTracker()
+        tracker6.record("04:123456", str(RSSI_WEAK - 1), now)
+        q6 = compute_quality("04:123456", [tracker6], now=now)
+        assert q6.rssi_quality == "very_weak"

--- a/tests/tests_tx/test_rssi_tracker.py
+++ b/tests/tests_tx/test_rssi_tracker.py
@@ -1,0 +1,171 @@
+"""Tests for the RssiTracker (transport-layer RSSI tracking per HGI).
+
+See: https://github.com/ramses-rf/ramses_cc/issues/1047
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime as dt
+
+import pytest
+
+from ramses_tx.rssi_tracker import RssiTracker
+
+
+@pytest.fixture
+def now() -> dt:
+    """Fixed timestamp for deterministic tests."""
+    return dt(2026, 1, 1, 12, 0, 0, tzinfo=UTC)
+
+
+class TestRssiTracker:
+    """Unit tests for RssiTracker."""
+
+    def test_record_and_best_rssi(self, now: dt) -> None:
+        """Basic recording and best_rssi retrieval."""
+        tracker = RssiTracker(window_size=3)
+        tracker.record("04:123456", "-70", now)
+        tracker.record("04:123456", "-65", now)
+        tracker.record("04:123456", "-72", now)
+
+        # Best (strongest = highest dBm) of last 3
+        assert tracker.best_rssi_for("04:123456") == -65
+
+    def test_window_eviction(self, now: dt) -> None:
+        """Old readings are evicted when window is full."""
+        tracker = RssiTracker(window_size=3)
+        tracker.record("04:123456", "-50", now)
+        tracker.record("04:123456", "-60", now)
+        tracker.record("04:123456", "-70", now)
+        tracker.record("04:123456", "-80", now)
+
+        # Only last 3 readings: -60, -70, -80
+        readings = tracker.readings_for("04:123456")
+        assert readings == [-60, -70, -80]
+        assert tracker.best_rssi_for("04:123456") == -60
+
+    def test_degradation_detection(self, now: dt) -> None:
+        """Window detects signal degradation (e.g. door closing)."""
+        tracker = RssiTracker(window_size=3)
+        # Good signal for a while
+        tracker.record("04:123456", "-55", now)
+        tracker.record("04:123456", "-56", now)
+        tracker.record("04:123456", "-54", now)
+        assert tracker.best_rssi_for("04:123456") == -54
+
+        # Door closes — signal degrades
+        tracker.record("04:123456", "-90", now)
+        tracker.record("04:123456", "-92", now)
+        tracker.record("04:123456", "-88", now)
+        # Old good readings evicted, now all weak
+        assert tracker.best_rssi_for("04:123456") == -88
+
+    def test_recovery_detection(self, now: dt) -> None:
+        """Window detects signal recovery (e.g. door opening)."""
+        tracker = RssiTracker(window_size=3)
+        tracker.record("04:123456", "-90", now)
+        tracker.record("04:123456", "-92", now)
+        tracker.record("04:123456", "-88", now)
+        assert tracker.best_rssi_for("04:123456") == -88
+
+        # Door opens — signal recovers
+        tracker.record("04:123456", "-55", now)
+        tracker.record("04:123456", "-56", now)
+        tracker.record("04:123456", "-54", now)
+        assert tracker.best_rssi_for("04:123456") == -54
+
+    def test_multiple_devices(self, now: dt) -> None:
+        """Each device has independent tracking."""
+        tracker = RssiTracker(window_size=3)
+        tracker.record("04:111111", "-70", now)
+        tracker.record("04:222222", "-80", now)
+        tracker.record("04:111111", "-65", now)
+
+        assert tracker.best_rssi_for("04:111111") == -65
+        assert tracker.best_rssi_for("04:222222") == -80
+        assert tracker.best_rssi_for("04:333333") is None
+
+    def test_unknown_device(self) -> None:
+        """Unknown device returns None."""
+        tracker = RssiTracker()
+        assert tracker.best_rssi_for("04:999999") is None
+        assert tracker.last_seen("04:999999") is None
+        assert tracker.readings_for("04:999999") == []
+
+    def test_sentinel_values_ignored(self, now: dt) -> None:
+        """Sentinel RSSI values are silently ignored."""
+        tracker = RssiTracker()
+        tracker.record("04:123456", "...", now)
+        tracker.record("04:123456", "---", now)
+        tracker.record("04:123456", "///", now)
+        tracker.record("04:123456", "", now)
+
+        assert tracker.best_rssi_for("04:123456") is None
+        assert tracker.readings_for("04:123456") == []
+
+    def test_unparsable_ignored(self, now: dt) -> None:
+        """Unparsable RSSI strings are silently ignored."""
+        tracker = RssiTracker()
+        tracker.record("04:123456", "abc", now)
+        tracker.record("04:123456", "N/A", now)
+
+        assert tracker.best_rssi_for("04:123456") is None
+
+    def test_int_rssi_accepted(self, now: dt) -> None:
+        """Integer RSSI values are accepted directly."""
+        tracker = RssiTracker()
+        tracker.record("04:123456", -70, now)
+        tracker.record("04:123456", -65, now)
+
+        assert tracker.best_rssi_for("04:123456") == -65
+
+    def test_last_seen(self, now: dt) -> None:
+        """last_seen returns the timestamp of the most recent reading."""
+        tracker = RssiTracker(window_size=3)
+        t1 = dt(2026, 1, 1, 12, 0, 0, tzinfo=UTC)
+        t2 = dt(2026, 1, 1, 12, 5, 0, tzinfo=UTC)
+        t3 = dt(2026, 1, 1, 12, 10, 0, tzinfo=UTC)
+
+        tracker.record("04:123456", "-70", t1)
+        tracker.record("04:123456", "-65", t2)
+        tracker.record("04:123456", "-72", t3)
+
+        assert tracker.last_seen("04:123456") == t3
+
+    def test_known_devices(self, now: dt) -> None:
+        """known_devices returns all devices with readings."""
+        tracker = RssiTracker()
+        tracker.record("04:111111", "-70", now)
+        tracker.record("04:222222", "-80", now)
+
+        known = tracker.known_devices()
+        assert "04:111111" in known
+        assert "04:222222" in known
+        assert "04:333333" not in known
+
+    def test_clear(self, now: dt) -> None:
+        """clear removes all readings."""
+        tracker = RssiTracker()
+        tracker.record("04:123456", "-70", now)
+        assert tracker.best_rssi_for("04:123456") == -70
+
+        tracker.clear()
+        assert tracker.best_rssi_for("04:123456") is None
+        assert tracker.known_devices() == frozenset()
+
+    def test_invalid_window_size(self) -> None:
+        """Window size < 1 raises ValueError."""
+        with pytest.raises(ValueError, match="window_size must be >= 1"):
+            RssiTracker(window_size=0)
+
+        with pytest.raises(ValueError, match="window_size must be >= 1"):
+            RssiTracker(window_size=-1)
+
+    def test_window_size_1(self, now: dt) -> None:
+        """Window size 1 keeps only the latest reading."""
+        tracker = RssiTracker(window_size=1)
+        tracker.record("04:123456", "-70", now)
+        tracker.record("04:123456", "-80", now)
+
+        assert tracker.readings_for("04:123456") == [-80]
+        assert tracker.best_rssi_for("04:123456") == -80


### PR DESCRIPTION
## Summary

Per-device communication quality tracking to detect RF issues before they cause stale entity state.

### Transport layer (ramses_tx)

- **`RssiTracker`**: per-HGI tracker maintaining the last N RSSI readings per device (default 3). Uses a ring buffer (`deque`) — not a running average — so degradation and recovery are detected within exactly N packets, regardless of packet frequency.

### Domain layer (ramses_rf)

- **`CommunicationQuality`**: immutable snapshot computed on demand from HGI-side RSSI data. Computes `best_rssi` (strongest across all HGIs) and staleness (time since last transmission).
- **`DeviceBase.communication_quality`** property exposes the snapshot.
- Quality labels: `strong` (>= -60 dBm), `normal` (-60 to -75), `weak` (-75 to -95), `very_weak` (< -95).

### Wiring

- `Gateway` holds an `RssiTracker` instance (one per HGI; multi-HGI support will add more).
- `StateProjector.process_state_updates` records RSSI for each inbound packet's source device.

### Design

Separates transport (HGI measures RSSI) from domain (device quality is computed from HGI data), consistent with the OSI decoupling architecture in ramses-rf/ramses_rf#639. The `best_rssi` across all HGIs avoids false warnings when one HGI has a weak antenna position — a device is "well-heard" if **any** HGI has good recent RSSI.

**Depends on PR 1121 (issue 1046) for consistent signed dBm format. Not stacked — this branch is based on master and will need 1046 merged first.**

See: https://github.com/ramses-rf/ramses_cc/issues/1047

#### Test plan

- [x] `pytest tests/tests_tx/test_rssi_tracker.py` — 14 tests (record, window eviction, degradation/recovery, multi-device, sentinels, staleness)
- [x] `pytest tests/tests_rf/test_communication_quality.py` — 15 tests (single/multi-HGI, thresholds, staleness, immutability)
- [x] `pytest tests/` (full suite) — 2659 passed, 3 skipped
- [x] `ruff check` + `mypy --strict` — clean
- [x] `ha_sim_test R89` — 5/5 passed, no unexpected errors/warnings