### PR TITLE
fix: suppress bogus exhaust_fan_speed for 4-byte Orcon 31D9 payloads

### DIFF
--- a/src/ramses_rf/payloads/hvac.py
+++ b/src/ramses_rf/payloads/hvac.py
@@ -2594,7 +2594,14 @@ class HvacBypassStatePayload(PayloadBase):
         else:
             fan_mode_map = {0: "off", 5: "auto"}
         result: dict[str, Any] = {}
-        if not (self._unknown_16 is not None and self._unknown_16 != "00"):
+        # exhaust_fan_speed = spd / 200.0 is only meaningful for long
+        # payloads (Itho, ClimaRad) where spd is a raw 0-200 RPM value.
+        # For 4-byte Orcon payloads, spd is a semantic fan mode (0-5),
+        # not a speed — dividing by 200 produces a meaningless 1-2%
+        # reading.  Suppress it for 4-byte payloads.
+        if not is_4b_orcon and not (
+            self._unknown_16 is not None and self._unknown_16 != "00"
+        ):
             result["exhaust_fan_speed"] = None if spd == 0xFF else spd / 200.0
         # For long-payload devices (Orcon, Brofer, etc.), unmapped fan_mode
         # raw bytes (e.g. 0x04, 0xC8, 0xFF) are NOT semantic names and conflict

--- a/tests/tests_rf/data_driven/parsers/code_31d9.log
+++ b/tests/tests_rf/data_driven/parsers/code_31d9.log
@@ -27,7 +27,7 @@
 
 
 # parse_fan_info:          31D9[4:6] == 31DA[36:38] ?Orcon, ignore speed
-2023-11-15T22:21:04.358292 076  I --- 32:134044 --:------ 32:134044 31D9 004 00000200                                                    # {'hvac_id': '00', 'exhaust_fan_speed': 0.01,  'fan_mode': '02',                                         'passive': False, 'damper_only': False, 'filter_dirty': False, 'frost_cycle': False, 'has_fault': False, '_flags': [0, 0, 0, 0, 0, 0, 0, 0], '_unknown_3': '00'}
+2023-11-15T22:21:04.358292 076  I --- 32:134044 --:------ 32:134044 31D9 004 00000200                                                    # {'hvac_id': '00', 'fan_mode': '02',                                         'passive': False, 'damper_only': False, 'filter_dirty': False, 'frost_cycle': False, 'has_fault': False, '_flags': [0, 0, 0, 0, 0, 0, 0, 0], '_unknown_3': '00'}
 2023-11-15T22:21:04.496217 077  I --- 32:134044 --:------ 32:134044 31DA 029 00EF007FFF3E30042406B806D8055FF800000248480000EFEF0F810F9D  # {'hvac_id': '00', 'exhaust_fan_speed': 0.36,  'fan_info': 'speed 2, medium', '_unknown_fan_info_flags': [0, 0, 0], 'air_quality': None, 'co2_level': None, 'indoor_humidity': 0.62, 'outdoor_humidity': 0.48, 'exhaust_temp': 10.6, 'supply_temp': 17.2, 'indoor_temp': 17.52, 'outdoor_temp': 13.75, 'speed_capabilities': ['off', 'low_med_high', 'timer', 'boost', 'auto'], 'bypass_position': 0.0, 'supply_fan_speed': 0.36, 'remaining_mins': 0, 'post_heat': None, 'pre_heat': None, 'supply_flow': 39.69, 'exhaust_flow': 39.97}
 
 # parse_exhaust_fan_speed: 31D9[4:6] == 31DA[38:40] ?Itho = speed %, ignore mode


### PR DESCRIPTION
## Summary

- 4-byte 31D9 payloads (Orcon-style) have a semantic fan mode (0-5) in the speed_byte, not a raw RPM value
- The code blindly divided it by 200, producing a meaningless 1-2% reading (e.g. mode 2 → 0.01 = 1%) that showed up as the fan speed in HA
- The `exhaust_fan_speed = spd / 200.0` formula is only meaningful for longer payloads (Itho, ClimaRad) where spd is a raw 0-200 RPM value

## Fix

Suppress `exhaust_fan_speed` for 4-byte Orcon payloads, since the speed_byte is a semantic mode, not a speed.

## Example

Payload `31D9 004 00200200` (TijmenvS's Orcon):
- Before: `exhaust_fan_speed: 0.01` (1% — bogus)
- After: `exhaust_fan_speed` not present (correct — it's a mode, not a speed)

The test data file comment already noted "Orcon, ignore speed" but the expected output still included the bogus value — updated to match the fix.

## Test plan

- [x] All 2664 existing tests pass
- [x] Updated test data file (`code_31d9.log`) to match corrected output
- [x] Verified 2-byte, 4-byte, and 17-byte payloads all produce correct results

## Related

- Forum post: https://gathering.tweakers.net/forum/view_message/86013804