### PR TITLE
fix(gateway): preserve _name in zone schema for issue 919 hydration

### DIFF
--- a/src/ramses_rf/gateway.py
+++ b/src/ramses_rf/gateway.py
@@ -185,6 +185,28 @@ class Gateway(GatewayLifecycle, GatewayInterface):
         self._schema: dict[str, Any] = SCH_GLOBAL_SCHEMAS(
             strip_traits(schema_in)
         )
+        # Preserve _name in zone entries for issue 919 fix.
+        # strip_traits removes all _ keys recursively, but Zone._update_schema
+        # needs _name to hydrate zone_state.name (so zone names survive
+        # MessageStore pruning after 24h).  SCH_GLOBAL_SCHEMAS doesn't accept
+        # _ keys, so we re-add _name from the original schema after validation.
+        for ctl_id, ctl_schema in self._schema.items():
+            if not (
+                isinstance(ctl_schema, dict)
+                and isinstance(ctl_schema.get("zones"), dict)
+            ):
+                continue
+            orig_ctl = schema_in.get(ctl_id, {})
+            if not isinstance(orig_ctl, dict):
+                continue
+            orig_zones = orig_ctl.get("zones", {})
+            if not isinstance(orig_zones, dict):
+                continue
+            for z_idx, z_schema in ctl_schema["zones"].items():
+                if isinstance(z_schema, dict) and z_idx in orig_zones:
+                    orig_name = orig_zones[z_idx].get("_name")  # type: ignore[union-attr]
+                    if orig_name is not None:
+                        z_schema["_name"] = orig_name
 
         self._tcs: Evohome | None = None
         self._eavesdrop_engine: Any = None


### PR DESCRIPTION
## Summary
- The Gateway constructor calls `strip_traits()` on the input schema before `SCH_GLOBAL_SCHEMAS` validation, which recursively removes all `_-prefixed` keys including `_name` from zone entries
- This defeats the issue 919 fix in `Zone._update_schema` (which hydrates `zone_state.name` from `_name` so zone names survive MessageStore pruning after 24h)
- Re-add `_name` from the original schema after validation, so it reaches `Zone._update_schema` via `System._update_schema` (`keep_hints=True`) and `get_htg_zone` (`keep_hints=True`)

#### Before fix
- `Zone._update_schema` receives `_name=None` (stripped by Gateway)
- Zone device registry name falls back to `01:150000_03` instead of `Lounge`
- Zone names lost after 24h MessageStore pruning

#### After fix
- `Zone._update_schema` receives `_name='Lounge'` (re-added after validation)
- Zone device registry name is `Lounge` (survives restart/MessageStore pruning)
- ha_sim_test R63 "after restart" check now passes

#### Test plan
- [x] `ruff check` passes
- [x] `ruff format` passes
- [x] ha_sim_test R63: "after restart" check passes (zone name survives)