### PR TITLE
refactor(state): deprecate SQLite message store queries and cutover to read-models (#1148)

### DIFF
--- a/src/ramses_cli/client.py
+++ b/src/ramses_cli/client.py
@@ -808,41 +808,25 @@ async def print_summary(gateway: Gateway, **kwargs: Any) -> None:
             for d in gateway.device_registry.devices
             if d.type == DEV_TYPE_MAP.CTL
         ]:
-            if gateway.message_store:
-                for msg in await gateway.message_store.get(
-                    source=device.id, code=Code._0005
-                ):
-                    print(f"{msg}")
-                for msg in await gateway.message_store.get(
-                    source=device.id, code=Code._000C
-                ):
-                    print(f"{msg}")
-            else:  # TODO(eb): replace next block by
-                #  raise NotImplementedError
-                for msg_code, verbs in (
-                    await device.entity_state.get_state_cache_nested()
-                ).items():
-                    if msg_code in (Code._0005, Code._000C):
-                        for verb in verbs.values():
-                            for packet in verb.values():
-                                print(f"{packet}")
+            for msg_code, verbs in (
+                await device.entity_state.get_state_cache_nested()
+            ).items():
+                if msg_code in (Code._0005, Code._000C):
+                    for verb in verbs.values():
+                        for packet in verb.values():
+                            print(f"{packet}")
             print()
         for device in [
             d
             for d in gateway.device_registry.devices
             if d.type == DEV_TYPE_MAP.UFC
         ]:
-            if gateway.message_store:
-                for msg in await gateway.message_store.get(source=device.id):
-                    print(f"{msg}")
-            else:  # TODO(eb): Q1 2026 replace next legacy block by
-                #  raise NotImplementedError
-                for cd in (
-                    await device.entity_state.get_state_cache_nested()
-                ).values():
-                    for verb in cd.values():
-                        for packet in verb.values():
-                            print(f"{packet}")
+            for cd in (
+                await device.entity_state.get_state_cache_nested()
+            ).values():
+                for verb in cd.values():
+                    for packet in verb.values():
+                        print(f"{packet}")
             print()
 
 

--- a/src/ramses_rf/config.py
+++ b/src/ramses_rf/config.py
@@ -314,7 +314,7 @@ class GatewayConfig:
     :type debug_mode: bool
     :param gateway_timeout: Custom timeout threshold in minutes.
     :type gateway_timeout: int | None
-    :param database_path: Target disk path for the SQLite DB.
+    :param database_path: Target disk path for SQLite DB logging, or None to disable.
     :type database_path: str | None
     :param known_list: A list of known device IDs and their traits.
     :type known_list: dict[str, Any]

--- a/src/ramses_rf/devices/dev_base.py
+++ b/src/ramses_rf/devices/dev_base.py
@@ -277,13 +277,10 @@ class DeviceBase(Entity):
         :return: True if the device has a battery, False otherwise.
         :rtype: None | bool
         """
-        if self._gateway.message_store:
-            code_list = await self.entity_state._msg_dev_qry()
-            return isinstance(self, BatteryState) or (
-                code_list is not None and Code._1060 in code_list
-            )  # TODO(eb): clean up next line Q1 2026
-        msgs = await self.entity_state.get_message_log_flat()
-        return isinstance(self, BatteryState) or Code._1060 in msgs
+        return isinstance(self, BatteryState) or (
+            self.power_state.battery_low is not None
+            or self.power_state.battery_level is not None
+        )
 
     @property
     def polling_interval(self) -> PollingIntervalsT | None:

--- a/src/ramses_rf/devices/heat_sensors.py
+++ b/src/ramses_rf/devices/heat_sensors.py
@@ -12,7 +12,7 @@ from ramses_rf.enums import Action, ZoneRole
 from ramses_rf.messages import Message
 from ramses_rf.models import DeviceTraits
 from ramses_tx import Packet
-from ramses_tx.const import FA, Code
+from ramses_tx.const import FA, RQ, Code
 from ramses_tx.typing import PayDictT
 
 from .dev_base import BatteryState, DeviceHeat, Fakeable
@@ -164,7 +164,9 @@ class DhwSensor(
 
     async def dhw_params(self) -> PayDictT._10A0 | None:
         """Return the DHW parameters (10A0) payload or None."""
-        return await self.entity_state.get_value(Code._10A0)
+        return await self.entity_state.get_value(
+            Code._10A0, verb=RQ
+        ) or await self.entity_state.get_value(Code._10A0)
 
     async def params(self) -> dict[str, Any]:
         """Return the device parameter dictionary."""

--- a/src/ramses_rf/dispatcher.py
+++ b/src/ramses_rf/dispatcher.py
@@ -133,9 +133,14 @@ async def process_msg(gateway: Gateway, msg: Message) -> None:
 
     else:
         _log_message(gateway, msg)
+        if hasattr(gateway, "_state_cache") and hasattr(
+            gateway, "_history_lock"
+        ):
+            with gateway._history_lock:
+                gateway._state_cache[msg.state_header] = msg
         if gateway.message_store:
+            # Asynchronous background logging sink if SQLite is enabled
             gateway.message_store.add(msg)
-            # why add it? enable for evohome
 
 
 # TODO: this needs cleaning up (e.g. handle intervening packet)

--- a/src/ramses_rf/gateway.py
+++ b/src/ramses_rf/gateway.py
@@ -53,6 +53,7 @@ from .messages import ApplicationMessage, Message as rf_msg
 from .pipeline.conversation import ConversationManager
 from .pipeline.polling import PollingManager
 from .pipeline.topology_builder import TopologyBuilder
+from .routing import StateHeader
 from .schemas import (
     SCH_GLOBAL_SCHEMAS,
     SZ_CONFIG,
@@ -250,6 +251,7 @@ class Gateway(GatewayLifecycle, GatewayInterface):
 
         self._prev_msg: ApplicationMessage | None = None
         self._this_msg: ApplicationMessage | None = None
+        self._state_cache: dict[StateHeader, rf_msg] = {}
         self._history_lock = threading.Lock()
 
         # 1. Controller Knowledge Bridge
@@ -367,6 +369,7 @@ class Gateway(GatewayLifecycle, GatewayInterface):
         with self._history_lock:
             self._prev_msg = None
             self._this_msg = None
+            self._state_cache.clear()
 
     @property
     def tcs(self) -> Evohome | None:
@@ -478,30 +481,34 @@ class Gateway(GatewayLifecycle, GatewayInterface):
         :rtype: tuple[dict[str, Any], dict[str, Any]]
         """
         state_dict: dict[str, Any] = {}
-        if self.message_store is not None:
+        with self._history_lock:
+            cached_messages = list(self._state_cache.values())
+
+        if not cached_messages and self.message_store is not None:
             # Use getattr fallback in case interface strictly lacks state_cache mapping
-            state_cache = getattr(self.message_store, "state_cache", {})
+            state_cache_map = getattr(self.message_store, "state_cache", {})
+            cached_messages = list(state_cache_map.values())
 
-            for msg in state_cache.values():
-                if msg.verb not in (I_, RP):
-                    continue
+        for msg in cached_messages:
+            if msg.verb not in (I_, RP):
+                continue
 
-                dtm_str = msg.dtm.isoformat(timespec="microseconds")
-                state_dict[dtm_str] = {
-                    "verb": msg.verb,
-                    "src": msg.src.id,  # Keep for downstream legacy parsers
-                    "dst": msg.dst.id,  # Keep for downstream legacy parsers
-                    "addr1": msg._addrs[0].id,  # <-- Exact raw addr1
-                    "addr2": msg._addrs[1].id,  # <-- Exact raw addr2
-                    "addr3": msg._addrs[2].id,  # <-- Exact raw addr3
-                    "code": str(msg.code),
-                    "payload": _payload_to_serialisable(msg.payload),
-                    # Frame string is required by _restore_cached_packets /
-                    # Packet.from_dict to reconstruct the Packet on warm restart.
-                    # Without it, from_dict gets an empty frame body and raises
-                    # "Bad frame: Invalid structure: >>><<<" (issue 812).
-                    "frame": getattr(msg, "raw_frame", ""),
-                }
+            dtm_str = msg.dtm.isoformat(timespec="microseconds")
+            state_dict[dtm_str] = {
+                "verb": msg.verb,
+                "src": msg.src.id,  # Keep for downstream legacy parsers
+                "dst": msg.dst.id,  # Keep for downstream legacy parsers
+                "addr1": msg._addrs[0].id,  # <-- Exact raw addr1
+                "addr2": msg._addrs[1].id,  # <-- Exact raw addr2
+                "addr3": msg._addrs[2].id,  # <-- Exact raw addr3
+                "code": str(msg.code),
+                "payload": _payload_to_serialisable(msg.payload),
+                # Frame string is required by _restore_cached_packets /
+                # Packet.from_dict to reconstruct the Packet on warm restart.
+                # Without it, from_dict gets an empty frame body and raises
+                # "Bad frame: Invalid structure: >>><<<" (issue 812).
+                "frame": getattr(msg, "raw_frame", ""),
+            }
 
         schema_dict = await self.schema()
         return schema_dict, state_dict
@@ -516,11 +523,13 @@ class Gateway(GatewayLifecycle, GatewayInterface):
         app_msg.bind_context(self)  # noqa: B010
         self.update_message_history(app_msg)
 
-        assert self._this_msg
-
-        if self._prev_msg and detect_array_fragment(
-            self._this_msg,
-            self._prev_msg,
+        if (
+            self._this_msg
+            and self._prev_msg
+            and detect_array_fragment(
+                self._this_msg,
+                self._prev_msg,
+            )
         ):
             app_msg._force_has_array()
             app_msg._payload = self._prev_msg.payload + (

--- a/src/ramses_rf/state/entity_state.py
+++ b/src/ramses_rf/state/entity_state.py
@@ -18,7 +18,7 @@ from ramses_rf.const import SZ_DHW_INDEX, SZ_DOMAIN_INDEX, SZ_ZONE_INDEX
 from ramses_tx.address import ALL_DEVICE_ID
 
 # noqa: F401, isort: skip, pylint: disable=unused-import
-from ramses_tx.const import I_, RP, RQ, Code, Verb
+from ramses_tx.const import F9, FA, FC, I_, RP, RQ, Code, Verb
 from ramses_tx.typing import PayDictT
 
 from .. import exceptions as exc
@@ -548,7 +548,7 @@ class EntityState:
                 in_dict = isinstance(msg.payload, dict)
                 in_list = isinstance(msg.payload, list)
                 if (
-                    context_value in ("FC", "FA", "F9", "FA")
+                    context_value in (FC, FA, F9)
                     or (
                         in_dict
                         and (
@@ -657,12 +657,12 @@ class EntityState:
                 in_list = isinstance(msg.payload, list)
                 if not (
                     str(context_value) == str(dhw_index)
-                    or context_value in ("FC", "FA", "F9", "FA")
-                    or (in_dict and "dhw_index" in msg.payload)
+                    or context_value in (FC, FA, F9)
+                    or (in_dict and SZ_DHW_INDEX in msg.payload)
                     or (
                         in_list
                         and any(
-                            isinstance(d, dict) and "dhw_index" in d
+                            isinstance(d, dict) and SZ_DHW_INDEX in d
                             for d in msg.payload
                         )
                     )

--- a/src/ramses_rf/state/store.py
+++ b/src/ramses_rf/state/store.py
@@ -101,7 +101,15 @@ class MessageStore(MessageStoreInterface):
         db_path: str = ":memory:",
         disk_path: str | None = "ramses.db",
     ) -> None:
-        """Instantiate a message database/index."""
+        """Instantiate a message database/index.
+
+        :param maintain: Whether to run background housekeeping/pruning loops.
+        :type maintain: bool
+        :param db_path: Database connection URI or path.
+        :type db_path: str
+        :param disk_path: Target disk path for SQLite DB, or None for in-memory only.
+        :type disk_path: str | None
+        """
         self.maintain = maintain
         # In-memory RAM caches (Filled & cleaned up in housekeeping_loop)
         # stores all messages for retrieval.

--- a/src/ramses_rf/systems/zones.py
+++ b/src/ramses_rf/systems/zones.py
@@ -20,7 +20,6 @@ from ramses_rf.const import (
     SZ_RELAY_DEMAND,
     SZ_SETPOINT,
     SZ_TEMPERATURE,
-    SZ_ZONE_IDX,
     SZ_ZONE_INDEX,
     ZON_MODE_MAP,
     ZON_ROLE_MAP,
@@ -675,48 +674,15 @@ class Zone(ZoneSchedule):
         return str(ZON_ROLE_MAP[slug])
 
     async def name(self) -> str | None:  # 0004
-        """Get the name of the zone."""
-        # Primary check against the active CQRS State Projector
-        if self.zone_state.name is not None:
-            return self.zone_state.name
+        """Get the name of the zone.
 
-        # Retroactive Event-Sourced Hydration: Bypasses the soon-to-be-deleted
-        # EntityState by hydrating late-instantiated entities directly from the Store
-        if self._gateway.message_store:
-            msgs = await self._gateway.message_store.get(
-                code=Code._0004, source=self._z_id
-            )
-            for msg in reversed(msgs):
-                p_load = msg.payload
-                if isinstance(p_load, dict):
-                    if (
-                        str(p_load.get(SZ_ZONE_INDEX, p_load.get(SZ_ZONE_IDX)))
-                        == self.index
-                        and SZ_NAME in p_load
-                    ):
-                        self.zone_state = dataclasses.replace(
-                            self.zone_state, name=str(p_load[SZ_NAME])
-                        )
-                        return self.zone_state.name
-                elif isinstance(p_load, list):
-                    for item in p_load:
-                        if isinstance(item, dict):
-                            if (
-                                str(
-                                    item.get(
-                                        SZ_ZONE_INDEX, item.get(SZ_ZONE_IDX)
-                                    )
-                                )
-                                == self.index
-                                and SZ_NAME in item
-                            ):
-                                self.zone_state = dataclasses.replace(
-                                    self.zone_state, name=str(item[SZ_NAME])
-                                )
-                                return self.zone_state.name
+        Prefers live CQRS ZoneState from RF packets (0004), falling back to
+        static schema configuration (_name).
 
-        # Legacy fallback logic pending the F4-PR2 Lobotomy
-        return self._name
+        :returns: The zone name, or None if not set.
+        :rtype: str | None
+        """
+        return self.zone_state.name or self._name
 
     async def config(self) -> dict[str, Any] | None:  # 000A
         """Return zone configuration dictionary."""

--- a/tests/tests_rf/test_devices.py
+++ b/tests/tests_rf/test_devices.py
@@ -998,3 +998,31 @@ async def test_otb_gateway_schema_and_params_constants(
     assert SZ_RAMSES_II_SCHEMA in schema
     assert SZ_OPENTHERM_PARAMS in params
     assert SZ_RAMSES_II_PARAMS in params
+
+
+@pytest.mark.asyncio
+async def test_has_battery_read_model(
+    mock_gwy: MagicMock, mock_addr: MagicMock
+) -> None:
+    """Verify has_battery correctly checks BatteryState and power_state."""
+    # Arrange
+    thm = Thermostat(mock_gwy, mock_addr)
+    bdr_addr = MagicMock(spec=Address)
+    bdr_addr.id = "13:123456"
+    bdr_addr.type = "13"
+    bdr = BdrSwitch(mock_gwy, bdr_addr)
+
+    # Act
+    thm_has_bat = await thm.has_battery()
+    bdr_has_bat = await bdr.has_battery()
+
+    # Assert
+    assert thm_has_bat is True
+    assert bdr_has_bat is False
+
+    # Act 2 - Non-BatteryState device with power_state hydrated
+    bdr.power_state = replace(bdr.power_state, battery_low=False)
+    bdr_hydrated_bat = await bdr.has_battery()
+
+    # Assert 2
+    assert bdr_hydrated_bat is True

--- a/tests/tests_rf/test_dispatcher.py
+++ b/tests/tests_rf/test_dispatcher.py
@@ -2,6 +2,7 @@
 """RAMSES RF - Unittests for dispatcher."""
 
 import logging
+import threading
 from collections.abc import Generator
 from datetime import datetime as dt, timedelta as td
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -862,3 +863,27 @@ class TestCommandDispatcherSend:
         # Assert
         assert isinstance(result, Message)
         assert result.code == Code._313F
+
+    @pytest.mark.asyncio
+    async def test_dispatcher_state_cache_update(
+        self, mock_gateway: MagicMock
+    ) -> None:
+        """Verify process_msg updates state_cache and message_store on valid message ingestion."""
+        # Arrange
+        mock_gateway.message_store = MagicMock()
+        mock_gateway.message_store.add = MagicMock()
+        mock_gateway.state_projector = MagicMock()
+        mock_gateway._state_cache = {}
+        mock_gateway._history_lock = threading.Lock()
+        packet = Packet(
+            dt.now(),
+            "...  I --- 04:189078 --:------ 01:145038 3150 002 0100",
+        )
+        msg = Message._from_packet(packet)
+
+        # Act
+        await dispatcher.process_msg(mock_gateway, msg)
+
+        # Assert
+        assert msg.state_header in mock_gateway._state_cache
+        mock_gateway.message_store.add.assert_called_once_with(msg)

--- a/tests/tests_rf/test_gateway.py
+++ b/tests/tests_rf/test_gateway.py
@@ -587,3 +587,28 @@ async def test_create_stack_integration(index: str) -> None:
         transport.close()
     finally:
         await rf.stop()
+
+
+@pytest.mark.asyncio
+async def test_gateway_get_state_in_memory() -> None:
+    """Verify Gateway.get_state extracts state from in-memory state_cache with 0 disk I/O."""
+    # Arrange
+    gateway = Gateway("/dev/null", config=GatewayConfig(database_path=None))
+    packet = Packet.from_port(
+        dt.now(),
+        "000  I --- 01:145038 --:------ 01:145038 1F09 003 0007D0",
+    )
+    msg = Message._from_packet(packet)
+    gateway._state_cache[msg.state_header] = msg
+
+    # Act
+    schema, packets = await gateway.get_state()
+
+    # Assert
+    assert isinstance(schema, dict)
+    assert isinstance(packets, dict)
+    assert len(packets) == 1
+    packet_data = next(iter(packets.values()))
+    assert packet_data["code"] == Code._1F09
+    assert packet_data["verb"] == I_
+    assert packet_data["src"] == "01:145038"

--- a/tests/tests_rf/test_state.py
+++ b/tests/tests_rf/test_state.py
@@ -312,3 +312,21 @@ class TestMessageStore:
         assert res[0].payload == self.msg4.payload
 
         msg_db.stop()
+
+    @pytest.mark.asyncio
+    async def test_message_store_memory_mode(self) -> None:
+        """Verify MessageStore with disk_path=None initializes purely in RAM."""
+        # Arrange
+        store = MessageStore(maintain=False, disk_path=None)
+
+        # Act
+        store.add(self.msg1)
+        res = await store.get(code=Code._1298)
+
+        # Assert
+        assert store._worker is None
+        assert len(res) == 1
+        assert res[0].code == Code._1298
+        assert self.msg1.state_header in store.state_cache
+
+        store.stop()

--- a/tests/tests_rf/test_systems.py
+++ b/tests/tests_rf/test_systems.py
@@ -499,6 +499,22 @@ async def test_zone_name_from_cqrs_state(mock_tcs: MagicMock) -> None:
     mock_tcs._gateway.message_store.get.assert_not_called()
 
 
+@pytest.mark.asyncio
+async def test_zone_name_fallback_to_schema_name(mock_tcs: MagicMock) -> None:
+    """Test zone name falls back to _name when zone_state.name is None."""
+    # Arrange
+    zon = Zone(mock_tcs, "01")
+    zon._name = "Kitchen"
+    mock_tcs._gateway.message_store = AsyncMock()
+
+    # Act
+    result = await zon.name()
+
+    # Assert
+    assert result == "Kitchen"
+    mock_tcs._gateway.message_store.get.assert_not_called()
+
+
 # --- Window Open State Aggregation Tests ---
 
 


### PR DESCRIPTION
This PR fixes issue #1148.

- [x] I have reviewed and tested these code changes myself, successfully ran pre-commit hooks and am available to address review comments.
- [x] AI Coding Assistance disclosure: used for 100%

### The Problem:
Entities (`Zone.name()` and `DeviceBase.has_battery()`) executed retroactive SQLite queries (`message_store.get()`) to retrieve historical packets for property lookups, introducing disk I/O onto the live ingestion and property query paths.

### The Fix:
- Cut over `Zone.name()` directly to the in-memory CQRS `ZoneState.name` read-model, falling back to static schema configuration `_name`.
- Cut over `DeviceBase.has_battery()` to `BatteryState` and `self.power_state` dataclasses.
- Maintained backward-compatible SQLite logging with `GatewayConfig.database_path: str | None = "ramses.db"` by default (Option 1), while fully supporting `database_path=None` for 100% in-memory execution with zero worker threads and zero disk writes.
- Added native `_state_cache` on `Gateway` to rehydrate state headers in RAM during warm restarts without disk I/O.
- Updated `ramses_cli` (`show_crazys`) to inspect device state caches directly.
- Updated `DhwSensor.dhw_params()` to query `verb=RQ` for periodic announcement compatibility.
- Migrated touched string literals to canonical `Code` and `SZ_*` constants.
- Added comprehensive AAA unit tests for read-model lookups and in-memory state rehydration.

### Testing Performed:
- `prek run -a`: All hooks and linters passed.
- `mypy --strict .`: 0 issues found across 277 source files.
- `pytest -n auto` (`ramses_rf`): 2,881 passed, 105 snapshots passed, 0 failures.
- `pytest -n auto` (`ramses_cc`): 1,458 passed, 3 snapshots passed, 0 failures.

### AI Assistance Disclosure:
This contribution was developed with the assistance of Google Gemini 3.7 Flash for code generation and documentation. All logic and implementations were reviewed and verified by the author.