### PR TITLE
fix: use strip_traits (stage 1) for schema validation in Gateway

### DIFF
--- a/src/ramses_rf/config.py
+++ b/src/ramses_rf/config.py
@@ -265,6 +265,13 @@ def strip_and_map_schema(schema: dict[str, Any]) -> dict[str, Any]:
     device's trait dict.  Top-level keys (``main_tcs``, ``orphans_heat``,
     ``controller``, etc.) are passed through unchanged.
 
+    .. note::
+        The output of this function is suitable for building a
+        **known_list** (mapped trait names like ``class``, ``alias``),
+        but **not** for ``SCH_GLOBAL_SCHEMAS`` validation — the schema
+        validator rejects mapped trait names.  For schema validation,
+        use :func:`strip_traits` (stage 1 only) instead.  See issue 1120.
+
     :param schema: A schema dict with device IDs as keys and trait
         dicts as values.
     :return: A new schema dict with ``_`` keys stripped/mapped per device.

--- a/src/ramses_rf/gateway.py
+++ b/src/ramses_rf/gateway.py
@@ -31,7 +31,7 @@ from ramses_tx.schemas import (
 )
 from ramses_tx.typing import PayloadT
 
-from .config import GatewayConfig as GatewayConfig, strip_and_map_schema
+from .config import GatewayConfig as GatewayConfig, strip_traits
 from .const import Code, Verb
 from .devices import (
     DeviceFilter,
@@ -178,8 +178,12 @@ class Gateway(GatewayLifecycle, GatewayInterface):
             )
 
         schema_in = self._gwy_config.schema or {}
+        # Use strip_traits (stage 1 only) to remove _-prefixed keys before
+        # validation.  strip_and_map_schema (stage 1+2) would map _class→class,
+        # but SCH_GLOBAL_SCHEMAS rejects mapped trait names — they are only
+        # valid for the known_list, not the schema validator (issue 1120).
         self._schema: dict[str, Any] = SCH_GLOBAL_SCHEMAS(
-            strip_and_map_schema(schema_in)
+            strip_traits(schema_in)
         )
 
         self._tcs: Evohome | None = None

--- a/tests/tests_rf/test_config.py
+++ b/tests/tests_rf/test_config.py
@@ -381,3 +381,64 @@ async def test_implicit_hgi_discovery_fallback() -> None:
 
     config = GatewayConfig(known_list=raw_known_list)
     assert config.hgi_id == "18:006402"
+
+
+@pytest.mark.asyncio
+async def test_gateway_accepts_underscore_schema() -> None:
+    """Gateway accepts a schema with _-prefixed trait keys (issue 1120).
+
+    The CLI and ramses_cc both use _-prefixed keys (_class, _alias, etc.)
+    in the schema.  The Gateway must strip them (stage 1) before passing
+    to SCH_GLOBAL_SCHEMAS, which rejects both _-prefixed and mapped
+    trait names.
+    """
+    schema = {
+        "01:234567": {
+            "_class": "CTL",
+            "_alias": "Living Room Controller",
+            "zones": {"01": {"sensor": "01:234567"}},
+        },
+    }
+
+    config = GatewayConfig(schema=schema)
+    loop = asyncio.get_running_loop()
+    gateway = Gateway(port_name="/dev/null", config=config, loop=loop)
+
+    # The schema should be accepted and the _-prefixed keys stripped
+    assert "01:234567" in gateway._schema
+    assert "_class" not in gateway._schema["01:234567"]
+    assert "_alias" not in gateway._schema["01:234567"]
+    # Structural keys should be preserved
+    assert "zones" in gateway._schema["01:234567"]
+
+    with contextlib.suppress(asyncio.CancelledError):
+        await gateway.stop()
+
+
+@pytest.mark.asyncio
+async def test_gateway_accepts_mixed_schema() -> None:
+    """Gateway accepts a schema mixing _-prefixed and native keys (issue 1120).
+
+    ramses_cc may pass a schema that has already been partially stripped
+    (native keys only) alongside _-prefixed keys.  The Gateway should
+    handle both without error.
+    """
+    schema = {
+        "main_tcs": "01:234567",
+        "01:234567": {
+            "_class": "CTL",
+            "zones": {"01": {"sensor": "01:234567"}},
+        },
+        "orphans_heat": ["04:111111"],
+    }
+
+    config = GatewayConfig(schema=schema)
+    loop = asyncio.get_running_loop()
+    gateway = Gateway(port_name="/dev/null", config=config, loop=loop)
+
+    assert gateway._schema["main_tcs"] == "01:234567"
+    assert "zones" in gateway._schema["01:234567"]
+    assert "_class" not in gateway._schema["01:234567"]
+
+    with contextlib.suppress(asyncio.CancelledError):
+        await gateway.stop()


### PR DESCRIPTION
## Summary

- Changed Gateway to use `strip_traits` (stage 1) instead of `strip_and_map_schema` (stage 1+2) for `SCH_GLOBAL_SCHEMAS` validation
- The Gateway was mapping `_`-prefixed keys to native trait names (`_class`→`class`), but `SCH_GLOBAL_SCHEMAS` rejects mapped trait names — they are only valid for the known_list
- This meant the CLI (and any caller passing a schema with `_`-prefixed keys directly to the Gateway) would fail with "not a valid value" when the schema contained `_`-prefixed trait keys

## Context

The stripping pipeline has two stages:
- **Stage 1** (`strip_traits`): removes `_`-prefixed keys (ramses_cc-only extensions like `_class`, `_alias`, `_commands`, `_owner`, `_disabled`)
- **Stage 2** (`strip_and_map_traits`/`strip_and_map_schema`): maps known `_`-prefixed keys to native trait names (`_class`→`class`, `_alias`→`alias`)

Stage 2 output is only valid for the **known_list** — `SCH_GLOBAL_SCHEMAS` (the schema validator) rejects mapped trait names. The Gateway was incorrectly using stage 1+2 for schema validation, causing it to reject schemas with `_`-prefixed keys.

ramses_cc works because it pre-strips the schema via `_strip_schema_extensions` (which calls `strip_traits`) before passing it to the Gateway. The CLI does not pre-strip, so it hits the bug.

Fixes https://github.com/ramses-rf/ramses_rf/issues/1120

#### Test plan

- [x] `pytest tests/tests_rf/test_config.py` — 32 passed (including 2 new tests)
- [x] `pytest tests/tests_rf/test_gateway.py tests/tests_rf/test_gateway_snapshot.py` — 17 passed
- [x] `pytest tests/tests_cli/` — 77 passed
- [x] `ruff check` + `ruff format --check` — clean
- [x] `mypy --strict` — clean
- [x] `test_gateway_accepts_underscore_schema` — verifies Gateway accepts schema with `_`-prefixed keys
- [x] `test_gateway_accepts_mixed_schema` — verifies Gateway accepts schema mixing `_`-prefixed and structural keys