### PR TITLE
Wave 0, PR 4: Replace polymorphic __new__ with factory methods

### DIFF
--- a/src/ramses_rf/commands/builders/dhw.py
+++ b/src/ramses_rf/commands/builders/dhw.py
@@ -54,7 +54,7 @@ def build_set_dhw_params(intent: Command) -> CommandDTO:
         raise ValueError(f"Out of range, differential: {differential}")
 
     addr1, addr2, addr3 = resolve_addrs(intent.src, intent.dst)
-    payload = DhwParamsPayload(
+    payload = DhwParamsPayload.create(
         dhw_index=dhw_index,
         setpoint=setpoint,
         overrun=overrun,

--- a/src/ramses_rf/commands/builders/heat.py
+++ b/src/ramses_rf/commands/builders/heat.py
@@ -11,7 +11,9 @@ from ramses_tx.dtos import CommandDTO
 def build_put_outdoor_temp(intent: Command) -> CommandDTO:
     """Translate a PUT_OUTDOOR_TEMP intent into a CommandDTO."""
     temperature = intent.get("temperature")
-    payload = TemperaturePayload(zone_index=0, temperature=temperature).hex()
+    payload = TemperaturePayload.create(
+        zone_index=0, temperature=temperature
+    ).hex()
     addr1, addr2, addr3 = resolve_addrs(intent.src, intent.dst)
 
     return CommandDTO(
@@ -48,7 +50,7 @@ def build_put_sensor_temp(intent: Command) -> CommandDTO:
     """Translate a PUT_SENSOR_TEMP intent into a CommandDTO."""
     temperature = intent.get("temperature")
     zone_index = intent.get("zone_index", 0)
-    payload = TemperaturePayload(
+    payload = TemperaturePayload.create(
         zone_index=zone_index, temperature=temperature
     ).hex()
 

--- a/src/ramses_rf/commands/builders/opentherm.py
+++ b/src/ramses_rf/commands/builders/opentherm.py
@@ -22,7 +22,7 @@ def build_get_opentherm_data(intent: Command) -> CommandDTO:
 
     msg_id_int = msg_id if isinstance(msg_id, int) else int(msg_id, 16)
     msg_type = 8 if parity(msg_id_int) else 0
-    payload = OpenThermMsgPayload(
+    payload = OpenThermMsgPayload.create(
         opentherm_index=0,
         msg_id=msg_id_int,
         msg_type=msg_type,

--- a/src/ramses_rf/commands/builders/zones.py
+++ b/src/ramses_rf/commands/builders/zones.py
@@ -59,7 +59,7 @@ def build_set_temperature(intent: Command) -> CommandDTO:
             "Missing 'zone_index'/'zone_index' or 'setpoint' in intent data"
         )
 
-    payload = ZoneSetpointPayload(
+    payload = ZoneSetpointPayload.create(
         zone_index=zone_index, setpoint_temp=setpoint
     ).hex()
 
@@ -107,7 +107,7 @@ def build_set_mode(intent: Command) -> CommandDTO:
 
     until, duration = normalise_until(mode, setpoint, until, duration)
 
-    payload = ZoneModePayload(
+    payload = ZoneModePayload.create(
         zone_index=zone_index,
         setpoint_temp=setpoint,
         mode_code=mode,
@@ -148,7 +148,7 @@ def build_set_name(intent: Command) -> CommandDTO:
             "Missing 'zone_index'/'zone_index' or 'name' in intent data"
         )
 
-    payload = ZoneNamePayload(zone_index=zone_index, name=name).hex()
+    payload = ZoneNamePayload.create(zone_index=zone_index, name=name).hex()
     addr1, addr2, addr3 = resolve_addrs(intent.src, intent.dst)
 
     return CommandDTO(

--- a/src/ramses_rf/payloads/dhw.py
+++ b/src/ramses_rf/payloads/dhw.py
@@ -259,7 +259,8 @@ class DhwParamsPayload(PayloadBase):
     overrun: int | None = None
     differential: float | None = None
 
-    def __new__(  # type: ignore[misc]
+    @classmethod
+    def create(
         cls,
         dhw_index: int | str = 0,
         setpoint: float | None = None,
@@ -267,8 +268,6 @@ class DhwParamsPayload(PayloadBase):
         differential: float = 0.0,
     ) -> "DhwParams3BPayload | DhwParams6BPayload":
         """Construct DhwParams payload variant dynamically from arguments."""
-        if cls is not DhwParamsPayload:
-            return super().__new__(cls)  # type: ignore[return-value]
         index = parse_index(dhw_index)
         if overrun != 0 or differential != 0.0:
             return DhwParams6BPayload(

--- a/src/ramses_rf/payloads/heating.py
+++ b/src/ramses_rf/payloads/heating.py
@@ -53,7 +53,8 @@ class HeatDemandPayload(PayloadBase):
     demand_percent: int
     raw_extra: bytes | None
 
-    def __new__(  # type: ignore[misc]
+    @classmethod
+    def create(
         cls,
         domain_or_zone_index: int | None = None,
         demand_percent: int = 0,
@@ -61,8 +62,6 @@ class HeatDemandPayload(PayloadBase):
         _is_array_item: bool = False,
     ) -> "HeatDemand1BPayload | HeatDemand2BPayload":
         """Construct HeatDemand payload variant dynamically."""
-        if cls is not HeatDemandPayload:
-            return super().__new__(cls)  # type: ignore[return-value]
         if domain_or_zone_index is not None:
             return HeatDemand2BPayload(
                 domain_or_zone_index=domain_or_zone_index,
@@ -289,14 +288,13 @@ class TemperaturePayload(PayloadBase):
     zone_index: int | str | None
     temperature: float | bool | None
 
-    def __new__(  # type: ignore[misc]
+    @classmethod
+    def create(
         cls,
         zone_index: int | str | None = None,
         temperature: float | bool | None = None,
     ) -> "Temperature2BPayload | Temperature3BPayload":
         """Construct Temperature payload variant dynamically from arguments."""
-        if cls is not TemperaturePayload:
-            return super().__new__(cls)  # type: ignore[return-value]
         if zone_index is not None:
             return Temperature3BPayload(
                 zone_index=zone_index, temperature=temperature
@@ -719,7 +717,8 @@ class SystemSyncPayload(PayloadBase):
     valve_run_time: int | None
     pump_run_time: int | None
 
-    def __new__(  # type: ignore[misc]
+    @classmethod
+    def create(
         cls,
         sync_flag: int = 0,
         max_flow_setpoint: int | None = None,
@@ -732,8 +731,6 @@ class SystemSyncPayload(PayloadBase):
         _raw_extra: bytes | None = None,
     ) -> "SystemSync1BPayload | SystemSyncVarPayload":
         """Construct SystemSync payload variant dynamically from arguments."""
-        if cls is not SystemSyncPayload:
-            return super().__new__(cls)  # type: ignore[return-value]
         if any(
             x is not None
             for x in (
@@ -1299,15 +1296,14 @@ class ZoneNamePayload(PayloadBase):
     name: str | None
     setpoint_temp: float | None
 
-    def __new__(  # type: ignore[misc]
+    @classmethod
+    def create(
         cls,
         zone_index: int | str = 0,
         name: str | None = None,
         setpoint_temp: float | None = None,
     ) -> "ZoneName22BPayload | ZoneNameShort3BPayload":
         """Construct ZoneName payload variant dynamically."""
-        if cls is not ZoneNamePayload:
-            return super().__new__(cls)  # type: ignore[return-value]
         if setpoint_temp is not None:
             return ZoneNameShort3BPayload(
                 zone_index=zone_index, setpoint_temp=setpoint_temp
@@ -1620,14 +1616,13 @@ class ZoneSetpointPayload(PayloadBase):
     zone_index: int | str
     setpoint_temp: float | bool | None
 
-    def __new__(
+    @classmethod
+    def create(
         cls,
         zone_index: int | str = 0,
         setpoint_temp: float | bool | None = None,
     ) -> "ZoneSetpoint3BPayload":
         """Construct ZoneSetpoint payload variant dynamically."""
-        if cls is not ZoneSetpointPayload:
-            return super().__new__(cls)  # type: ignore[return-value]
         return ZoneSetpoint3BPayload(
             zone_index=zone_index, setpoint_temp=setpoint_temp
         )
@@ -1849,15 +1844,14 @@ class SystemZonesPayload(PayloadBase):
 
     VARIANTS: ClassVar[tuple[type[PayloadBase], ...]] = ()
 
-    def __new__(
+    @classmethod
+    def create(
         cls,
         zone_type: int = 0,
         zone_mask: int = 0,
         zone_class_id: int = 0,
     ) -> "SystemZones4BPayload":
         """Construct SystemZones payload variant dynamically from arguments."""
-        if cls is not SystemZonesPayload:
-            return super().__new__(cls)  # type: ignore[return-value]
         return SystemZones4BPayload(
             zone_type=zone_type,
             zone_mask=zone_mask,
@@ -2008,15 +2002,14 @@ class RelayDemandPayload(PayloadBase):
     demand_percent: float
     raw_extra: bytes | None
 
-    def __new__(
+    @classmethod
+    def create(
         cls,
         domain_or_zone_index: int = 0,
         demand_percent: float = 0.0,
         raw_extra: bytes | None = None,
     ) -> "RelayDemand2BPayload":
         """Construct RelayDemand payload variant dynamically."""
-        if cls is not RelayDemandPayload:
-            return super().__new__(cls)  # type: ignore[return-value]
         return RelayDemand2BPayload(
             domain_or_zone_index=domain_or_zone_index,
             demand_percent=demand_percent,
@@ -2150,7 +2143,8 @@ class ZoneDevicesPayload(PayloadBase):
 
     VARIANTS: ClassVar[tuple[type[PayloadBase], ...]] = ()
 
-    def __new__(  # type: ignore[misc]
+    @classmethod
+    def create(
         cls,
         zone_index_raw: int = 0,
         device_role_id: int = 0,
@@ -2158,8 +2152,6 @@ class ZoneDevicesPayload(PayloadBase):
         sub_index: int = 0,
     ) -> "ZoneDevices5BPayload | ZoneDevices6BPayload":
         """Construct ZoneDevices payload variant dynamically from arguments."""
-        if cls is not ZoneDevicesPayload:
-            return super().__new__(cls)  # type: ignore[return-value]
         if sub_index != 0:
             return ZoneDevices6BPayload(
                 zone_index_raw=zone_index_raw,
@@ -2890,7 +2882,8 @@ class ZoneModePayload(PayloadBase):
     duration_minutes: int | None
     until_dtm: str | dt | bytes | None
 
-    def __new__(  # type: ignore[misc]
+    @classmethod
+    def create(
         cls,
         zone_index: int | str = 0,
         setpoint_temp: float | None = None,
@@ -2899,8 +2892,6 @@ class ZoneModePayload(PayloadBase):
         until_dtm: str | dt | bytes | None = None,
     ) -> "ZoneMode7BPayload | ZoneMode13BPayload":
         """Construct ZoneMode payload variant dynamically."""
-        if cls is not ZoneModePayload:
-            return super().__new__(cls)  # type: ignore[return-value]
         if until_dtm is not None:
             return ZoneMode13BPayload(
                 zone_index=zone_index,
@@ -3677,7 +3668,8 @@ class ActuatorCyclePayload(PayloadBase):
 
     VARIANTS: ClassVar[tuple[type[PayloadBase], ...]] = ()
 
-    def __new__(  # type: ignore[misc]
+    @classmethod
+    def create(
         cls,
         cycle_countdown_sec: int | None = None,
         actuator_countdown_sec: int | None = None,
@@ -3685,8 +3677,6 @@ class ActuatorCyclePayload(PayloadBase):
         domain_index: int | None = None,
     ) -> "ActuatorCycle6BPayload | ActuatorCycle7BPayload":
         """Construct ActuatorCycle payload variant dynamically from arguments."""
-        if cls is not ActuatorCyclePayload:
-            return super().__new__(cls)  # type: ignore[return-value]
         if domain_index is not None:
             return ActuatorCycle7BPayload(
                 domain_index=domain_index,

--- a/src/ramses_rf/payloads/hvac.py
+++ b/src/ramses_rf/payloads/hvac.py
@@ -441,15 +441,14 @@ class Co2Payload(PayloadBase):
     co2_level: int | None
     co2_level_fault: str | None
 
-    def __new__(  # type: ignore[misc]
+    @classmethod
+    def create(
         cls,
         co2_level: int | None = None,
         domain_index: int | None = None,
         co2_level_fault: str | None = None,
     ) -> "Co22BPayload | Co23BPayload":
         """Construct Co2 payload variant dynamically from arguments."""
-        if cls is not Co2Payload:
-            return super().__new__(cls)  # type: ignore[return-value]
         if domain_index is not None:
             return Co23BPayload(
                 domain_index=domain_index,
@@ -3407,14 +3406,13 @@ class WindowStatePayload(PayloadBase):
     zone_index: int
     window_open: bool | None
 
-    def __new__(  # type: ignore[misc]
+    @classmethod
+    def create(
         cls,
         zone_index: int = 0,
         window_open: bool | None = None,
     ) -> "WindowState2BPayload | WindowState3BPayload":
         """Construct WindowState payload variant dynamically from arguments."""
-        if cls is not WindowStatePayload:
-            return super().__new__(cls)  # type: ignore[return-value]
         return WindowState3BPayload(
             zone_index=zone_index, window_open=window_open
         )
@@ -3553,14 +3551,13 @@ class HvacVentilationDemandPayload(PayloadBase):
     flags: int
     demand_percent: float
 
-    def __new__(
+    @classmethod
+    def create(
         cls,
         flags: int = 0,
         demand_percent: float = 0.0,
     ) -> "HvacVentilationDemand4BPayload":
         """Construct HvacVentilationDemand payload variant dynamically from arguments."""
-        if cls is not HvacVentilationDemandPayload:
-            return super().__new__(cls)  # type: ignore[return-value]
         return HvacVentilationDemand4BPayload(
             flags=flags, demand_percent=demand_percent
         )

--- a/src/ramses_rf/payloads/opentherm.py
+++ b/src/ramses_rf/payloads/opentherm.py
@@ -48,7 +48,8 @@ class OpenThermMsgPayload(PayloadBase):
     msg_type: int
     raw_value: bytes
 
-    def __new__(  # type: ignore[misc]
+    @classmethod
+    def create(
         cls,
         msg_id: int = 0,
         msg_type: int = 0,
@@ -56,8 +57,6 @@ class OpenThermMsgPayload(PayloadBase):
         opentherm_index: int | None = None,
     ) -> "OpenThermMsg4BPayload | OpenThermMsg5BPayload":
         """Construct OpenThermMsg payload variant dynamically from arguments."""
-        if cls is not OpenThermMsgPayload:
-            return super().__new__(cls)  # type: ignore[return-value]
         if opentherm_index is not None:
             return OpenThermMsg5BPayload(
                 opentherm_index=opentherm_index,
@@ -486,15 +485,14 @@ class OpenThermFaultFlagsPayload(PayloadBase):
 
     VARIANTS: ClassVar[tuple[type[PayloadBase], ...]] = ()
 
-    def __new__(  # type: ignore[misc]
+    @classmethod
+    def create(
         cls,
         fault_code: int = 0,
         flags: int = 0,
         hdr: int | None = None,
     ) -> "OpenThermFaultFlags2BPayload | OpenThermFaultFlags3BPayload":
         """Construct OpenThermFaultFlags payload variant dynamically from arguments."""
-        if cls is not OpenThermFaultFlagsPayload:
-            return super().__new__(cls)  # type: ignore[return-value]
         if hdr is not None:
             return OpenThermFaultFlags3BPayload(
                 hdr=hdr, fault_code=fault_code, flags=flags

--- a/tests/tests_rf/test_payload_dataclasses.py
+++ b/tests/tests_rf/test_payload_dataclasses.py
@@ -237,7 +237,9 @@ def test_system_sync_payload_1030_parity() -> None:
     }
 
     # Verify programmatic creation on the fly packs parameter bytes dynamically
-    on_fly_payload = SystemSyncPayload(sync_flag=10, max_flow_setpoint=55)
+    on_fly_payload = SystemSyncPayload.create(
+        sync_flag=10, max_flow_setpoint=55
+    )
     assert on_fly_payload.to_bytes().hex().upper() == "0AC80137"
 
 


### PR DESCRIPTION
see https://github.com/ramses-rf/ramses_rf/issues/1122
## Summary

Replace the polymorphic `__new__` pattern in 15 payload dispatcher classes with `@classmethod create()` factory methods, removing 28 `# type: ignore` suppressions.

### Problem

The `__new__` override was used to dispatch construction to variant subclasses (e.g., `HeatDemandPayload(...)` → `HeatDemand1BPayload` or `HeatDemand2BPayload`). This caused:
- `[misc]` errors — incompatible `__new__` signature with frozen dataclass base
- `[return-value]` errors — returning a subclass type from `__new__`

### Solution

Replace `__new__` with a `create()` classmethod. Since the dispatcher classes are never instantiated directly (only via `from_bytes()` or `create()`), this is a safe refactor. The variant subclasses use the default dataclass `__init__`/`__new__`.

### Dispatcher classes converted (15 total)

**heating.py** (9): HeatDemandPayload, TemperaturePayload, SystemSyncPayload, ZoneNamePayload, ZoneSetpointPayload, SystemZonesPayload, RelayDemandPayload, ZoneDevicesPayload, ZoneModePayload, ActuatorCyclePayload

**hvac.py** (3): Co2Payload, WindowStatePayload, HvacVentilationDemandPayload

**opentherm.py** (2): OpenThermMsgPayload, OpenThermFaultFlagsPayload

**dhw.py** (1): DhwParamsPayload

### Caller sites updated

- `commands/builders/heat.py`: `TemperaturePayload(...)` → `.create(...)`
- `commands/builders/zones.py`: `ZoneSetpointPayload`, `ZoneModePayload`, `ZoneNamePayload` → `.create(...)`
- `commands/builders/opentherm.py`: `OpenThermMsgPayload` → `.create(...)`
- `commands/builders/dhw.py`: `DhwParamsPayload` → `.create(...)`
- `tests/test_payload_dataclasses.py`: `SystemSyncPayload` → `.create(...)`

### Suppressions retained

2 `# type: ignore[override]` on `to_dict` overrides (`SystemZonesPayload`, `HvacFlowRatePayload`) — these have wider return types (`dict | list`) than the base class and are unrelated to the `__new__` pattern.

### Stacking

Stacked on PR 3 (serial transport typing). Should be merged after PRs 1-3.

#### Test plan

- [x] `mypy .` (267 files) — 0 errors
- [x] `ruff check` + `ruff format` — clean
- [x] `pytest tests/tests_rf/ tests/tests_tx/` — 2589 passed, 3 skipped
- [x] ha_sim_test full suite (pending)