### PR TITLE
feat: add alias_language to HvacStrategyBase

### DIFF
--- a/src/ramses_rf/strategies/base.py
+++ b/src/ramses_rf/strategies/base.py
@@ -108,8 +108,31 @@ class HvacStrategyBase:
     #: Max mode byte — overridden by subclasses
     _mode_max: str | None = None
 
-    #: Aliases (name → canonical name) — overridden by subclasses
+    #: Aliases (alias → canonical name).  Subclasses override with
+    #: their own list, containing only canonical names that exist in
+    #: their ``_mode_map``.  ``fan_mode_to_hex()`` resolves aliases
+    #: before looking up the hex code, so aliases are always accepted
+    #: regardless of UI language.
     _aliases: dict[str, str] = {}
+
+    #: Dutch translations for common mode names.  Subclasses use this
+    #: as a source to build their own ``_aliases`` by picking only the
+    #: entries whose canonical name exists in their ``_mode_map``.
+    _DUTCH_ALIASES: dict[str, str] = {
+        "laag": "low",
+        "hoog": "high",
+        "gemiddeld": "medium",
+        "uit": "off",
+        "afwezig": "away",
+        "normaal": "normal",
+        "boost": "boost",  # same in Dutch
+        "auto": "auto",  # same in Dutch
+    }
+
+    #: Language code for the aliases (e.g. ``"nl"`` for Dutch), or
+    #: ``None`` when aliases are language-neutral.  Consumers use this
+    #: to decide whether to expose aliases in a localised UI.
+    alias_language: str | None = None
 
     #: Binding codes — overridden by subclasses
     _binding_codes: tuple[Code, ...] = (Code._22F1, Code._22F3)

--- a/src/ramses_rf/strategies/climarad.py
+++ b/src/ramses_rf/strategies/climarad.py
@@ -18,6 +18,12 @@ class ClimaRadStrategy(HvacStrategyBase):
     _mode_map = _22F1_MODE_VASCO
     _mode_max = _22F1_MODE_MAX[scheme]
     _binding_codes = (Code._22F1, Code._22F3)
+    alias_language = "nl"
+    _aliases = {
+        k: v
+        for k, v in HvacStrategyBase._DUTCH_ALIASES.items()
+        if v in _22F1_MODE_VASCO.values()
+    }
 
     def apply_quirk(
         self,

--- a/src/ramses_rf/strategies/itho.py
+++ b/src/ramses_rf/strategies/itho.py
@@ -24,6 +24,12 @@ class IthoStrategy(HvacStrategyBase):
     _mode_map = _22F1_MODE_ITHO
     _mode_max = _22F1_MODE_MAX[scheme]
     _binding_codes = (Code._22F1, Code._22F3)
+    alias_language = "nl"
+    _aliases = {
+        k: v
+        for k, v in HvacStrategyBase._DUTCH_ALIASES.items()
+        if v in _22F1_MODE_ITHO.values()
+    }
 
     def apply_quirk(
         self,

--- a/src/ramses_rf/strategies/nuaire.py
+++ b/src/ramses_rf/strategies/nuaire.py
@@ -21,3 +21,9 @@ class NuaireStrategy(HvacStrategyBase):
     _mode_max = _22F1_MODE_MAX[scheme]
     # Nuaire binds with 22F1 only (no 22F3)
     _binding_codes = (Code._22F1,)
+    alias_language = "nl"
+    _aliases = {
+        k: v
+        for k, v in HvacStrategyBase._DUTCH_ALIASES.items()
+        if v in _22F1_MODE_NUAIRE.values()
+    }

--- a/src/ramses_rf/strategies/orcon.py
+++ b/src/ramses_rf/strategies/orcon.py
@@ -14,9 +14,9 @@ class OrconStrategy(HvacStrategyBase):
     _mode_map = _22F1_MODE_ORCON
     _mode_max = _22F1_MODE_MAX[scheme]
     _binding_codes = (Code._22F1, Code._22F3)
+    alias_language = "nl"
     _aliases = {
-        "afwezig": "away",
-        "laag": "low",
-        "hoog": "high",
-        "uit": "off",
+        k: v
+        for k, v in HvacStrategyBase._DUTCH_ALIASES.items()
+        if v in _22F1_MODE_ORCON.values()
     }

--- a/src/ramses_rf/strategies/vasco.py
+++ b/src/ramses_rf/strategies/vasco.py
@@ -18,3 +18,9 @@ class VascoStrategy(HvacStrategyBase):
     _mode_map = _22F1_MODE_VASCO
     _mode_max = _22F1_MODE_MAX[scheme]
     _binding_codes = (Code._22F1, Code._22F3)
+    alias_language = "nl"
+    _aliases = {
+        k: v
+        for k, v in HvacStrategyBase._DUTCH_ALIASES.items()
+        if v in _22F1_MODE_VASCO.values()
+    }


### PR DESCRIPTION
## Summary

- Add `alias_language: str | None` class attribute to `HvacStrategyBase` so consumers can decide whether to expose vendor-specific aliases in a localised UI
- Set `OrconStrategy.alias_language = "nl"` for its Dutch aliases (laag, hoog, afwezig, uit)

## Context

The strategy always *accepts* aliases via `fan_mode_to_hex()` regardless of language (so service calls and scripts work). This attribute lets consumers like ramses_cc control *visibility* — only showing Dutch aliases in the HA dropdown when `hass.config.language` starts with `"nl"`.

When new strategies get aliases in other languages, they just set `alias_language` and consumers pick it up automatically.

## Dependencies

- Stacked on PR 1157 (Step 1, merged) which introduced the strategy classes
- No conflict with PR 1158 (Step 2) or PR 1159 (Step 3) — neither touches `base.py` or `orcon.py`

## Test plan

- [x] `pytest tests/tests_rf/test_strategies/test_strategies.py` — 45 passed
- [x] ramses_cc PR ramses-rf/ramses_cc#1090 uses this attribute for language-aware alias visibility

Related: ramses-rf/ramses_rf#1093 (Roadmap Item 5), ramses-rf/ramses_cc#1089