### PR TITLE
fix: restore 5 missing params in _2411_PARAMS_SCHEMA

### DIFF
--- a/src/ramses_rf/models/hvac_schemas.py
+++ b/src/ramses_rf/models/hvac_schemas.py
@@ -105,8 +105,25 @@ _2411_PARAMS_SCHEMA: dict[str, FanParamInfo] = {
     "52": FanParamInfo(
         "Trickle mode timer (minutes)", 0, 180, 10, "00", "minutes"
     ),
+    "54": FanParamInfo(
+        "Moisture sensor overrun time (mins)", 15, 60, 1, "00", "min"
+    ),
     "64": FanParamInfo("Exhaust temperature limit (°C)", 5, 25, 1, "92", "°C"),
     "65": FanParamInfo("Supply temperature limit (°C)", 5, 25, 1, "92", "°C"),
+    "75": FanParamInfo(
+        "Comfort temperature (°C)", 0.0, 30.0, 0.01, "92", "°C"
+    ),
+    "88": FanParamInfo(
+        "Timer configuration (ClimaRad Ventura)",
+        0,
+        0xFFFFFFFF,
+        1,
+        "10",
+        "",
+    ),
+    "95": FanParamInfo(
+        "Boost mode Supply/exhaust fan rate (%)", 0.0, 1.0, 0.005, "0F", "%"
+    ),
     "C8": FanParamInfo("Bypass mode (auto/manual)", 255, 255, 1, "20", ""),
     "CA": FanParamInfo(
         "Bypass override timer (minutes)", 0, 180, 10, "00", "minutes"
@@ -114,6 +131,9 @@ _2411_PARAMS_SCHEMA: dict[str, FanParamInfo] = {
     "CB": FanParamInfo("Summer mode limit (°C)", 15, 25, 1, "92", "°C"),
     "CE": FanParamInfo("Winter mode limit (°C)", 5, 15, 1, "92", "°C"),
     "CF": FanParamInfo("Bypass hysteresis (°C)", 0.5, 5, 0.5, "92", "°C"),
+    "DA": FanParamInfo(
+        "Unknown (ClimaRad Ventura)", 0, 0xFFFFFFFF, 1, "10", ""
+    ),
     "F5": FanParamInfo("Pre-heater limit (°C)", -15, -5, 1, "92", "°C"),
     "F6": FanParamInfo("Pre-heater hysteresis (°C)", 0.5, 5, 0.5, "92", "°C"),
 }


### PR DESCRIPTION
## Summary

- Restores 5 fan parameters that were dropped when `_2411_PARAMS_SCHEMA` was migrated from `protocol/ramses.py` to `models/hvac_schemas.py` in commit 99b29c37e (Jul 22)
- Fixes `set_fan_param` service failing with `ValueError: Unknown parameter ID` for these params

## Root cause

Commit 99b29c37e ("style: run formatting on hvac.py") created `models/hvac_schemas.py` with a new `_2411_PARAMS_SCHEMA` dict, but 5 parameters from the original `protocol/ramses.py` schema were not copied over:

| Param | Description |
|---|---|
| `54` | Moisture sensor overrun time (mins) |
| `75` | Comfort temperature (°C) |
| `88` | Timer configuration (ClimaRad Ventura) |
| `95` | Boost mode Supply/exhaust fan rate (%) |
| `DA` | Unknown (ClimaRad Ventura) |

The `build_set_fan_param` builder imports from the new `models/hvac_schemas.py`, so any `set_fan_param` call for these 5 params raised `ValueError`. `get_fan_param` (RQ) was unaffected as it does not validate against the schema.

## Fix

Added the 5 missing `FanParamInfo` entries to `models/hvac_schemas.py`, matching the values from `protocol/ramses.py`.

#### Test plan

- [x] 347 HVAC-related tests pass (`pytest -k "2411 or fan_param or hvac"`)
- [x] All 12 packet tests pass
- [ ] Manual: `set_fan_param` for param `75` (comfort temperature) on a ClimaRad Ventura FAN
- [ ] Manual: `set_fan_param` for param `95` (boost mode) on an Orcon FAN

Reported in ramses-rf/ramses_cc#1053.