### PR TITLE
fix: drop redundant Optional(Remove) for probatio compat (HA 2026.9.0b0)

### DIFF
--- a/src/ramses_rf/config.py
+++ b/src/ramses_rf/config.py
@@ -81,7 +81,7 @@ def sch_global_traits_dict_factory(
                 None, SCH_POLLING_INTERVAL
             ),
             vol.Optional(SZ_IS_BATTERY, default=False): vol.Any(None, bool),
-            vol.Optional(vol.Remove("_note")): str,
+            vol.Remove("_note"): str,
             vol.Optional("locked", default=False): vol.Any(None, bool),
         },
         extra=vol.PREVENT_EXTRA,

--- a/src/ramses_rf/schemas.py
+++ b/src/ramses_rf/schemas.py
@@ -225,7 +225,7 @@ SCH_TCS = vol.Schema(
             [SCH_DEVICE_ID_ANY], vol.Unique()
         ),
         vol.Optional(SZ_ZONES, default={}): vol.Any({}, SCH_TCS_ZONES),
-        vol.Optional(vol.Remove("is_tcs")): vol.Coerce(bool),
+        vol.Remove("is_tcs"): vol.Coerce(bool),
     },
     extra=vol.PREVENT_EXTRA,
 )
@@ -246,7 +246,7 @@ SCH_VCS_DATA = vol.Schema(
             [SCH_DEVICE_ID_ANY],
             vol.Unique(),  # vol.Length(min=1)
         ),
-        vol.Optional(vol.Remove("is_vcs")): vol.Coerce(bool),
+        vol.Remove("is_vcs"): vol.Coerce(bool),
     },
     extra=vol.PREVENT_EXTRA,
 )
@@ -270,9 +270,7 @@ SCH_VCS = vol.All(SCH_VCS_KEYS, SCH_VCS_DATA)
 SCH_GLOBAL_SCHEMAS_DICT = {  # System schemas - can be 0-many Heat/HVAC schemas
     # orphans are devices to create that won't be in a (cached) schema...
     vol.Optional(SZ_MAIN_TCS): vol.Any(None, SCH_DEVICE_ID_CTL),
-    vol.Optional(vol.Remove("main_controller")): vol.Any(
-        None, SCH_DEVICE_ID_CTL
-    ),
+    vol.Remove("main_controller"): vol.Any(None, SCH_DEVICE_ID_CTL),
     vol.Optional(SCH_DEVICE_ID_CTL): vol.Any(SCH_TCS, SCH_VCS),
     vol.Optional(
         SCH_DEVICE_ID_ANY


### PR DESCRIPTION
## Summary

HA 2026.9.0b0 swaps voluptuous for [probatio](https://probatio.frenck.dev/) (a clean-room, MIT-licensed drop-in reimplementation). probatio rejects a mapping key that carries two presence markers, so `vol.Optional(vol.Remove(...))` raises `SchemaError` at schema build time.

This is the root cause of ramses-rf/ramses_cc issue 1063 ("0.60.1 won't load under HA 2026.9.0b0: probatio error"). The failing traceback:

```
ramses_rf/config.py:139  vol.Any(SCH_TRAITS_HEAT, SCH_TRAITS_HVAC)
  → probatio/validators/combinators.py:414  _compile_branches
  → probatio/markers.py:386  resolve_key
probatio.error.SchemaError: a mapping key carries two presence markers: Optional and Remove
```

`Remove` is already optional by default under voluptuous (only `Required` makes a key required), so the `Optional` wrapper was always redundant. Dropping it is the form probatio accepts, and is also the form recommended in the [probatio dict schemas guide](https://probatio.frenck.dev/guides/dict-schemas-and-markers/#removing-keys).

Four sites fixed, all in `ramses_rf`:
- `src/ramses_rf/config.py` — `vol.Remove("_note")`
- `src/ramses_rf/schemas.py` — `vol.Remove("is_tcs")`, `vol.Remove("is_vcs")`, `vol.Remove("main_controller")`

No other `Optional(Remove(...))` / `Required(Remove(...))` patterns exist in `ramses_rf`, `ramses_cc`, or `ramses_extras`.

### Behaviour unchanged under voluptuous

Verified on voluptuous 0.15.2 and 0.16.0 that `vol.Remove("x"): str` and `vol.Optional(vol.Remove("x")): str` produce identical results: key validated if present and dropped from output, no-op if absent.

#### Test plan

- [x] Reproduced the exact `SchemaError` from issue 1063 under probatio 0.11.2 with the old form
- [x] Confirmed the new form builds under probatio; `sch_global_traits_dict_factory()` (the failing line) now succeeds
- [x] Confirmed `install_as_voluptuous()` + `from ramses_rf.schemas import ...` + `from ramses_rf.config import sch_global_traits_dict_factory` works end-to-end under probatio (simulates HA 2026.9.0b0)
- [x] ramses_rf test suite under voluptuous 0.16.0: 2661 passed, 3 skipped
- [x] ruff check / ruff format / codespell / pre-commit hooks pass