### PR TITLE
fix: skip faked devices in PollingManager

### DIFF
--- a/src/ramses_rf/pipeline/polling.py
+++ b/src/ramses_rf/pipeline/polling.py
@@ -208,7 +208,7 @@ class PollingManager:
         """Resolve the effective polling schedule for a given device.
 
         Combines default device schedule tables with SSOT schema trait overrides,
-        ensuring battery-powered devices always resolve to zero polling.
+        ensuring battery-powered and faked devices always resolve to zero polling.
 
         :param device: The target device instance.
         :type device: DeviceBase
@@ -217,6 +217,12 @@ class PollingManager:
         """
         slug = getattr(device, "_SLUG", "DEFAULT")
         if slug == DevType.HGI:
+            return {}
+
+        # Faked devices are virtual — they don't exist on the RF network,
+        # so polling them only generates timeouts and log spam (e.g. a
+        # faked REM created via ramses_cc's add_faked_rem service).
+        if device.is_faked:
             return {}
 
         # Battery devices sleep and cannot receive RF requests; never poll them

--- a/tests/tests_rf/test_polling_manager.py
+++ b/tests/tests_rf/test_polling_manager.py
@@ -155,6 +155,40 @@ def test_polling_manager_battery_device_zero_polling(
     assert explicit_schedule == {}
 
 
+def test_polling_manager_faked_device_zero_polling(
+    mock_gateway: MagicMock,
+) -> None:
+    """Faked devices are virtual and must never be polled.
+
+    A faked REM (e.g. 37:999999 created via ramses_cc's add_faked_rem
+    service) does not exist on the RF network.  Polling it with 10E0
+    generates a 20s timeout and log spam (issue 1067).
+    """
+    # ARRANGE — a CTL that would normally get a 10E0 poll, but is faked
+    faked_dev = MockDevice(mock_gateway, "01:111111", slug="CTL")
+    faked_dev._binding_manager = MagicMock()  # is_faked → True
+
+    # A faked HVAC device with no explicit class (DeviceHvac, HVC slug)
+    # — this is the scenario where a faked REM's class trait was lost
+    # during schema migration, leaving it as a generic DeviceHvac.
+    faked_hvc_dev = MockDevice(mock_gateway, "37:999999", slug="HVC")
+    faked_hvc_dev._binding_manager = MagicMock()  # is_faked → True
+
+    poller = PollingManager(mock_gateway, shadow_mode=False)
+
+    # ACT
+    faked_schedule = poller.resolve_schedule_for_device(faked_dev)
+    faked_hvc_schedule = poller.resolve_schedule_for_device(faked_hvc_dev)
+
+    # ASSERT — faked devices get zero polling regardless of their slug
+    assert faked_schedule == {}
+    assert faked_hvc_schedule == {}
+
+    # No tasks should be created for faked devices
+    assert poller.update_device_tasks(faked_dev) == set()
+    assert poller.update_device_tasks(faked_hvc_dev) == set()
+
+
 @pytest.mark.asyncio
 async def test_polling_manager_shadow_execution_parity(
     mock_gateway: MagicMock,


### PR DESCRIPTION
## Summary

- The PollingManager was sending `RQ|10E0` to faked/virtual devices that don't exist on the RF network, causing 20s timeouts and log spam (see ramses_cc issue 1067)
- Faked devices (`is_faked=True`) are now skipped in `resolve_schedule_for_device` — a faked REM created via ramses_cc's `add_faked_rem` service (e.g. `37:999999`) is virtual and polling it only generates timeouts

The `is_faked` check is sufficient regardless of the device's slug: even if a faked REM's class trait is lost during schema migration (leaving it as a generic `DeviceHvac` with `HVC` slug), `is_faked` still returns `True` because `_binding_manager` is set.

#### Before fix
- A faked REM (`37:999999`) with a lost class trait became `DeviceHvac` (HVC slug)
- `is_battery` returned `None` (not `True`) → battery filter didn't skip it
- `HVC` not in `DEFAULT_POLLING_SCHEDULES` → fell to `"DEFAULT"` → daily `10E0` poll
- `RQ|10E0` sent to `37:999999` → 20s timeout → `PollingManager failed to send command 10E0` warning

#### After fix
- Faked devices are skipped regardless of their slug or class trait state

#### Test plan
- [x] `ruff check` passes
- [x] `ruff format` passes
- [x] `mypy --strict` passes
- [x] `pytest tests/tests_rf/test_polling_manager.py` — 30 passed (2 new tests)
- [x] `pytest tests/tests_rf/` — 2263 passed, 3 skipped
- [x] `pytest tests/tests_tx/` — 330 passed