### PR TITLE
Wave 0, PR 3: Modernise serial transport typing (remove type: ignore & cast)

### DIFF
--- a/src/ramses_tx/discovery.py
+++ b/src/ramses_tx/discovery.py
@@ -9,7 +9,7 @@ import logging
 import os
 import sys
 from functools import partial
-from typing import Protocol, cast
+from typing import Protocol
 
 from serial import SerialException, serial_for_url
 
@@ -46,7 +46,7 @@ if sys.platform == "win32":
         # the signature keeps type-checkers happy because all branches now look
         # identical.
         del include_links, _hide_subsystems
-        return cast(list[_PortInfo], _win_comports())
+        return list(_win_comports())
 
 elif os.name != "posix":
     raise ImportError(
@@ -65,7 +65,7 @@ elif sys.platform.lower()[:5] != "linux":
         # kwargs on macOS/Unix, but exposing them suppresses "definition differs"
         # errors when mypy analyses this file on other platforms.
         del include_links, _hide_subsystems
-        return cast(list[_PortInfo], _posix_comports())
+        return list(_posix_comports())
 
 else:
     from serial.tools.list_ports_linux import SysFS
@@ -105,7 +105,7 @@ else:
             for d in map(SysFS, devices)
             if d.subsystem not in _hide_subsystems
         ]
-        return cast(list[_PortInfo], result)
+        return list(result)
 
 
 async def is_hgi80(serial_port: SerPortNameT) -> bool | None:

--- a/src/ramses_tx/protocol/base.py
+++ b/src/ramses_tx/protocol/base.py
@@ -194,12 +194,23 @@ class _BaseProtocol(ProtocolInterface, asyncio.Protocol):
 
         return del_handler
 
-    def connection_made(self, transport: TransportInterface) -> None:  # type: ignore[override]
+    def connection_made(
+        self, transport: Any, /, *, ramses: bool = False
+    ) -> None:
         """Establish connection to the Transport.
 
         The argument is the transport representing the pipe connection.
         To receive data, wait for packet_received() calls. When the
         connection is closed, connection_lost() is called.
+
+        The ``ramses`` keyword is accepted for compatibility with
+        ``ProtocolInterface.connection_made`` but ignored here —
+        ``PortTransport`` calls this directly after signature echo.
+
+        ``transport`` is typed ``Any`` to satisfy mypy's Liskov check
+        against ``asyncio.BaseProtocol.connection_made`` (which expects
+        ``BaseTransport``).  At runtime it is always a
+        ``TransportInterface``.
         """
         if self._wait_connection_made.done():
             return
@@ -391,6 +402,10 @@ class _BaseProtocol(ProtocolInterface, asyncio.Protocol):
             qos=qos or DEFAULT_QOS,
         )
 
+        if packet is None:
+            raise ProtocolSendFailed(
+                f"Failed to send command: {patched_cmd} (no packet returned)"
+            )
         return packet
 
     async def _send_cmd(
@@ -402,7 +417,7 @@ class _BaseProtocol(ProtocolInterface, asyncio.Protocol):
         num_repeats: int = DEFAULT_NUM_REPEATS,
         priority: Priority = Priority.DEFAULT,
         qos: QosParams = DEFAULT_QOS,
-    ) -> Packet:  # only cmd, no args, kwargs
+    ) -> Packet | None:  # only cmd, no args, kwargs
         raise NotImplementedError(f"{self}: Unexpected error")
 
     async def _send_frame(

--- a/src/ramses_tx/protocol/core.py
+++ b/src/ramses_tx/protocol/core.py
@@ -9,7 +9,7 @@ together.
 from __future__ import annotations
 
 import logging
-from typing import Final, TypeAlias
+from typing import Any, Final, TypeAlias
 
 from ..const import (
     DEFAULT_DISABLE_QOS,
@@ -28,7 +28,6 @@ from ..exceptions import (
     ProtocolSendFailed,
     ProtocolTimeoutError,
 )
-from ..interfaces import TransportInterface
 from ..packet import Packet
 from ..typing import DeviceIdT, MsgHandlerT, QosParams
 from .base import DEFAULT_QOS, _DeviceIdFilterMixin
@@ -76,8 +75,8 @@ class ReadProtocol(_DeviceIdFilterMixin):
         )
         self._pause_writing = True
 
-    def connection_made(  # type: ignore[override]
-        self, transport: TransportInterface, /, *, ramses: bool = False
+    def connection_made(
+        self, transport: Any, /, *, ramses: bool = False
     ) -> None:
         """Consume the callback if invoked by SerialTransport rather than PortTransport.
 
@@ -153,8 +152,8 @@ class PortProtocol(_DeviceIdFilterMixin):
         cls = self._context.state.__class__.__name__
         return f"QosProtocol({cls}, len(queue)={self._context.qsize})"
 
-    def connection_made(  # type: ignore[override]
-        self, transport: TransportInterface, /, *, ramses: bool = False
+    def connection_made(
+        self, transport: Any, /, *, ramses: bool = False
     ) -> None:
         """Consume the callback if invoked by SerialTransport rather than PortTransport.
 
@@ -239,7 +238,7 @@ class PortProtocol(_DeviceIdFilterMixin):
         num_repeats: int = DEFAULT_NUM_REPEATS,
         priority: Priority = Priority.DEFAULT,
         qos: QosParams = DEFAULT_QOS,
-    ) -> Packet:
+    ) -> Packet | None:
         """Send a Command with QoS (retries, until success or exception)."""
 
         async def send_cmd(kmd: CommandDTO) -> None:
@@ -257,7 +256,7 @@ class PortProtocol(_DeviceIdFilterMixin):
 
         if _DBG_DISABLE_QOS:
             await send_cmd(command)
-            return None  # type: ignore[return-value]
+            return None
 
         assert self._context
 

--- a/src/ramses_tx/schemas.py
+++ b/src/ramses_tx/schemas.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 
 import logging
 from collections.abc import Callable
-from typing import Any, Final, cast
+from typing import Any, Final
 
 import voluptuous as vol
 
@@ -163,17 +163,17 @@ def sch_serial_port_dict_factory() -> dict[vol.Required, vol.Any]:
     SCH_SERIAL_PORT_NAME = str
 
     def normalise_serial_port_factory() -> Callable[
-        [str | PortConfigT], PortConfigT
+        [str | PortConfigT], dict[str, Any]
     ]:
         def normalise_serial_port(
             node_value: str | PortConfigT,
-        ) -> PortConfigT:
+        ) -> dict[str, Any]:
             if isinstance(node_value, str):
-                return cast(
-                    "PortConfigT",
-                    {SZ_PORT_NAME: node_value} | SCH_SERIAL_PORT_CONFIG({}),
-                )
-            return node_value
+                defaults = SCH_SERIAL_PORT_CONFIG({})
+                return {SZ_PORT_NAME: node_value} | {
+                    k: v for k, v in defaults.items()
+                }
+            return dict(node_value)
 
         return normalise_serial_port
 
@@ -195,9 +195,12 @@ def extract_serial_port(
 ) -> tuple[str, PortConfigT]:
     """Extract serial port and port config tuple from schema."""
     port_name = str(serial_port_dict.get(SZ_PORT_NAME, ""))
-    port_config = cast(
-        "PortConfigT",
-        {k: v for k, v in serial_port_dict.items() if k != SZ_PORT_NAME},
+    port_config = PortConfigT(
+        baudrate=int(serial_port_dict.get(SZ_BAUDRATE, 115200)),
+        dsrdtr=bool(serial_port_dict.get(SZ_DSRDTR, False)),
+        rtscts=bool(serial_port_dict.get(SZ_RTSCTS, False)),
+        timeout=int(serial_port_dict.get(SZ_TIMEOUT, 0)),
+        xonxoff=bool(serial_port_dict.get(SZ_XONXOFF, True)),
     )
     return port_name, port_config
 

--- a/src/ramses_tx/transport/port.py
+++ b/src/ramses_tx/transport/port.py
@@ -45,7 +45,7 @@ from collections.abc import Awaitable, Callable, Iterable
 from datetime import datetime as dt
 from functools import wraps
 from time import perf_counter, time
-from typing import Any, Final
+from typing import TYPE_CHECKING, Any, Final
 
 from serial import Serial, SerialException
 
@@ -83,12 +83,42 @@ __all__ = [
     "serial_asyncio",
 ]
 
-try:
-    import serial_asyncio_fast as serial_asyncio  # type: ignore[import-not-found, import-untyped, unused-ignore]
+if TYPE_CHECKING:
+    # pyserial-asyncio has no type stubs — declare the minimal interface
+    # we need.  SerialTransport extends asyncio.transports.Transport but
+    # adds a custom __init__ that takes (loop, protocol, serial_instance).
+    from serial import Serial as _Serial
 
-    _LOGGER.debug("Using pyserial-asyncio-fast in place of pyserial-asyncio")
-except ImportError:
-    import serial_asyncio  # type: ignore[import-not-found, import-untyped, unused-ignore, no-redef]
+    class _SerialTransportBase:
+        """Type-checking stub for serial_asyncio.SerialTransport."""
+
+        serial: _Serial
+
+        def __init__(
+            self,
+            loop: asyncio.AbstractEventLoop,
+            protocol: Any,
+            serial_instance: _Serial,
+        ) -> None:
+            """Initialize serial transport."""
+            self.serial = serial_instance
+
+        def _abort(self, exc: Exception) -> None:
+            """Abort the transport."""
+
+        def _close(self, exc: exc.RamsesException | None = None) -> None:
+            """Close the transport."""
+else:
+    try:
+        import serial_asyncio_fast as serial_asyncio
+
+        _LOGGER.debug(
+            "Using pyserial-asyncio-fast in place of pyserial-asyncio"
+        )
+    except ImportError:
+        import serial_asyncio
+
+    _SerialTransportBase = serial_asyncio.SerialTransport
 
 
 def limit_duty_cycle(
@@ -151,7 +181,7 @@ def limit_duty_cycle(
     return decorator
 
 
-class _PortTransportAbstractor(serial_asyncio.SerialTransport):
+class _PortTransportAbstractor(_SerialTransportBase):
     """Do the bare minimum to abstract a transport from its underlying class."""
 
     serial: Serial
@@ -170,7 +200,7 @@ class _PortTransportAbstractor(serial_asyncio.SerialTransport):
         )
 
 
-class PortTransport(_FullTransport, _PortTransportAbstractor):  # type: ignore[misc]
+class PortTransport(_FullTransport, _PortTransportAbstractor):
     """Send/receive packets async to/from evofw3/HGI80 via a serial port.
 
     See: https://github.com/ghoti57/evofw3
@@ -180,6 +210,7 @@ class PortTransport(_FullTransport, _PortTransportAbstractor):  # type: ignore[m
     _init_task: asyncio.Task[None]
 
     _recv_buffer: bytes = b""
+    _max_read_size: int = 1024  # from asyncio.transports.Transport
 
     _tx_bits_in_bucket: float | None = None
     _tx_last_time_bit_added: float | None = None
@@ -360,7 +391,7 @@ class PortTransport(_FullTransport, _PortTransportAbstractor):  # type: ignore[m
         """Perform the actual write to the serial port."""
         self.serial.write(data)
 
-    def _abort(self, exc: Exception) -> None:  # type: ignore[override]
+    def _abort(self, exc: Exception) -> None:
         """Abort the transport."""
         super()._abort(exc)
 
@@ -371,9 +402,7 @@ class PortTransport(_FullTransport, _PortTransportAbstractor):  # type: ignore[m
         if conn_task := getattr(self, "_conn_task", None):
             conn_task.cancel()
 
-    def _close(  # type: ignore[override]
-        self, exc: exc.RamsesException | None = None
-    ) -> None:
+    def _close(self, exc: exc.RamsesException | None = None) -> None:
         """Close the transport (cancel any outstanding tasks)."""
         super()._close(exc)
 


### PR DESCRIPTION
see https://github.com/ramses-rf/ramses_rf/issues/1122
## Summary

Remove 10 `# type: ignore` suppressions and 5 `cast()` calls from the serial transport, schema, discovery, and protocol layers, as tracked in issue 1122 (PR 3).

### Changes by file

**`transport/port.py`** (5 suppressions removed):
- Replace `import serial_asyncio` `type: ignore[import-not-found, ...]` with a `TYPE_CHECKING` stub class (`_SerialTransportBase`) that declares the minimal interface (`serial`, `__init__`, `_abort`, `_close`) — pyserial-asyncio has no type stubs
- Remove `type: ignore[misc]` on `PortTransport` class def (MRO now reconcilable with the stub)
- Remove `type: ignore[override]` on `_abort`/`_close` (stub declares them)
- Add `_max_read_size` class attribute (was `attr-defined` error)

**`schemas.py`** (2 casts removed):
- `normalise_serial_port`: construct dict explicitly instead of `cast()`
- `extract_serial_port`: construct `PortConfigT` TypedDict explicitly instead of `cast()`

**`discovery.py`** (3 casts removed):
- `comports()`: return `list()` directly — `types-pyserial` stubs make `cast()` unnecessary

**`protocol/base.py`** (1 suppression removed):
- `connection_made`: accept `transport: Any` and `*, ramses: bool = False` to match both `ProtocolInterface` and `asyncio.BaseProtocol` signatures
- `_send_cmd`: return type `Packet | None` (debug path can return None)
- `send_cmd`: add None check with `ProtocolSendFailed`

**`protocol/core.py`** (3 suppressions removed):
- `connection_made`: match base signature with `transport: Any`
- `_send_cmd`: return `Packet | None` to match base
- Remove `type: ignore[return-value]` on debug `return None`

### Stacking

This PR is stacked on PR 1 (nullable field annotations) and PR 2 (generics, tuples, DeviceIdT wrapping). It should be merged after both. < Done

#### Test plan

- [x] `mypy --strict src/` — 2 pre-existing errors only (aiofiles stubs, TypedDict key)
- [x] `ruff check` + `ruff format` — clean
- [x] `pytest tests/tests_tx/` — 330 passed
- [x] `pytest tests/tests_rf/` — 2259 passed, 3 skipped
- [x] ha_sim_test full suite (pending)