### PR TITLE
fix: device-class-aware staleness threshold for battery devices

### DIFF
--- a/src/ramses_rf/devices/dev_base.py
+++ b/src/ramses_rf/devices/dev_base.py
@@ -169,6 +169,11 @@ class DeviceBase(Entity):
         ``None`` if the gateway has no RSSI tracker (e.g. during
         tests without a real gateway).
 
+        The staleness threshold is derived from the device's
+        ``heartbeat_timeout``, which is device-class-aware (e.g. 12h
+        for TRVs/sensors, 24h for BDR/DHW).  This prevents battery
+        devices from being falsely flagged as stale (issue 1062).
+
         :return: Communication quality snapshot, or ``None``.
         :rtype: CommunicationQuality | None
         """
@@ -178,7 +183,11 @@ class DeviceBase(Entity):
         tracker = getattr(gwy, "_rssi_tracker", None)
         if tracker is None:
             return None
-        return compute_quality(str(self.id), [tracker])
+        return compute_quality(
+            str(self.id),
+            [tracker],
+            stale_warn_seconds=int(self.heartbeat_timeout.total_seconds()),
+        )
 
     def _update_traits(self, traits: DeviceTraits) -> None:
         """Update a device with new schema attributes.

--- a/tests/tests_rf/test_communication_quality.py
+++ b/tests/tests_rf/test_communication_quality.py
@@ -244,3 +244,28 @@ class TestComputeQuality:
         tracker6.record("04:123456", str(RSSI_WEAK - 1), now)
         q6 = compute_quality("04:123456", [tracker6], now=now)
         assert q6.rssi_quality == "very_weak"
+
+    def test_staleness_battery_device_not_stale(self) -> None:
+        """Battery devices use longer staleness thresholds (issue 1062).
+
+        Evohome battery devices (TRVs, sensors) transmit every 10-30
+        minutes to conserve battery.  A 5-minute default threshold
+        falsely flags them as stale.  The device's heartbeat_timeout
+        (12h for TRV/sensor, 24h for DHW) should be used instead.
+        """
+        now = dt(2026, 1, 1, 12, 0, 0, tzinfo=UTC)
+        # 10 minutes since last tx — would be stale with 300s default
+        recent = now - td(minutes=10)
+
+        tracker = RssiTracker()
+        tracker.record("04:123456", "-70", recent)
+
+        # Default threshold (300s = 5min) → stale
+        q_default = compute_quality("04:123456", [tracker], now=now)
+        assert q_default.is_stale is True
+
+        # Battery sensor threshold (12h = 43200s) → not stale
+        q_battery = compute_quality(
+            "04:123456", [tracker], now=now, stale_warn_seconds=43200
+        )
+        assert q_battery.is_stale is False


### PR DESCRIPTION
## Summary

- The `communication_quality` property was using a flat 5-minute (`STALE_WARN_SECONDS = 300`) staleness threshold for all devices
- Evohome battery devices (TRVs, sensors, DHW sensors) transmit every 10-30 minutes to conserve battery, so they were almost always falsely flagged as stale
- Fix: pass the device's `heartbeat_timeout` as the `stale_warn_seconds` parameter to `compute_quality()`

## Context

`heartbeat_timeout` is already device-class-aware:
- 1h default (mains devices)
- 12h for TRV / sensor (battery)
- 24h for BDR / DHW / filter / OTB / remote

The staleness check now uses the same per-class timeout, so battery devices are no longer flagged as stale during their normal transmission intervals.

Fixes https://github.com/ramses-rf/ramses_cc/issues/1062

#### Test plan

- [x] `pytest tests/tests_rf/test_communication_quality.py` — 16 passed (including new `test_staleness_battery_device_not_stale`)
- [x] `pytest tests/tests_rf/test_gateway.py tests/tests_rf/test_config.py` — 46 passed
- [x] `ruff check` + `ruff format --check` — clean
- [x] `mypy --strict` — clean
- [x] New test verifies that a 10-minute silence is stale with 300s default but not stale with 12h battery threshold