### PR TITLE
fix(gateway): preserve _name in zone entries through strip_traits

### DIFF
--- a/src/ramses_rf/gateway.py
+++ b/src/ramses_rf/gateway.py
@@ -182,9 +182,32 @@ class Gateway(GatewayLifecycle, GatewayInterface):
         # validation.  strip_and_map_schema (stage 1+2) would map _class→class,
         # but SCH_GLOBAL_SCHEMAS rejects mapped trait names — they are only
         # valid for the known_list, not the schema validator (issue 1120).
-        self._schema: dict[str, Any] = SCH_GLOBAL_SCHEMAS(
-            strip_traits(schema_in)
-        )
+        stripped = strip_traits(schema_in)
+
+        # Preserve _name in zone entries (ramses-rf/ramses_cc#919: zone names
+        # lost after 24h when the MessageStore prunes 0004 packets — the
+        # schema is the only persistent source of the name).  strip_traits
+        # removes _name, so re-add it from the original schema for
+        # SCH_TCS_ZONES_ZON to accept and Zone._update_schema to hydrate.
+        for ctl_id, ctl_entry in schema_in.items():
+            if not isinstance(ctl_entry, dict) or not isinstance(
+                ctl_entry.get("zones"), dict
+            ):
+                continue
+            stripped_ctl = stripped.get(ctl_id)
+            if not isinstance(stripped_ctl, dict) or not isinstance(
+                stripped_ctl.get("zones"), dict
+            ):
+                continue
+            for z_idx, z_entry in ctl_entry["zones"].items():
+                if (
+                    isinstance(z_entry, dict)
+                    and z_entry.get("_name")
+                    and isinstance(stripped_ctl["zones"].get(z_idx), dict)
+                ):
+                    stripped_ctl["zones"][z_idx]["_name"] = z_entry["_name"]
+
+        self._schema: dict[str, Any] = SCH_GLOBAL_SCHEMAS(stripped)
 
         self._tcs: Evohome | None = None
         self._eavesdrop_engine: Any = None


### PR DESCRIPTION
## Summary

- The Gateway constructor called `strip_traits(schema_in)` which removed all `_-prefixed` keys, including `_name` in zone entries
- This caused `Zone._update_schema` to see `_name=None`, so `zone_state.name` was never hydrated from the schema
- The device registry fell back to the device-ID form (e.g. `01:150000_03`) instead of the user-configured zone name
- ramses_cc already had preservation logic to re-add `_name` after `strip_traits`, but the Gateway constructor stripped it again before `SCH_GLOBAL_SCHEMAS` validation
- `SCH_TCS_ZONES_ZON` accepts `_name` (`vol.Optional`), so preserving it through the validator is safe

Fix: re-add `_name` from the original schema after `strip_traits`, before `SCH_GLOBAL_SCHEMAS` validation. This mirrors the preservation logic in ramses_cc's `_strip_and_orchestrate`.

Resolves ramses-rf/ramses_cc#919 (zone names lost after 24h when MessageStore prunes 0004 packets — the schema is the only persistent source of the name).

#### Test plan

- [x] `mypy --strict` passes
- [x] `ruff check` + `ruff format --check` pass
- [x] `pytest tests/tests_rf/ -x -q` — 557 passed, 1 skipped
- [x] ha_sim_test R63 (Zone name survives MessageStore pruning) — 5/5 PASS, 0 FAIL