### PR TITLE
feat: add best_hvac_strategy, strategy-aware fan commands, REM→DIS rule

### DIFF
--- a/src/ramses_rf/strategies/base.py
+++ b/src/ramses_rf/strategies/base.py
@@ -108,8 +108,31 @@ class HvacStrategyBase:
     #: Max mode byte — overridden by subclasses
     _mode_max: str | None = None
 
-    #: Aliases (name → canonical name) — overridden by subclasses
+    #: Aliases (alias → canonical name).  Subclasses override with
+    #: their own list, containing only canonical names that exist in
+    #: their ``_mode_map``.  ``fan_mode_to_hex()`` resolves aliases
+    #: before looking up the hex code, so aliases are always accepted
+    #: regardless of UI language.
     _aliases: dict[str, str] = {}
+
+    #: Dutch translations for common mode names.  Subclasses use this
+    #: as a source to build their own ``_aliases`` by picking only the
+    #: entries whose canonical name exists in their ``_mode_map``.
+    _DUTCH_ALIASES: dict[str, str] = {
+        "laag": "low",
+        "hoog": "high",
+        "gemiddeld": "medium",
+        "uit": "off",
+        "afwezig": "away",
+        "normaal": "normal",
+        "boost": "boost",  # same in Dutch
+        "auto": "auto",  # same in Dutch
+    }
+
+    #: Language code for the aliases (e.g. ``"nl"`` for Dutch), or
+    #: ``None`` when aliases are language-neutral.  Consumers use this
+    #: to decide whether to expose aliases in a localised UI.
+    alias_language: str | None = None
 
     #: Binding codes — overridden by subclasses
     _binding_codes: tuple[Code, ...] = (Code._22F1, Code._22F3)

--- a/src/ramses_rf/strategies/climarad.py
+++ b/src/ramses_rf/strategies/climarad.py
@@ -18,6 +18,12 @@ class ClimaRadStrategy(HvacStrategyBase):
     _mode_map = _22F1_MODE_VASCO
     _mode_max = _22F1_MODE_MAX[scheme]
     _binding_codes = (Code._22F1, Code._22F3)
+    alias_language = "nl"
+    _aliases = {
+        k: v
+        for k, v in HvacStrategyBase._DUTCH_ALIASES.items()
+        if v in _22F1_MODE_VASCO.values()
+    }
 
     def apply_quirk(
         self,

--- a/src/ramses_rf/strategies/itho.py
+++ b/src/ramses_rf/strategies/itho.py
@@ -24,6 +24,12 @@ class IthoStrategy(HvacStrategyBase):
     _mode_map = _22F1_MODE_ITHO
     _mode_max = _22F1_MODE_MAX[scheme]
     _binding_codes = (Code._22F1, Code._22F3)
+    alias_language = "nl"
+    _aliases = {
+        k: v
+        for k, v in HvacStrategyBase._DUTCH_ALIASES.items()
+        if v in _22F1_MODE_ITHO.values()
+    }
 
     def apply_quirk(
         self,

--- a/src/ramses_rf/strategies/nuaire.py
+++ b/src/ramses_rf/strategies/nuaire.py
@@ -21,3 +21,9 @@ class NuaireStrategy(HvacStrategyBase):
     _mode_max = _22F1_MODE_MAX[scheme]
     # Nuaire binds with 22F1 only (no 22F3)
     _binding_codes = (Code._22F1,)
+    alias_language = "nl"
+    _aliases = {
+        k: v
+        for k, v in HvacStrategyBase._DUTCH_ALIASES.items()
+        if v in _22F1_MODE_NUAIRE.values()
+    }

--- a/src/ramses_rf/strategies/orcon.py
+++ b/src/ramses_rf/strategies/orcon.py
@@ -14,9 +14,9 @@ class OrconStrategy(HvacStrategyBase):
     _mode_map = _22F1_MODE_ORCON
     _mode_max = _22F1_MODE_MAX[scheme]
     _binding_codes = (Code._22F1, Code._22F3)
+    alias_language = "nl"
     _aliases = {
-        "afwezig": "away",
-        "laag": "low",
-        "hoog": "high",
-        "uit": "off",
+        k: v
+        for k, v in HvacStrategyBase._DUTCH_ALIASES.items()
+        if v in _22F1_MODE_ORCON.values()
     }

--- a/src/ramses_rf/strategies/vasco.py
+++ b/src/ramses_rf/strategies/vasco.py
@@ -18,3 +18,9 @@ class VascoStrategy(HvacStrategyBase):
     _mode_map = _22F1_MODE_VASCO
     _mode_max = _22F1_MODE_MAX[scheme]
     _binding_codes = (Code._22F1, Code._22F3)
+    alias_language = "nl"
+    _aliases = {
+        k: v
+        for k, v in HvacStrategyBase._DUTCH_ALIASES.items()
+        if v in _22F1_MODE_VASCO.values()
+    }

--- a/tests/tests_rf/test_strategies/test_strategies.py
+++ b/tests/tests_rf/test_strategies/test_strategies.py
@@ -25,6 +25,7 @@ from ramses_rf.strategies import (
     VascoStrategy,
     best_hvac_strategy,
 )
+from ramses_rf.strategies.base import HvacStrategyBase
 from ramses_tx.const import Code
 
 # ---------------------------------------------------------------------------
@@ -173,6 +174,119 @@ class TestOrconDutchAliases:
         hex_code = strategy.fan_mode_to_hex("afwezig")
         assert hex_code == "00"
         assert strategy.hex_to_fan_mode(hex_code) == "away"
+
+
+# ---------------------------------------------------------------------------
+# alias_language attribute
+# ---------------------------------------------------------------------------
+
+
+class TestAliasLanguage:
+    """Verify alias_language is set and consistent across strategies."""
+
+    @pytest.mark.parametrize(
+        "strategy_cls,expected_lang",
+        [
+            (OrconStrategy, "nl"),
+            (IthoStrategy, "nl"),
+            (NuaireStrategy, "nl"),
+            (VascoStrategy, "nl"),
+            (ClimaRadStrategy, "nl"),
+        ],
+    )
+    def test_alias_language_set(
+        self, strategy_cls: type, expected_lang: str
+    ) -> None:
+        assert strategy_cls().alias_language == expected_lang
+
+    def test_base_alias_language_is_none(self) -> None:
+        assert HvacStrategyBase.alias_language is None
+
+
+# ---------------------------------------------------------------------------
+# Filtered aliases per strategy
+# ---------------------------------------------------------------------------
+
+
+class TestFilteredAliases:
+    """Verify each strategy only has aliases for modes it supports."""
+
+    @pytest.mark.parametrize(
+        "strategy_cls",
+        [
+            OrconStrategy,
+            IthoStrategy,
+            NuaireStrategy,
+            VascoStrategy,
+            ClimaRadStrategy,
+        ],
+    )
+    def test_aliases_resolve_to_existing_modes(
+        self, strategy_cls: type
+    ) -> None:
+        strategy = strategy_cls()
+        mode_names = set(strategy.fan_modes.values())
+        for alias, canonical in strategy._aliases.items():
+            assert canonical in mode_names, (
+                f"{strategy.scheme}: alias '{alias}' -> '{canonical}' "
+                f"but '{canonical}' not in mode_map"
+            )
+
+    def test_orcon_has_dutch_aliases(self) -> None:
+        s = OrconStrategy()
+        assert "laag" in s._aliases
+        assert s._aliases["laag"] == "low"
+        assert "afwezig" in s._aliases
+        assert s._aliases["afwezig"] == "away"
+
+    def test_itho_has_dutch_aliases(self) -> None:
+        s = IthoStrategy()
+        assert "laag" in s._aliases
+        assert s._aliases["laag"] == "low"
+        assert "uit" in s._aliases
+        assert s._aliases["uit"] == "off"
+
+    def test_itho_does_not_have_afwezig(self) -> None:
+        # Itho has no "away" mode, so the Dutch alias should be absent
+        s = IthoStrategy()
+        assert "afwezig" not in s._aliases
+
+    def test_nuaire_has_normaal(self) -> None:
+        s = NuaireStrategy()
+        assert "normaal" in s._aliases
+        assert s._aliases["normaal"] == "normal"
+
+    def test_nuaire_does_not_have_laag(self) -> None:
+        # Nuaire has no "low" mode
+        s = NuaireStrategy()
+        assert "laag" not in s._aliases
+
+    def test_vasco_has_dutch_aliases(self) -> None:
+        s = VascoStrategy()
+        assert "laag" in s._aliases
+        assert "afwezig" in s._aliases
+
+    def test_climarad_shares_vasco_aliases(self) -> None:
+        # ClimaRad uses the same mode map as Vasco
+        s = ClimaRadStrategy()
+        v = VascoStrategy()
+        assert s._aliases == v._aliases
+
+    def test_dutch_aliases_accept_via_fan_mode_to_hex(self) -> None:
+        # All strategies should accept their Dutch aliases
+        for cls in [
+            OrconStrategy,
+            IthoStrategy,
+            NuaireStrategy,
+            VascoStrategy,
+            ClimaRadStrategy,
+        ]:
+            s = cls()
+            for alias in s._aliases:
+                # Should not raise
+                hex_code = s.fan_mode_to_hex(alias)
+                assert isinstance(hex_code, str)
+                assert len(hex_code) == 2
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Adds `alias_language` and Dutch aliases to all HVAC strategies (roadmap item 5):

- **`alias_language` class attribute** on `HvacStrategyBase` — lets consumers decide whether to expose vendor-specific aliases in a localised UI. `None` on the base, `"nl"` on all five vendor strategies.
- **`_DUTCH_ALIASES` reference dict** on `HvacStrategyBase` — common Dutch translations for fan mode names (laag, hoog, gemiddeld, uit, afwezig, normaal, boost, auto).
- **Filtered aliases per strategy** — each strategy picks only the entries whose canonical name exists in its own `_mode_map`, so users never see aliases for modes their device doesn't support:
  - Orcon: 7 aliases (laag, hoog, gemiddeld, uit, afwezig, boost, auto)
  - Itho: 4 aliases (laag, hoog, gemiddeld, uit) — no afwezig (no away mode)
  - Nuaire: 2 aliases (normaal, boost) — no laag (no low mode)
  - Vasco/ClimaRad: 6 aliases (laag, hoog, gemiddeld, uit, afwezig, auto)

The strategy always *accepts* aliases via `fan_mode_to_hex()` regardless of language; `alias_language` only controls visibility in the HA dropdown (consumed by ramses_cc PR ramses-rf/ramses_cc#1090).

## Note

This PR was previously a combined PR including `best_hvac_strategy()`, strategy-aware `build_set_fan_mode`, and the REM→DIS rule. Those parts have been merged to master via PRs #1158, #1159, and #1161, so this PR is now scoped to only the `alias_language` + Dutch aliases work.

## Test plan

- [x] `ruff check` passes
- [x] `mypy` passes (0 issues, 7 files)
- [x] `pytest tests/tests_rf/test_strategies/test_strategies.py` — 71 passed (19 new)
- [x] All aliases resolve to existing modes (parametrized verification)

Related: ramses-rf/ramses_rf#1093 (Roadmap Item 5), ramses-rf/ramses_cc#1089, ramses-rf/ramses_cc#1090
