### PR TITLE
refactor(commands): cut over outbound dispatch to CommandDispatcher and deprecate legacy send APIs (#1150)

### DIFF
--- a/src/ramses_cli/discovery.py
+++ b/src/ramses_cli/discovery.py
@@ -12,9 +12,10 @@ from typing import TYPE_CHECKING, Any, Final
 
 from ramses_rf import exceptions as exc
 from ramses_rf.address import HGI_DEV_ADDR, Address
-from ramses_rf.commands.builders import build_dto
 from ramses_rf.commands.core import Command as Intent
 from ramses_rf.const import (
+    FC,
+    HW,
     SZ_FRAGMENT_NUMBER,
     SZ_LOG_INDEX,
     SZ_MESSAGE_ID,
@@ -26,7 +27,7 @@ from ramses_rf.devices import Controller, Fakeable
 from ramses_rf.enums import Action
 from ramses_rf.protocol.opentherm import OPENTHERM_DATA_IDS
 from ramses_rf.protocol.ramses import CODE_NAME_LOOKUP, RQ_NO_PAYLOAD
-from ramses_tx import CommandDTO, DeviceIdT, Priority
+from ramses_tx import CommandDTO, DeviceIdT, Packet, Priority
 from ramses_tx.address import NON_DEV_ADDR
 from ramses_tx.const import RQ, W_, Code
 
@@ -50,6 +51,31 @@ SCAN_XXXX: Final = "scan_xxxx"
 _LOGGER = logging.getLogger(__name__)
 
 
+def _send_probe_dto(
+    gateway: Gateway,
+    command: CommandDTO,
+    /,
+    *,
+    priority: Priority = Priority.DEFAULT,
+    num_repeats: int = 1,
+) -> asyncio.Task[Packet]:
+    """Schedule low-level command transmission as a background task for CLI discovery scripts."""
+    coro = gateway._async_send_dto(
+        command, priority=priority, num_repeats=num_repeats
+    )
+    task = gateway._engine._loop.create_task(coro)
+
+    def _clear_exc(fut: asyncio.Task[Any]) -> None:
+        if not fut.cancelled() and fut.exception():
+            _LOGGER.debug(
+                "Background discovery task failed: %s", fut.exception()
+            )
+
+    task.add_done_callback(_clear_exc)
+    gateway.add_task(task)
+    return task
+
+
 def script_decorator(fnc: Callable[..., Any]) -> Callable[..., Any]:
     """Decorate a script to broadcast 'Script begins:' and 'Script done.' messages.
 
@@ -59,28 +85,26 @@ def script_decorator(fnc: Callable[..., Any]) -> Callable[..., Any]:
 
     @functools.wraps(fnc)
     async def wrapper(gateway: Gateway, *args: Any, **kwargs: Any) -> None:
-        command = build_dto(
-            Intent(
-                src=HGI_DEV_ADDR,
-                dst=HGI_DEV_ADDR,
-                action=Action.SEND_PUZZLE,
-                data={"message": "Script begins:"},
-            )
+        start_intent = Intent(
+            src=HGI_DEV_ADDR,
+            dst=HGI_DEV_ADDR,
+            action=Action.SEND_PUZZLE,
+            data={"message": "Script begins:"},
         )
-        gateway.send_cmd(command, priority=Priority.HIGHEST, num_repeats=3)
+        gateway.dispatcher.send_background(
+            start_intent, priority=Priority.HIGHEST
+        )
 
         await fnc(gateway, *args, **kwargs)
 
-        finish_command = build_dto(
-            Intent(
-                src=HGI_DEV_ADDR,
-                dst=HGI_DEV_ADDR,
-                action=Action.SEND_PUZZLE,
-                data={"message": "Script done."},
-            )
+        finish_intent = Intent(
+            src=HGI_DEV_ADDR,
+            dst=HGI_DEV_ADDR,
+            action=Action.SEND_PUZZLE,
+            data={"message": "Script done."},
         )
-        gateway.send_cmd(
-            finish_command, priority=Priority.LOWEST, num_repeats=3
+        gateway.dispatcher.send_background(
+            finish_intent, priority=Priority.LOWEST
         )
 
     return wrapper
@@ -140,7 +164,7 @@ async def exec_cmd(gateway: Gateway, **kwargs: Any) -> None:
     :param kwargs: CLI parameters containing the 'EXEC_CMD' string.
     """
     command = CommandDTO.from_cli(kwargs[EXEC_CMD])
-    await gateway.async_send_cmd(command, priority=Priority.HIGH)
+    await gateway._async_send_dto(command, priority=Priority.HIGH)
 
 
 async def get_faults(
@@ -173,73 +197,74 @@ async def get_schedule(
     """Retrieve the zone schedule for a specific zone under a controller.
 
     :param gateway: The gateway instance.
-    :param controller_id: The device ID of the controller.
-    :param zone_index: The zone index string (e.g. "00" or "HW").
+    :param controller_id: The device ID of the controller to query.
+    :param zone_index: The zone index to fetch schedule for.
     """
     controller = gateway.device_registry.get_device(
         controller_id, cls=Controller
     )
-    if not controller.tcs:
-        _LOGGER.error("get_schedule(): Controller has no TCS active.")
-        return
-
-    zone = controller.tcs.get_htg_zone(zone_index)
 
     try:
-        await zone.get_schedule()
+        if zone_index == HW:
+            if controller.tcs and controller.tcs.dhw:
+                await controller.tcs.dhw.get_schedule()
+        elif controller.tcs:
+            zone = controller.tcs.get_htg_zone(zone_index)
+            if zone:
+                await zone.get_schedule()
     except exc.ExpiredCallbackError as err:
         _LOGGER.error("get_schedule(): Function timed out: %s", err)
 
 
 async def set_schedule(
-    gateway: Gateway, controller_id: DeviceIdT, schedule: str
+    gateway: Gateway, controller_id: DeviceIdT, schedule_input: str | Any
 ) -> None:
     """Set the zone schedule for a specific zone under a controller via JSON payload.
 
     :param gateway: The gateway instance.
-    :param controller_id: The device ID of the controller.
-    :param schedule: A JSON string describing the full schedule dictionary.
+    :param controller_id: The device ID of the controller to command.
+    :param schedule_input: A JSON string, file-like object, or file path describing the schedule.
     """
-    schedule_ = json.loads(schedule)
-    zone_index = schedule_.get(SZ_ZONE_INDEX, schedule_.get("zone_index"))
+    if hasattr(schedule_input, "read"):
+        schedule_ = json.load(schedule_input)
+    elif isinstance(schedule_input, str):
+        try:
+            schedule_ = json.loads(schedule_input)
+        except json.JSONDecodeError:
+            with open(schedule_input) as schedule_file:  # noqa: ASYNC230
+                schedule_ = json.load(schedule_file)
+    else:
+        schedule_ = schedule_input
+
+    zone_index = schedule_.get(
+        SZ_ZONE_INDEX, schedule_.get("zone_index", "00")
+    )
+    schedule = schedule_.get(SZ_SCHEDULE, schedule_)
 
     controller = gateway.device_registry.get_device(
         controller_id, cls=Controller
     )
-    if not controller.tcs:
-        _LOGGER.error("set_schedule(): Controller has no TCS active.")
-        return
-
-    zone = controller.tcs.get_htg_zone(zone_index)
 
     try:
-        await zone.set_schedule(schedule_[SZ_SCHEDULE])  # 0404
+        if zone_index == HW:
+            if controller.tcs and controller.tcs.dhw:
+                await controller.tcs.dhw.set_schedule(schedule)
+        elif controller.tcs:
+            zone = controller.tcs.get_htg_zone(zone_index)
+            if zone:
+                await zone.set_schedule(schedule)
+
     except exc.ExpiredCallbackError as err:
         _LOGGER.error("set_schedule(): Function timed out: %s", err)
 
 
-async def script_bind_req(
-    gateway: Gateway, device_id: DeviceIdT, code: Code = Code._2309
-) -> None:
-    """Make the targeted device artificially enter a supplicant bind phase.
-
-    :param gateway: The gateway instance.
-    :param device_id: The device ID to transition to binding state.
-    :param code: The code to offer during the bind request.
-    """
-    device = gateway.device_registry.get_device(device_id)
-    assert isinstance(device, Fakeable)  # mypy
-    device._make_fake()
-    await device._initiate_binding_process([code])
-
-
-async def script_bind_wait(
+async def script_bind_device(
     gateway: Gateway,
     device_id: DeviceIdT,
-    code: Code = Code._2309,
+    code: Code,
     zone_index: IndexT = "00",
 ) -> None:
-    """Make the targeted device artificially enter a respondent bind phase.
+    """Put a device into binding mode and wait for binding packets to exchange.
 
     :param gateway: The gateway instance.
     :param device_id: The device ID to transition to binding state.
@@ -270,7 +295,7 @@ def script_poll_device(
     ) -> None:
         async def periodic_(interval_: float) -> None:
             await asyncio.sleep(interval_)
-            gateway.send_cmd(command, priority=Priority.LOW)
+            _send_probe_dto(gateway, command, priority=Priority.LOW)
 
         if interval is None:
             interval = 0 if count == 1 else 60
@@ -325,16 +350,15 @@ async def script_scan_full(gateway: Gateway, device_id: DeviceIdT) -> None:
     """
     _LOGGER.warning("scan_full() invoked - expect a lot of Warnings")
 
-    gateway.send_cmd(
-        (
-            CommandDTO(
-                verb=RQ,
-                addr1=HGI_DEV_ADDR.id,
-                addr2=device_id,
-                addr3=NON_DEV_ADDR.id,
-                code=Code._0016,
-                payload="0000",
-            )
+    _send_probe_dto(
+        gateway,
+        CommandDTO(
+            verb=RQ,
+            addr1=HGI_DEV_ADDR.id,
+            addr2=device_id,
+            addr3=NON_DEV_ADDR.id,
+            code=Code._0016,
+            payload="0000",
         ),
         num_repeats=3,
     )
@@ -342,7 +366,8 @@ async def script_scan_full(gateway: Gateway, device_id: DeviceIdT) -> None:
     for code in sorted(CODE_NAME_LOOKUP):
         if code == Code._0005:
             for zone_type in range(20):  # known up to 18
-                gateway.send_cmd(
+                _send_probe_dto(
+                    gateway,
                     CommandDTO(
                         verb=RQ,
                         addr1=HGI_DEV_ADDR.id,
@@ -350,12 +375,13 @@ async def script_scan_full(gateway: Gateway, device_id: DeviceIdT) -> None:
                         addr3=NON_DEV_ADDR.id,
                         code=code,
                         payload=f"00{zone_type:02X}",
-                    )
+                    ),
                 )
 
         elif code == Code._000C:
             for zone_index in range(16):  # also: FA-FF?
-                gateway.send_cmd(
+                _send_probe_dto(
+                    gateway,
                     CommandDTO(
                         verb=RQ,
                         addr1=HGI_DEV_ADDR.id,
@@ -363,15 +389,16 @@ async def script_scan_full(gateway: Gateway, device_id: DeviceIdT) -> None:
                         addr3=NON_DEV_ADDR.id,
                         code=code,
                         payload=f"{zone_index:02X}00",
-                    )
+                    ),
                 )
 
         elif code == Code._0016:
             continue
 
         elif code in (Code._01D0, Code._01E9):
-            for str_zone_index in ("00", "01", "FC"):
-                gateway.send_cmd(
+            for str_zone_index in ("00", "01", FC):
+                _send_probe_dto(
+                    gateway,
                     CommandDTO(
                         verb=W_,
                         addr1=HGI_DEV_ADDR.id,
@@ -379,9 +406,10 @@ async def script_scan_full(gateway: Gateway, device_id: DeviceIdT) -> None:
                         addr3=NON_DEV_ADDR.id,
                         code=code,
                         payload=f"{str_zone_index}00",
-                    )
+                    ),
                 )
-                gateway.send_cmd(
+                _send_probe_dto(
+                    gateway,
                     CommandDTO(
                         verb=W_,
                         addr1=HGI_DEV_ADDR.id,
@@ -389,88 +417,77 @@ async def script_scan_full(gateway: Gateway, device_id: DeviceIdT) -> None:
                         addr3=NON_DEV_ADDR.id,
                         code=code,
                         payload=f"{str_zone_index}03",
-                    )
+                    ),
                 )
 
         elif code == Code._0404:  # FIXME
-            cmd1 = build_dto(
-                Intent(
-                    src=HGI_DEV_ADDR,
-                    dst=Address(device_id),
-                    action=Action.GET_SCHEDULE_FRAGMENT,
-                    data={
-                        SZ_ZONE_INDEX: "HW",
-                        SZ_FRAGMENT_NUMBER: 1,
-                        SZ_TOTAL_FRAGMENTS: 0,
-                    },
-                )
+            intent1 = Intent(
+                src=HGI_DEV_ADDR,
+                dst=Address(device_id),
+                action=Action.GET_SCHEDULE_FRAGMENT,
+                data={
+                    SZ_ZONE_INDEX: HW,
+                    SZ_FRAGMENT_NUMBER: 1,
+                    SZ_TOTAL_FRAGMENTS: 0,
+                },
             )
-            gateway.send_cmd(cmd1)
-            cmd2 = build_dto(
-                Intent(
-                    src=HGI_DEV_ADDR,
-                    dst=Address(device_id),
-                    action=Action.GET_SCHEDULE_FRAGMENT,
-                    data={
-                        SZ_ZONE_INDEX: "00",
-                        SZ_FRAGMENT_NUMBER: 1,
-                        SZ_TOTAL_FRAGMENTS: 0,
-                    },
-                )
+            gateway.dispatcher.send_background(intent1)
+            intent2 = Intent(
+                src=HGI_DEV_ADDR,
+                dst=Address(device_id),
+                action=Action.GET_SCHEDULE_FRAGMENT,
+                data={
+                    SZ_ZONE_INDEX: "00",
+                    SZ_FRAGMENT_NUMBER: 1,
+                    SZ_TOTAL_FRAGMENTS: 0,
+                },
             )
-            gateway.send_cmd(cmd2)
+            gateway.dispatcher.send_background(intent2)
 
         elif code == Code._0418:
             for log_index in range(2):
-                cmd3 = build_dto(
-                    Intent(
-                        src=HGI_DEV_ADDR,
-                        dst=Address(device_id),
-                        action=Action.GET_FAULTLOG_ENTRY,
-                        data={SZ_LOG_INDEX: log_index},
-                    )
+                intent3 = Intent(
+                    src=HGI_DEV_ADDR,
+                    dst=Address(device_id),
+                    action=Action.GET_FAULTLOG_ENTRY,
+                    data={SZ_LOG_INDEX: log_index},
                 )
-                gateway.send_cmd(cmd3)
+                gateway.dispatcher.send_background(intent3)
 
         elif code == Code._1100:
-            cmd4 = build_dto(
-                Intent(
-                    src=HGI_DEV_ADDR,
-                    dst=Address(device_id),
-                    action=Action.GET_TPI_PARAMS,
-                    data={},
-                )
+            intent4 = Intent(
+                src=HGI_DEV_ADDR,
+                dst=Address(device_id),
+                action=Action.GET_TPI_PARAMS,
+                data={},
             )
-            gateway.send_cmd(cmd4)
+            gateway.dispatcher.send_background(intent4)
 
         elif code == Code._2E04:
-            command = build_dto(
-                Intent(
-                    src=HGI_DEV_ADDR,
-                    dst=Address(device_id),
-                    action=Action.GET_SYSTEM_MODE,
-                    data={},
-                )
+            intent_mode = Intent(
+                src=HGI_DEV_ADDR,
+                dst=Address(device_id),
+                action=Action.GET_SYSTEM_MODE,
+                data={},
             )
-            gateway.send_cmd(command)
+            gateway.dispatcher.send_background(intent_mode)
 
         elif code == Code._3220:
             for data_id in (0, 3):  # these are mandatory READ_DATA data_ids
-                command = build_dto(
-                    Intent(
-                        src=HGI_DEV_ADDR,
-                        dst=Address(device_id),
-                        action=Action.GET_OPENTHERM_DATA,
-                        data={"msg_id": data_id},
-                    )
+                intent_ot = Intent(
+                    src=HGI_DEV_ADDR,
+                    dst=Address(device_id),
+                    action=Action.GET_OPENTHERM_DATA,
+                    data={SZ_MESSAGE_ID: data_id},
                 )
-                gateway.send_cmd(command)
+                gateway.dispatcher.send_background(intent_ot)
 
         elif code == Code._PUZZ:
             continue
 
         elif code in RQ_NO_PAYLOAD:
-            gateway.send_cmd(
+            _send_probe_dto(
+                gateway,
                 CommandDTO(
                     verb=RQ,
                     addr1=HGI_DEV_ADDR.id,
@@ -478,11 +495,12 @@ async def script_scan_full(gateway: Gateway, device_id: DeviceIdT) -> None:
                     addr3=NON_DEV_ADDR.id,
                     code=code,
                     payload="00",
-                )
+                ),
             )
 
         else:
-            gateway.send_cmd(
+            _send_probe_dto(
+                gateway,
                 CommandDTO(
                     verb=RQ,
                     addr1=HGI_DEV_ADDR.id,
@@ -490,12 +508,13 @@ async def script_scan_full(gateway: Gateway, device_id: DeviceIdT) -> None:
                     addr3=NON_DEV_ADDR.id,
                     code=code,
                     payload="0000",
-                )
+                ),
             )
 
     # these are possible/difficult codes
     for code in (Code._0150, Code._2389):
-        gateway.send_cmd(
+        _send_probe_dto(
+            gateway,
             CommandDTO(
                 verb=RQ,
                 addr1=HGI_DEV_ADDR.id,
@@ -503,7 +522,7 @@ async def script_scan_full(gateway: Gateway, device_id: DeviceIdT) -> None:
                 addr3=NON_DEV_ADDR.id,
                 code=code,
                 payload="0000",
-            )
+            ),
         )
 
 
@@ -522,16 +541,14 @@ async def script_scan_hard(
     start_code = start_code or 0
 
     for code in range(start_code, 0x5000):
-        await gateway.async_send_cmd(
-            (
-                CommandDTO(
-                    verb=RQ,
-                    addr1=HGI_DEV_ADDR.id,
-                    addr2=device_id,
-                    addr3=NON_DEV_ADDR.id,
-                    code=f"{code:04X}",
-                    payload="0000",
-                )
+        await gateway._async_send_dto(
+            CommandDTO(
+                verb=RQ,
+                addr1=HGI_DEV_ADDR.id,
+                addr2=device_id,
+                addr3=NON_DEV_ADDR.id,
+                code=f"{code:04X}",
+                payload="0000",
             ),
             priority=Priority.LOW,
         )
@@ -557,7 +574,8 @@ async def script_scan_fan(gateway: Gateway, device_id: DeviceIdT) -> None:
         c for k in _DEV_KLASSES_HVAC.values() for c in k if c not in OUT_CODES
     )
     for code in OLD_CODES:
-        gateway.send_cmd(
+        _send_probe_dto(
+            gateway,
             CommandDTO(
                 verb=RQ,
                 addr1=HGI_DEV_ADDR.id,
@@ -565,7 +583,7 @@ async def script_scan_fan(gateway: Gateway, device_id: DeviceIdT) -> None:
                 addr3=NON_DEV_ADDR.id,
                 code=code,
                 payload="00",
-            )
+            ),
         )
 
     NEW_CODES = (
@@ -595,7 +613,8 @@ async def script_scan_fan(gateway: Gateway, device_id: DeviceIdT) -> None:
 
     for code in NEW_CODES:
         if code not in OLD_CODES and code not in OUT_CODES:
-            gateway.send_cmd(
+            _send_probe_dto(
+                gateway,
                 CommandDTO(
                     verb=RQ,
                     addr1=HGI_DEV_ADDR.id,
@@ -603,7 +622,7 @@ async def script_scan_fan(gateway: Gateway, device_id: DeviceIdT) -> None:
                     addr3=NON_DEV_ADDR.id,
                     code=code,
                     payload="00",
-                )
+                ),
             )
 
 
@@ -617,15 +636,13 @@ async def script_scan_otb(gateway: Gateway, device_id: DeviceIdT) -> None:
     _LOGGER.warning("script_scan_otb_full invoked - expect a lot of nonsense")
 
     for msg_id in OPENTHERM_DATA_IDS:
-        command = build_dto(
-            Intent(
-                src=HGI_DEV_ADDR,
-                dst=Address(device_id),
-                action=Action.GET_OPENTHERM_DATA,
-                data={SZ_MESSAGE_ID: msg_id},
-            )
+        intent = Intent(
+            src=HGI_DEV_ADDR,
+            dst=Address(device_id),
+            action=Action.GET_OPENTHERM_DATA,
+            data={SZ_MESSAGE_ID: msg_id},
         )
-        gateway.send_cmd(command)
+        gateway.dispatcher.send_background(intent)
 
 
 @script_decorator
@@ -638,15 +655,13 @@ async def script_scan_otb_hard(gateway: Gateway, device_id: DeviceIdT) -> None:
     _LOGGER.warning("script_scan_otb_hard invoked - expect a lot of nonsense")
 
     for msg_id in range(0x80):
-        command = build_dto(
-            Intent(
-                src=HGI_DEV_ADDR,
-                dst=Address(device_id),
-                action=Action.GET_OPENTHERM_DATA,
-                data={"msg_id": msg_id},
-            )
+        intent = Intent(
+            src=HGI_DEV_ADDR,
+            dst=Address(device_id),
+            action=Action.GET_OPENTHERM_DATA,
+            data={SZ_MESSAGE_ID: msg_id},
         )
-        gateway.send_cmd(command, priority=Priority.LOW)
+        gateway.dispatcher.send_background(intent, priority=Priority.LOW)
 
 
 @script_decorator
@@ -672,28 +687,25 @@ async def script_scan_otb_map(gateway: Gateway, device_id: DeviceIdT) -> None:
     }
 
     for code, msg_id in RAMSES_TO_OPENTHERM.items():
-        gateway.send_cmd(
-            (
-                CommandDTO(
-                    verb=RQ,
-                    addr1=HGI_DEV_ADDR.id,
-                    addr2=device_id,
-                    addr3=NON_DEV_ADDR.id,
-                    code=code,
-                    payload="00",
-                )
+        _send_probe_dto(
+            gateway,
+            CommandDTO(
+                verb=RQ,
+                addr1=HGI_DEV_ADDR.id,
+                addr2=device_id,
+                addr3=NON_DEV_ADDR.id,
+                code=code,
+                payload="00",
             ),
             priority=Priority.LOW,
         )
-        command = build_dto(
-            Intent(
-                src=HGI_DEV_ADDR,
-                dst=Address(device_id),
-                action=Action.GET_OPENTHERM_DATA,
-                data={"msg_id": msg_id},
-            )
+        intent = Intent(
+            src=HGI_DEV_ADDR,
+            dst=Address(device_id),
+            action=Action.GET_OPENTHERM_DATA,
+            data={SZ_MESSAGE_ID: msg_id},
         )
-        gateway.send_cmd(command, priority=Priority.LOW)
+        gateway.dispatcher.send_background(intent, priority=Priority.LOW)
 
 
 @script_decorator
@@ -725,7 +737,7 @@ async def script_scan_otb_ramses(
         Code._1260,  # dhw temp               / DHWTemperature
         Code._1290,  # outdoor temp           / OutsideTemperature
         Code._3200,  # boiler output temp     / BoilerWaterTemperature
-        Code._3210,  # boiler return temp     / ReturnWaterTemperature
+        Code._3210,  # boiler return temp     / BoilerWaterTemperature
         Code._0150,
         Code._12F0,  # dhw flow rate          / DHWFlowRate
         Code._1098,
@@ -737,16 +749,15 @@ async def script_scan_otb_ramses(
     )
 
     for code in _CODES:
-        gateway.send_cmd(
-            (
-                CommandDTO(
-                    verb=RQ,
-                    addr1=HGI_DEV_ADDR.id,
-                    addr2=device_id,
-                    addr3=NON_DEV_ADDR.id,
-                    code=code,
-                    payload="00",
-                )
+        _send_probe_dto(
+            gateway,
+            CommandDTO(
+                verb=RQ,
+                addr1=HGI_DEV_ADDR.id,
+                addr2=device_id,
+                addr3=NON_DEV_ADDR.id,
+                code=code,
+                payload="00",
             ),
             priority=Priority.LOW,
         )

--- a/src/ramses_rf/binding_fsm.py
+++ b/src/ramses_rf/binding_fsm.py
@@ -15,7 +15,6 @@ from typing import TYPE_CHECKING, Final
 import probatio as vol
 
 from ramses_rf.address import Address
-from ramses_rf.commands.builders import build_dto
 from ramses_rf.commands.core import Command as Intent
 from ramses_rf.enums import Action, DevType
 from ramses_tx import (
@@ -35,6 +34,8 @@ from .const import (  # noqa: F401, isort: skip, pylint: disable=unused-import
     RP,
     RQ,
     W_,
+    SZ_OEM_CODE,
+    SZ_PHASE,
     Code,
 )
 
@@ -45,9 +46,6 @@ if TYPE_CHECKING:
 
     from .interfaces import CommandDispatcher, DeviceInterface
 
-#
-# NOTE: All debug flags should be False for deployment to end-users
-_DBG_DISABLE_PHASE_ASSERTS: Final[bool] = False
 _DBG_MAINTAIN_STATE_CHAIN: Final[bool] = False  # maintain Context._prev_state
 
 _LOGGER = logging.getLogger(__name__)
@@ -153,13 +151,13 @@ class BindRole(StrEnum):
 
 
 SCHEME_LOOKUP = {
-    Vendor.ITHO: {"oem_code": "01"},
-    Vendor.BROFER: {"oem_code": "6A"},
-    Vendor.NUAIRE: {"oem_code": "6C"},
-    Vendor.CLIMARAD: {"oem_code": "65"},
-    Vendor.VASCO: {"oem_code": "66"},
-    Vendor.ORCON: {"oem_code": "67", "offer_to": ALL_DEVICE_ID},
-    Vendor.DEFAULT: {"oem_code": None},
+    Vendor.ITHO: {SZ_OEM_CODE: "01"},
+    Vendor.BROFER: {SZ_OEM_CODE: "6A"},
+    Vendor.NUAIRE: {SZ_OEM_CODE: "6C"},
+    Vendor.CLIMARAD: {SZ_OEM_CODE: "65"},
+    Vendor.VASCO: {SZ_OEM_CODE: "66"},
+    Vendor.ORCON: {SZ_OEM_CODE: "67", "offer_to": ALL_DEVICE_ID},
+    Vendor.DEFAULT: {SZ_OEM_CODE: None},
 }
 
 
@@ -308,7 +306,7 @@ class BindingManagerRespondent(BindingManagerBase):
         *,
         zone_index: IndexT = "00",
         require_ratify: bool = False,
-    ) -> tuple[Message, Packet, Message, Message | None]:
+    ) -> tuple[Message, Message, Message, Message | None]:
         """Device starts binding as a Respondent, by listening for an Offer.
 
         Returns the Supplicant's Offer or raises an exception if the binding is
@@ -359,42 +357,35 @@ class BindingManagerRespondent(BindingManagerBase):
 
     async def _accept_offer(
         self, tender: Message, codes: Iterable[Code], zone_index: IndexT = "00"
-    ) -> Packet:
-        """Resp sends an Accept on the basis of a rcvd Offer & returns the Confirm.
+    ) -> Message:
+        """Resp sends an Accept on the basis of a rcvd Offer & returns the sent message.
 
         :param tender: The received offer message.
         :param codes: Iterable of codes accepted.
         :param zone_index: The bound index.
-        :return: The sent accept packet.
+        :return: The sent accept message.
         """
-        command = build_dto(
-            Intent(
-                src=Address(self._dev.id),
-                dst=Address(tender.src.id),
-                action=Action.PUT_BIND,
-                data={"verb": W_, "codes": codes, "index": zone_index},
-            )
+        intent = Intent(
+            src=Address(self._dev.id),
+            dst=Address(tender.src.id),
+            action=Action.PUT_BIND,
+            data={"verb": W_, "codes": codes, "index": zone_index},
         )
-        if not _DBG_DISABLE_PHASE_ASSERTS:  # TODO: should be in test suite
-            assert (
-                Message._from_cmd(command).payload["phase"] == BindPhase.ACCEPT
-            )
-
-        packet: Packet = await self._dispatcher(  # type: ignore[assignment]
-            command, priority=Priority.HIGH, qos=BINDING_QOS
+        msg: Message = await self._dispatcher.send(
+            intent, priority=Priority.HIGH
         )
 
         self.state.cast_accept_offer()
-        return packet
+        return msg
 
     async def _wait_for_confirm(
         self,
-        accept: Packet,
+        accept: Message | Packet,
         timeout: float = _AFFIRM_WAIT_TIME,
     ) -> Message:
         """Resp waits timeout seconds for a Confirm to arrive & returns it.
 
-        :param accept: The accept packet previously sent.
+        :param accept: The accept message or packet previously sent.
         :param timeout: Time to wait in seconds.
         :return: The confirm message.
         """
@@ -402,12 +393,12 @@ class BindingManagerRespondent(BindingManagerBase):
 
     async def _wait_for_addenda(
         self,
-        accept: Packet,
+        accept: Message | Packet,
         timeout: float = _RATIFY_WAIT_TIME,
     ) -> Message:
         """Resp waits timeout seconds for an Addenda to arrive & returns it.
 
-        :param accept: The accept packet previously sent.
+        :param accept: The accept message or packet previously sent.
         :param timeout: Time to wait in seconds.
         :return: The addenda message.
         """
@@ -426,7 +417,7 @@ class BindingManagerSupplicant(BindingManagerBase):
         *,
         confirm_code: Code | None = None,
         ratify_command: CommandDTO | None = None,
-    ) -> tuple[Packet, Message, Packet, Packet | None]:
+    ) -> tuple[Message, Message, Message, Packet | None]:
         """Device starts binding as a Supplicant, by sending an Offer.
 
         Returns the Respondent's Accept, or raises an exception if the binding is
@@ -464,9 +455,9 @@ class BindingManagerSupplicant(BindingManagerBase):
         affirm = await self._confirm_accept(accept, confirm_code=confirm_code)
 
         # Step S3: Supplicant sends an Addenda (optional)
-        if vendor_code:
+        if vendor_code and ratify_command is not None:
             self.set_state(SuppIsReadyToSendAddenda)  # HACK: easiest way
-            ratify = await self._cast_addenda(accept, ratify_command)  # type: ignore[arg-type]
+            ratify = await self._cast_addenda(accept, ratify_command)
         else:
             ratify = None
 
@@ -477,50 +468,43 @@ class BindingManagerSupplicant(BindingManagerBase):
         self,
         codes: Iterable[Code],
         vendor_code: str | None = None,
-    ) -> Packet:
-        """Supp sends an Offer & returns the corresponding Packet.
+    ) -> Message:
+        """Supp sends an Offer & returns the corresponding Message.
 
         :param codes: Codes to offer.
         :param vendor_code: Optional vendor specific code block.
-        :return: The sent offer packet.
+        :return: The sent offer message.
         """
         # if vendor_code, send an 10E0
 
         # state = self.state
-        command = build_dto(
-            Intent(
-                src=Address(self._dev.id),
-                dst=Address(self._dev.id),
-                action=Action.PUT_BIND,
-                data={
-                    "verb": I_,
-                    "codes": codes,
-                    "vendor_code": vendor_code,
-                    "oem_code": vendor_code,
-                },
-            )
+        intent = Intent(
+            src=Address(self._dev.id),
+            dst=Address(self._dev.id),
+            action=Action.PUT_BIND,
+            data={
+                "verb": I_,
+                "codes": codes,
+                "vendor_code": vendor_code,
+                SZ_OEM_CODE: vendor_code,
+            },
         )
-        if not _DBG_DISABLE_PHASE_ASSERTS:  # TODO: should be in test suite
-            assert (
-                Message._from_cmd(command).payload["phase"] == BindPhase.TENDER
-            )
-
-        packet: Packet = await self._dispatcher(  # type: ignore[assignment]
-            command, priority=Priority.HIGH, qos=BINDING_QOS
+        msg: Message = await self._dispatcher.send(
+            intent, priority=Priority.HIGH
         )
 
         # await state._fut
         self.state.cast_offer()
-        return packet
+        return msg
 
     async def _wait_for_accept(
         self,
-        tender: Packet,
+        tender: Message | Packet,
         timeout: float = _ACCEPT_WAIT_TIME,
     ) -> Message:
         """Supp waits timeout seconds for an Accept to arrive & returns it.
 
-        :param tender: The previously sent offer packet.
+        :param tender: The previously sent offer message or packet.
         :param timeout: Time to wait in seconds.
         :return: The accept message.
         """
@@ -528,12 +512,12 @@ class BindingManagerSupplicant(BindingManagerBase):
 
     async def _confirm_accept(
         self, accept: Message, confirm_code: Code | None = None
-    ) -> Packet:
+    ) -> Message:
         """Supp casts a Confirm on the basis of a rcvd Accept & returns the Confirm.
 
         :param accept: The received accept message.
         :param confirm_code: The code to confirm with.
-        :return: The sent confirm packet.
+        :return: The sent confirm message.
         """
         # HACK assumes all index same
         if accept.payload and hasattr(accept.payload, "index"):
@@ -546,25 +530,18 @@ class BindingManagerSupplicant(BindingManagerBase):
         target_id = (
             accept.dst.id if accept.src.id == self._dev.id else accept.src.id
         )
-        command = build_dto(
-            Intent(
-                src=Address(self._dev.id),
-                dst=Address(target_id),
-                action=Action.PUT_BIND,
-                data={"verb": I_, "codes": confirm_code, "index": index},
-            )
+        intent = Intent(
+            src=Address(self._dev.id),
+            dst=Address(target_id),
+            action=Action.PUT_BIND,
+            data={"verb": I_, "codes": confirm_code, "index": index},
         )
-        if not _DBG_DISABLE_PHASE_ASSERTS:  # TODO: should be in test suite
-            assert (
-                Message._from_cmd(command).payload["phase"] == BindPhase.AFFIRM
-            )
-
-        packet: Packet = await self._dispatcher(  # type: ignore[assignment]
-            command, priority=Priority.HIGH, qos=BINDING_QOS
+        msg: Message = await self._dispatcher.send(
+            intent, priority=Priority.HIGH
         )
 
         await self.state.cast_confirm_accept()
-        return packet
+        return msg
 
     async def _cast_addenda(
         self, accept: Message, command: CommandDTO
@@ -575,9 +552,19 @@ class BindingManagerSupplicant(BindingManagerBase):
         :param command: The ratify command to cast.
         :return: The sent addenda packet.
         """
-        packet: Packet = await self._dispatcher(  # type: ignore[assignment]
-            command, priority=Priority.HIGH, qos=BINDING_QOS
-        )
+        gateway = getattr(self._dev, "_gateway", None)
+        if gateway is not None:
+            packet: Packet = await gateway._async_send_dto(
+                command, priority=Priority.HIGH
+            )
+        else:
+            send_dto = getattr(self._dispatcher, "_async_send_dto", None)
+            if send_dto is not None:
+                packet = await send_dto(command, priority=Priority.HIGH)
+            else:
+                raise RuntimeError(
+                    "No gateway or dispatcher available to send DTO"
+                )
 
         await self.state.cast_addenda()
         return packet

--- a/src/ramses_rf/commands/dispatcher.py
+++ b/src/ramses_rf/commands/dispatcher.py
@@ -1,5 +1,11 @@
 """RAMSES RF - Outbound Command Dispatcher."""
 
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import TYPE_CHECKING, Any
+
 from ramses_rf.commands.builders import build_dto
 from ramses_rf.commands.core import Command
 from ramses_rf.interfaces import GatewayInterface
@@ -7,6 +13,13 @@ from ramses_rf.messages import Message
 from ramses_tx import Priority
 from ramses_tx.const import DEFAULT_WAIT_FOR_REPLY
 from ramses_tx.dtos import CommandDTO
+from ramses_tx.exceptions import ProtocolSendFailed
+
+if TYPE_CHECKING:
+    from ramses_tx import Packet
+
+_QOS_TX_LIMIT = 12
+_LOGGER = logging.getLogger(__name__)
 
 
 class CommandDispatcher:
@@ -20,8 +33,51 @@ class CommandDispatcher:
         """Initialize the dispatcher with a reference to the Gateway.
 
         :param gateway: The main gateway instance for sending L3 payloads.
+        :type gateway: GatewayInterface
         """
         self._gateway = gateway
+
+    def _check_transmission_policy(self, intent: Command) -> None:
+        """Validate intent against destination device policies before transmission.
+
+        :param intent: The command intent to evaluate.
+        :type intent: Command
+        :raises ProtocolSendFailed: If destination device is unreachable/deprecated.
+        """
+        registry = getattr(self._gateway, "device_registry", None)
+        if registry is None:
+            return
+
+        target_dev = getattr(registry, "device_by_id", {}).get(intent.dst.id)
+        if target_dev is None:
+            return
+
+        # 1. Check if unreachable device has exceeded transmission limit
+        qos_count = getattr(target_dev, "_qos_tx_count", 0)
+        if isinstance(qos_count, int) and qos_count > _QOS_TX_LIMIT:
+            _LOGGER.warning(
+                "%s < Sending was deprecated for %s", intent, target_dev
+            )
+            raise ProtocolSendFailed(
+                f"Sending deprecated for {target_dev} (exceeded tx limit)"
+            )
+
+        # 2. Check if destination is a real battery-powered device
+        is_faked = getattr(target_dev, "is_faked", False)
+        has_battery = getattr(target_dev, "has_battery", None)
+        is_battery_state = False
+        if callable(has_battery):
+            # Synchronous check if BatteryState is inherited
+            from ramses_rf.devices.dev_base import BatteryState
+
+            is_battery_state = isinstance(target_dev, BatteryState)
+
+        if is_battery_state and not is_faked:
+            _LOGGER.info(
+                "%s < Sending inadvisable for %s (it has a battery)",
+                intent,
+                target_dev,
+            )
 
     async def send(
         self,
@@ -41,12 +97,13 @@ class CommandDispatcher:
         :returns: The resulting Message domain object.
         :rtype: Message
         """
+        self._check_transmission_policy(intent)
         dto: CommandDTO = build_dto(intent)
         conv_mgr = self._gateway.conversation_manager
 
         if wait_for_reply and conv_mgr is not None:
             rply_fut = await conv_mgr.track_intent(intent, dto)
-            await self._gateway.async_send_cmd(
+            await self._gateway._async_send_dto(
                 dto,
                 priority=priority
                 if priority is not None
@@ -54,10 +111,52 @@ class CommandDispatcher:
             )
             return await rply_fut
 
-        packet = await self._gateway.async_send_cmd(
+        packet: Packet = await self._gateway._async_send_dto(
             dto,
             priority=priority
             if priority is not None
             else Priority(dto.priority),
         )
-        return Message._from_packet(packet)
+        msg = Message._from_packet(packet)
+        msg._pkt = packet  # type: ignore[attr-defined]
+        return msg
+
+    def send_background(
+        self,
+        intent: Command,
+        *,
+        priority: Priority | None = None,
+        wait_for_reply: bool | None = DEFAULT_WAIT_FOR_REPLY,
+    ) -> asyncio.Task[Message]:
+        """Schedule command intent transmission as a background task.
+
+        :param intent: The high-level intent to execute.
+        :type intent: Command
+        :param priority: Priority override for transmission.
+        :type priority: Priority | None
+        :param wait_for_reply: True if the L7 FSM should await a reply.
+        :type wait_for_reply: bool | None
+        :returns: An asyncio Task resolving to the resulting Message.
+        :rtype: asyncio.Task[Message]
+        """
+        coro = self.send(
+            intent,
+            priority=priority,
+            wait_for_reply=wait_for_reply,
+        )
+        loop = (
+            getattr(self._gateway, "_loop", None) or asyncio.get_running_loop()
+        )
+        task = loop.create_task(coro)
+
+        def _clear_exc(fut: asyncio.Task[Any]) -> None:
+            if not fut.cancelled() and fut.exception():
+                _LOGGER.debug(
+                    "Background intent task failed: %s", fut.exception()
+                )
+
+        task.add_done_callback(_clear_exc)
+        add_task = getattr(self._gateway, "add_task", None)
+        if callable(add_task):
+            add_task(task)
+        return task

--- a/src/ramses_rf/devices/dev_base.py
+++ b/src/ramses_rf/devices/dev_base.py
@@ -6,7 +6,6 @@ Base for all devices.
 
 from __future__ import annotations
 
-import asyncio
 import logging
 from collections.abc import Iterable
 from datetime import UTC, datetime as dt, timedelta as td
@@ -42,7 +41,7 @@ from ramses_rf.schemas import (
 )
 from ramses_rf.strategies import HvacStrategy, best_hvac_strategy
 from ramses_rf.topology import Child
-from ramses_tx import CommandDTO, Packet, Priority, QosParams
+from ramses_tx import Packet
 from ramses_tx.const import Code
 
 from ..messages import Message
@@ -54,6 +53,7 @@ if TYPE_CHECKING:
     from ramses_rf.models import DeviceTraits
     from ramses_rf.systems import Zone
     from ramses_rf.typing import PollingIntervalsT
+    from ramses_tx import CommandDTO
     from ramses_tx.const import IndexT
     from ramses_tx.typing import DeviceIdT
 
@@ -251,23 +251,6 @@ class DeviceBase(Entity):
         if traits:
             device._update_traits(traits)
         return device
-
-    def _send_cmd(
-        self, command: CommandDTO, **kwargs: Any
-    ) -> asyncio.Task[Any] | None:
-        """Send a command from this device."""
-        if (
-            isinstance(self, BatteryState)
-            and not self.is_faked
-            and command.addr2 == self.id
-        ):
-            _LOGGER.info(
-                "%s < Sending inadvisable for %s (it has a battery)",
-                command,
-                self,
-            )
-
-        return super()._send_cmd(command, **kwargs)
 
     async def has_battery(self) -> None | bool:  # 1060
         """Return True if the device is battery powered.
@@ -577,30 +560,13 @@ class Fakeable(DeviceBase):
         if self._binding_manager:
             return
 
-        self._binding_manager = BindingManager(self, self._async_send_cmd)
+        self._binding_manager = BindingManager(self, self._gateway.dispatcher)
         if self.id not in self._gateway.config.known_list:
             self._gateway.config.known_list[self.id] = {}
         self._gateway.config.known_list[self.id][SZ_FAKED] = (
             True  # TODO: remove this
         )
         _LOGGER.info("Faking now enabled for: %s", self)
-
-    async def _async_send_cmd(
-        self,
-        command: CommandDTO,
-        priority: Priority | None = None,
-        qos: QosParams | None = None,
-    ) -> Packet | None:
-        """Send a command and forward to the binding context if binding."""
-        if self._binding_manager and self._binding_manager.is_binding:
-            # cmd.code in (Code._1FC9, Code._10E0)
-            self._binding_manager.sent_cmd(
-                command
-            )  # other codes needed for edge cases
-
-        return await super()._async_send_cmd(
-            command, priority=priority, qos=qos
-        )
 
     async def _wait_for_binding_request(
         self,
@@ -609,7 +575,7 @@ class Fakeable(DeviceBase):
         *,
         zone_index: IndexT = "00",
         require_ratify: bool = False,
-    ) -> tuple[Message, Packet, Message, Message | None]:
+    ) -> tuple[Message, Message, Message, Message | None]:
         """Listen for a binding and return the Offer packets.
 
         :param accept_codes: The codes allowed for this binding.
@@ -619,7 +585,7 @@ class Fakeable(DeviceBase):
         :param require_ratify: Whether ratification is required.
         :type require_ratify: bool
         :return: A tuple of the four binding transaction packets.
-        :rtype: tuple[Message, Packet, Message, Message | None]
+        :rtype: tuple[Message, Message, Message, Message | None]
         """
         if not self._binding_manager:
             raise DeviceNotFaked(f"Device is not fakeable: {self}")
@@ -635,7 +601,7 @@ class Fakeable(DeviceBase):
         *,
         zone_index: IndexT = "00",
         require_ratify: bool = False,
-    ) -> tuple[Message, Packet, Message, Message | None]:
+    ) -> tuple[Message, Message, Message, Message | None]:
         """Listen for a binding and return the Offer packets.
 
         :param accept_codes: The codes allowed for this binding.
@@ -645,7 +611,7 @@ class Fakeable(DeviceBase):
         :param require_ratify: Whether ratification is required.
         :type require_ratify: bool
         :return: A tuple of the four binding transaction packets.
-        :rtype: tuple[Message, Packet, Message, Message | None]
+        :rtype: tuple[Message, Message, Message, Message | None]
         :raises NotImplementedError: Subclasses must implement this.
         """
         raise NotImplementedError
@@ -657,7 +623,7 @@ class Fakeable(DeviceBase):
         *,
         confirm_code: Code | None = None,
         ratify_command: CommandDTO | None = None,
-    ) -> tuple[Packet, Message, Packet, Packet | None]:
+    ) -> tuple[Message, Message, Message, Packet | None]:
         """Start a binding and return the Accept, or raise an exception.
 
         :param offer_codes: Codes to offer during the binding process.
@@ -667,7 +633,7 @@ class Fakeable(DeviceBase):
         :param ratify_command: An optional ratification command to send.
         :type ratify_command: CommandDTO | None
         :return: A tuple of the binding transaction packets.
-        :rtype: tuple[Packet, Message, Packet, Packet | None]
+        :rtype: tuple[Message, Message, Message, Packet | None]
         :raises DeviceNotFaked: If faking is not enabled.
         """
         # confirm_code can be FFFF.
@@ -686,11 +652,11 @@ class Fakeable(DeviceBase):
 
     async def initiate_binding_process(
         self,
-    ) -> tuple[Packet, Message, Packet, Packet | None]:
+    ) -> tuple[Message, Message, Message, Packet | None]:
         """Start a binding and return the Accept, or raise an exception.
 
         :return: A tuple of the binding transaction packets.
-        :rtype: tuple[Packet, Message, Packet, Packet | None]
+        :rtype: tuple[Message, Message, Message, Packet | None]
         :raises NotImplementedError: Subclasses must implement this.
         """
         raise NotImplementedError

--- a/src/ramses_rf/devices/heat_sensors.py
+++ b/src/ramses_rf/devices/heat_sensors.py
@@ -158,7 +158,7 @@ class DhwSensor(
 
     async def initiate_binding_process(
         self,
-    ) -> tuple[Packet, Message, Packet, Packet | None]:
+    ) -> tuple[Message, Message, Message, Packet | None]:
         """Initiate the RF binding handshake for the DHW sensor."""
         return await super()._initiate_binding_process(Code._1260)
 

--- a/src/ramses_rf/devices/heat_thermostats.py
+++ b/src/ramses_rf/devices/heat_thermostats.py
@@ -56,7 +56,7 @@ class Thermostat(BatteryState, Setpoint, Fakeable):  # THM (..):
 
     async def initiate_binding_process(
         self,
-    ) -> tuple[Packet, Message, Packet, Packet | None]:
+    ) -> tuple[Message, Message, Message, Packet | None]:
         """Initiate the RF binding handshake for the thermostat."""
         return await super()._initiate_binding_process(
             (Code._2309, Code._30C9, Code._0008)

--- a/src/ramses_rf/devices/hvac_remotes.py
+++ b/src/ramses_rf/devices/hvac_remotes.py
@@ -61,7 +61,7 @@ class HvacRemote(BatteryState, Fakeable, HvacRemoteBase):  # REM: I/22F[138]
 
     async def initiate_binding_process(
         self,
-    ) -> tuple[Packet, Message, Packet, Packet | None]:
+    ) -> tuple[Message, Message, Message, Packet | None]:
         """Initiate the RF binding handshake for the HVAC remote."""
         # .I --- 37:155617 --:------ 37:155617 1FC9 024 00-22F1-965FE1 00-22F3-965FE1 67-10E09-65FE1 00-1FC9-965FE1
         # .W --- 32:155617 37:155617 --:------ 1FC9 012 00-31D9-825FE1 00-31DA-825FE1

--- a/src/ramses_rf/devices/hvac_sensors.py
+++ b/src/ramses_rf/devices/hvac_sensors.py
@@ -253,11 +253,11 @@ class HvacCarbonDioxideSensor(CarbonDioxide, Fakeable):  # CO2: I/1298
 
     async def initiate_binding_process(
         self,
-    ) -> tuple[Packet, Message, Packet, Packet | None]:
+    ) -> tuple[Message, Message, Message, Packet | None]:
         """Initiate the binding process for the CO2 sensor.
 
-        :return: The packet sent to initiate binding
-        :rtype: tuple[Packet, Message, Packet, Packet | None]
+        :return: The packets/messages generated during the binding process.
+        :rtype: tuple[Message, Message, Message, Packet | None]
         :raises exc.BindingError: If binding fails
         """
         return await super()._initiate_binding_process(

--- a/src/ramses_rf/devices/hvac_ventilators.py
+++ b/src/ramses_rf/devices/hvac_ventilators.py
@@ -8,7 +8,7 @@ from datetime import timedelta as td
 from typing import Any
 
 from ramses_rf import exceptions as exc
-from ramses_rf.address import Address
+from ramses_rf.address import HGI_DEV_ADDR, Address
 from ramses_rf.commands.core import Command as Intent
 from ramses_rf.const import (
     HEARTBEAT_TIMEOUT_FILTER,
@@ -48,7 +48,6 @@ from ramses_rf.helpers import shrink
 from ramses_rf.messages import Message
 from ramses_rf.models import DeviceTraits, HvacState
 from ramses_tx import Priority
-from ramses_tx.const import Code, Verb
 from ramses_tx.typing import DeviceIdT
 
 from .dev_base import DeviceHvac
@@ -374,20 +373,18 @@ class HvacVentilator(FilterChange):  # FAN: RP/31DA, I/31D[9A], 2411
 
         # Send RQ for param 0x01 to probe support
         try:
-            from ramses_tx.dtos import CommandDTO
-
-            from_id = self.hgi.id if self.hgi else "18:000730"
-            cmd = CommandDTO(
-                verb=Verb.RQ,
-                addr1=from_id,
-                addr2=self.id,
-                addr3="--:------",
-                code=Code._2411,
-                payload="000001",  # Param 0x01 (common across Orcon/Itho)
+            intent = Intent(
+                src=Address(self.hgi.id) if self.hgi else HGI_DEV_ADDR,
+                dst=Address(self.id),
+                action=Action.GET_FAN_PARAM,
+                data={
+                    "param_id": "01"
+                },  # Param 0x01 (common across Orcon/Itho)
             )
-            await self._gateway.async_send_cmd(cmd)
+            await self._gateway.dispatcher.send(intent)
             _LOGGER.debug("Sent 2411 discovery probe to %s", self.id)
             return True
+
         except Exception as ex:
             _LOGGER.debug("Failed to send 2411 probe to %s: %s", self.id, ex)
             return False

--- a/src/ramses_rf/entity.py
+++ b/src/ramses_rf/entity.py
@@ -3,13 +3,10 @@
 
 from __future__ import annotations
 
-import asyncio
 import logging
 from inspect import getmembers, isclass
 from sys import modules
 from typing import TYPE_CHECKING, Any
-
-from ramses_tx import Priority, QosParams
 
 from .models import (
     DemandState,
@@ -25,7 +22,7 @@ from .models import (
 from .state import EntityState
 
 if TYPE_CHECKING:
-    from ramses_tx import CommandDTO, Packet
+    from ramses_tx import Packet
     from ramses_tx.typing import DeviceIdT, DevIndexT
 
     from .gateway import Gateway
@@ -153,60 +150,6 @@ class _Entity:
             self, "power_state"
         ):
             setattr(self, "power_state", event.state)  # noqa: B010
-
-    def _send_cmd(
-        self, command: CommandDTO, **kwargs: Any
-    ) -> asyncio.Task[Any] | None:
-        """Proxy command sending to the Gateway.
-
-        :param command: The command to send.
-        :type command: CommandDTO
-        :param kwargs: Optional sending parameters (e.g., priority).
-        :type kwargs: Any
-        :returns: The corresponding asyncio Task or None.
-        :rtype: asyncio.Task[Any] | None
-        """
-        if self._qos_tx_count > _QOS_TX_LIMIT:
-            _LOGGER.info("%s < Sending was deprecated for %s", command, self)
-            return None
-
-        return self._gateway.send_cmd(command, **kwargs)
-
-    async def _async_send_cmd(
-        self,
-        command: CommandDTO,
-        priority: Priority | None = None,
-        qos: QosParams | None = None,
-    ) -> Packet | None:
-        """Proxy asynchronous command sending to the Gateway.
-
-        :param command: The command to send.
-        :type command: CommandDTO
-        :param priority: Transmission priority, defaults to None.
-        :type priority: Priority | None, optional
-        :param qos: Quality of Service parameters, defaults to None.
-        :type qos: QosParams | None, optional
-        :returns: The response or echo packet.
-        :rtype: Packet | None
-        """
-        if self._qos_tx_count > _QOS_TX_LIMIT:
-            _LOGGER.warning(
-                "%s < Sending was deprecated for %s", command, self
-            )
-            return None
-
-        # Build kwargs dynamically to prevent passing `None` to strict Gateway args
-        kwargs: dict[str, Any] = {}
-        if priority is not None:
-            kwargs["priority"] = priority
-
-        if qos:
-            if hasattr(qos, "max_retries") and qos.max_retries is not None:
-                kwargs["max_retries"] = qos.max_retries
-            if hasattr(qos, "timeout") and qos.timeout is not None:
-                kwargs["timeout"] = qos.timeout
-
-        return await self._gateway.async_send_cmd(command, **kwargs)
 
 
 class Entity(_Entity):

--- a/src/ramses_rf/gateway.py
+++ b/src/ramses_rf/gateway.py
@@ -618,6 +618,44 @@ class Gateway(GatewayLifecycle, GatewayInterface):
             **kwargs,
         )
 
+    async def async_send_raw_command(
+        self,
+        command: CommandDTO,
+        /,
+        *,
+        gap_duration: float = DEFAULT_GAP_DURATION,
+        num_repeats: int = DEFAULT_NUM_REPEATS,
+        priority: Priority = Priority.DEFAULT,
+        timeout: float = DEFAULT_SEND_TIMEOUT,
+        max_retries: int = DEFAULT_MAX_RETRIES,
+    ) -> Packet:
+        """Transmit a raw command DTO for diagnostics and developer tools.
+
+        :param command: The compiled CommandDTO packet to transmit.
+        :type command: CommandDTO
+        :param gap_duration: Inter-frame gap in seconds.
+        :type gap_duration: float
+        :param num_repeats: Number of transmission retries.
+        :type num_repeats: int
+        :param priority: QoS transmission priority.
+        :type priority: Priority
+        :param timeout: Maximum await duration in seconds.
+        :type timeout: float
+        :param max_retries: Maximum protocol retransmissions.
+        :type max_retries: int
+        :returns: The acknowledged echo packet.
+        :rtype: Packet
+        :raises ProtocolSendFailed: If transmission fails or is cancelled.
+        """
+        return await self._async_send_dto(
+            command,
+            gap_duration=gap_duration,
+            num_repeats=num_repeats,
+            priority=priority,
+            timeout=timeout,
+            max_retries=max_retries,
+        )
+
     async def _async_send_dto(
         self,
         command: CommandDTO,

--- a/src/ramses_rf/gateway.py
+++ b/src/ramses_rf/gateway.py
@@ -32,7 +32,7 @@ from ramses_tx.schemas import (
 from ramses_tx.typing import PayloadT
 
 from .config import GatewayConfig as GatewayConfig, strip_traits
-from .const import Code, Verb
+from .const import SZ_PAYLOAD, SZ_ZONES, Code, Verb
 from .devices import (
     DeviceFilter,
     DeviceRegistry,
@@ -192,21 +192,21 @@ class Gateway(GatewayLifecycle, GatewayInterface):
         # SCH_TCS_ZONES_ZON to accept and Zone._update_schema to hydrate.
         for ctl_id, ctl_entry in schema_in.items():
             if not isinstance(ctl_entry, dict) or not isinstance(
-                ctl_entry.get("zones"), dict
+                ctl_entry.get(SZ_ZONES), dict
             ):
                 continue
             stripped_ctl = stripped.get(ctl_id)
             if not isinstance(stripped_ctl, dict) or not isinstance(
-                stripped_ctl.get("zones"), dict
+                stripped_ctl.get(SZ_ZONES), dict
             ):
                 continue
-            for z_idx, z_entry in ctl_entry["zones"].items():
+            for z_idx, z_entry in ctl_entry[SZ_ZONES].items():
                 if (
                     isinstance(z_entry, dict)
                     and z_entry.get("_name")
-                    and isinstance(stripped_ctl["zones"].get(z_idx), dict)
+                    and isinstance(stripped_ctl[SZ_ZONES].get(z_idx), dict)
                 ):
-                    stripped_ctl["zones"][z_idx]["_name"] = z_entry["_name"]
+                    stripped_ctl[SZ_ZONES][z_idx]["_name"] = z_entry["_name"]
 
         self._schema: dict[str, Any] = SCH_GLOBAL_SCHEMAS(stripped)
 
@@ -269,7 +269,7 @@ class Gateway(GatewayLifecycle, GatewayInterface):
         self._dispatcher = CommandDispatcher(self)
         self._conversation_manager = ConversationManager(
             loop=loop,
-            send_func=lambda dto: self.async_send_cmd(dto),
+            send_func=self._async_send_dto,
         )
         self._polling_manager = PollingManager(self, shadow_mode=False)
 
@@ -502,7 +502,7 @@ class Gateway(GatewayLifecycle, GatewayInterface):
                 "addr2": msg._addrs[1].id,  # <-- Exact raw addr2
                 "addr3": msg._addrs[2].id,  # <-- Exact raw addr3
                 "code": str(msg.code),
-                "payload": _payload_to_serialisable(msg.payload),
+                SZ_PAYLOAD: _payload_to_serialisable(msg.payload),
                 # Frame string is required by _restore_cached_packets /
                 # Packet.from_dict to reconstruct the Packet on warm restart.
                 # Without it, from_dict gets an empty frame body and raises
@@ -541,7 +541,7 @@ class Gateway(GatewayLifecycle, GatewayInterface):
         # NEW: Feed the async TopologyBuilder so it can structurally map the
         # graph *before* the message state is ingested by the Read-Models.
         payload_data = getattr(app_msg, "data", None) or getattr(
-            app_msg, "payload", None
+            app_msg, SZ_PAYLOAD, None
         )
 
         if payload_data is not None:
@@ -618,37 +618,7 @@ class Gateway(GatewayLifecycle, GatewayInterface):
             **kwargs,
         )
 
-    def send_cmd(
-        self,
-        command: CommandDTO,
-        /,
-        *,
-        gap_duration: float = DEFAULT_GAP_DURATION,
-        num_repeats: int = DEFAULT_NUM_REPEATS,
-        priority: Priority = Priority.DEFAULT,
-        timeout: float = DEFAULT_SEND_TIMEOUT,
-        max_retries: int = DEFAULT_MAX_RETRIES,
-    ) -> asyncio.Task[Packet]:
-        """Schedule command transmission as a background task."""
-        coro = self.async_send_cmd(
-            command,
-            gap_duration=gap_duration,
-            num_repeats=num_repeats,
-            priority=priority,
-            timeout=timeout,
-            max_retries=max_retries,
-        )
-        task = self._engine._loop.create_task(coro)
-
-        def _clear_exc(fut: asyncio.Task[Any]) -> None:
-            if not fut.cancelled() and fut.exception():
-                _LOGGER.debug("Background task failed: %s", fut.exception())
-
-        task.add_done_callback(_clear_exc)
-        self.add_task(task)
-        return task
-
-    async def async_send_cmd(
+    async def _async_send_dto(
         self,
         command: CommandDTO,
         /,
@@ -659,7 +629,7 @@ class Gateway(GatewayLifecycle, GatewayInterface):
         timeout: float = DEFAULT_SEND_TIMEOUT,
         max_retries: int = DEFAULT_MAX_RETRIES,
     ) -> Packet:
-        """Transmit a command and wait for response packet."""
+        """Transmit a command DTO over the L3 engine and return the echo packet."""
         try:
             return await self._engine.async_send_cmd(
                 command,

--- a/src/ramses_rf/interfaces.py
+++ b/src/ramses_rf/interfaces.py
@@ -665,6 +665,37 @@ class GatewayInterface(Protocol):
         """
         ...
 
+    async def async_send_raw_command(
+        self,
+        command: CommandDTO,
+        /,
+        *,
+        gap_duration: float = 0.02,
+        num_repeats: int = 1,
+        priority: Priority = Priority.DEFAULT,
+        timeout: float = 3.0,
+        max_retries: int = 3,
+    ) -> Packet:
+        """Transmit a raw command DTO for diagnostics and developer tools.
+
+        :param command: The compiled CommandDTO packet to transmit.
+        :type command: CommandDTO
+        :param gap_duration: Inter-frame gap in seconds.
+        :type gap_duration: float
+        :param num_repeats: Number of transmission retries.
+        :type num_repeats: int
+        :param priority: QoS transmission priority.
+        :type priority: Priority
+        :param timeout: Maximum await duration in seconds.
+        :type timeout: float
+        :param max_retries: Maximum protocol retransmissions.
+        :type max_retries: int
+        :returns: The acknowledged echo packet.
+        :rtype: Packet
+        :raises ProtocolSendFailed: If transmission fails or is cancelled.
+        """
+        ...
+
     async def _async_send_dto(
         self,
         command: CommandDTO,

--- a/src/ramses_rf/interfaces.py
+++ b/src/ramses_rf/interfaces.py
@@ -13,12 +13,12 @@ from typing import (
     runtime_checkable,
 )
 
-from ramses_tx import CommandDTO, Packet, Priority, QosParams
+from ramses_tx import CommandDTO, Packet, Priority
 
 from .messages import Message
 from .typing import DeviceIdT, DeviceListT
 
-# Callback type invoked when the system topology/schema is updated dynamically
+# Callback type invoked when system topology/schema is updated dynamically
 SchemaUpdatedCallback = Callable[[dict[str, Any]], Awaitable[None] | None]
 
 if TYPE_CHECKING:
@@ -29,21 +29,51 @@ if TYPE_CHECKING:
     from .routing import StateHeader
     from .topology import Parent
 
-# Generic type variable for downcasting returned Device instances to subclasses
+# Generic type variable for downcasting returned Device instances
 _DeviceT = TypeVar("_DeviceT", bound="Device")
 
 
 class CommandDispatcher(Protocol):
-    """Protocol for a service/callback that dispatches commands."""
+    """Protocol for a service that dispatches commands."""
 
-    async def __call__(
+    async def send(
         self,
-        command: CommandDTO,
+        intent: Any,
         *,
         priority: Priority | None = None,
-        qos: QosParams | None = None,
-    ) -> Packet | None:
-        """Dispatch a command asynchronously."""
+        wait_for_reply: bool | None = None,
+    ) -> Message:
+        """Translate and send a high-level intent.
+
+        :param intent: The command intent to dispatch.
+        :type intent: Any
+        :param priority: Optional transmission priority.
+        :type priority: Priority | None
+        :param wait_for_reply: Whether to await a reply message.
+        :type wait_for_reply: bool | None
+        :returns: The sent or received Message.
+        :rtype: Message
+        """
+        ...
+
+    def send_background(
+        self,
+        intent: Any,
+        *,
+        priority: Priority | None = None,
+        wait_for_reply: bool | None = None,
+    ) -> asyncio.Task[Message]:
+        """Schedule command intent transmission as a background task.
+
+        :param intent: The command intent to dispatch.
+        :type intent: Any
+        :param priority: Optional transmission priority.
+        :type priority: Priority | None
+        :param wait_for_reply: Whether to await a reply message.
+        :type wait_for_reply: bool | None
+        :returns: An asyncio Task resolving to the Message.
+        :rtype: asyncio.Task[Message]
+        """
         ...
 
 
@@ -58,7 +88,19 @@ class ConversationManagerInterface(Protocol):
         timeout: float | None = None,
         max_retries: int | None = None,
     ) -> asyncio.Future[Message]:
-        """Track an intent transaction until resolution."""
+        """Track an intent transaction until resolution.
+
+        :param intent: The command intent to track.
+        :type intent: Any
+        :param dto: The compiled CommandDTO for correlation.
+        :type dto: CommandDTO | None
+        :param timeout: Optional transaction timeout in seconds.
+        :type timeout: float | None
+        :param max_retries: Optional maximum retry attempts.
+        :type max_retries: int | None
+        :returns: A future resolving with the reply Message.
+        :rtype: asyncio.Future[Message]
+        """
         ...
 
 
@@ -66,17 +108,45 @@ class MessageStoreInterface(Protocol):
     """Protocol interface for central message store."""
 
     def add(self, msg: Message) -> Message | None:
-        """Add message to store index."""
+        """Add message to store index.
+
+        :param msg: The message to index.
+        :type msg: Message
+        :returns: The indexed message or None.
+        :rtype: Message | None
+        """
         ...
 
     def add_record(
-        self, source: str, code: str = "", verb: str = "", payload: str = "00"
+        self,
+        source: str,
+        code: str = "",
+        verb: str = "",
+        payload: str = "00",
     ) -> None:
-        """Add record without message contents."""
+        """Add record without message contents.
+
+        :param source: The source device address string.
+        :type source: str
+        :param code: The RAMSES command code string, optional.
+        :type code: str
+        :param verb: The command verb string, optional.
+        :type verb: str
+        :param payload: The raw hex payload string, optional.
+        :type payload: str
+        :returns: None
+        :rtype: None
+        """
         ...
 
     def start_consumer(self, in_queue: asyncio.Queue[Any]) -> None:
-        """Start the asynchronous queue consumer task for SSOT ingestion."""
+        """Start asynchronous queue consumer task for SSOT ingestion.
+
+        :param in_queue: The input queue for raw packet ingestion.
+        :type in_queue: asyncio.Queue[Any]
+        :returns: None
+        :rtype: None
+        """
         ...
 
     async def get(
@@ -91,7 +161,27 @@ class MessageStoreInterface(Protocol):
         context: Any | None = None,
         hdr: str | StateHeader | None = None,
     ) -> tuple[Message, ...] | list[Message]:
-        """Query matching messages from store."""
+        """Query matching messages from store.
+
+        :param msg: An example message to match against.
+        :type msg: Any | None
+        :param dtm: Timestamp constraint, optional.
+        :type dtm: Any | None
+        :param source: Source device identifier constraint.
+        :type source: str | None
+        :param destination: Destination device identifier constraint.
+        :type destination: str | None
+        :param verb: Verb constraint, optional.
+        :type verb: str | None
+        :param code: Command code constraint, optional.
+        :type code: str | None
+        :param context: Context payload constraint, optional.
+        :type context: Any | None
+        :param hdr: Packet header string or StateHeader, optional.
+        :type hdr: str | StateHeader | None
+        :returns: A tuple or list of matching messages.
+        :rtype: tuple[Message, ...] | list[Message]
+        """
         ...
 
     async def rem(
@@ -106,7 +196,27 @@ class MessageStoreInterface(Protocol):
         context: Any | None = None,
         hdr: str | None = None,
     ) -> tuple[Any, ...] | None:
-        """Remove matching messages from store."""
+        """Remove matching messages from store.
+
+        :param msg: An example message to match against.
+        :type msg: Any | None
+        :param dtm: Timestamp constraint, optional.
+        :type dtm: Any | None
+        :param source: Source device identifier constraint.
+        :type source: str | None
+        :param destination: Destination device identifier constraint.
+        :type destination: str | None
+        :param verb: Verb constraint, optional.
+        :type verb: str | None
+        :param code: Command code constraint, optional.
+        :type code: str | None
+        :param context: Context payload constraint, optional.
+        :type context: Any | None
+        :param hdr: Packet header string constraint, optional.
+        :type hdr: str | None
+        :returns: A tuple of removed records, or None.
+        :rtype: tuple[Any, ...] | None
+        """
         ...
 
     async def contains(
@@ -120,41 +230,95 @@ class MessageStoreInterface(Protocol):
         context: Any | None = None,
         hdr: str | None = None,
     ) -> bool:
-        """Return True if store contains matching record."""
+        """Return True if store contains matching record.
+
+        :param dtm: Timestamp constraint, optional.
+        :type dtm: Any | None
+        :param source: Source device identifier constraint.
+        :type source: str | None
+        :param destination: Destination device identifier constraint.
+        :type destination: str | None
+        :param verb: Verb constraint, optional.
+        :type verb: str | None
+        :param code: Command code constraint, optional.
+        :type code: str | None
+        :param context: Context payload constraint, optional.
+        :type context: Any | None
+        :param hdr: Packet header string constraint, optional.
+        :type hdr: str | None
+        :returns: True if a matching record exists, False otherwise.
+        :rtype: bool
+        """
         ...
 
     async def get_rp_codes(self, parameters: tuple[str, ...]) -> list[Any]:
-        """Query response opcode codes."""
+        """Query response opcode codes.
+
+        :param parameters: SQL parameters for opcode filtering.
+        :type parameters: tuple[str, ...]
+        :returns: A list of response opcode codes.
+        :rtype: list[Any]
+        """
         ...
 
     async def all(self, include_expired: bool = False) -> tuple[Any, ...]:
-        """Return all indexed messages."""
+        """Return all indexed messages.
+
+        :param include_expired: Whether to include expired messages.
+        :type include_expired: bool
+        :returns: A tuple of all indexed messages.
+        :rtype: tuple[Any, ...]
+        """
         ...
 
     async def clr(self) -> None:
-        """Clear all indexed messages."""
+        """Clear all indexed messages from the store."""
         ...
 
     async def qry(
         self, sql: str, parameters: tuple[str, ...]
     ) -> tuple[Any, ...]:
-        """Execute custom SQL query on store."""
+        """Execute custom SQL query on store.
+
+        :param sql: The SQL query statement.
+        :type sql: str
+        :param parameters: The tuple of SQL parameter values.
+        :type parameters: tuple[str, ...]
+        :returns: A tuple of query results.
+        :rtype: tuple[Any, ...]
+        """
         ...
 
     async def qry_field(
         self, sql: str, parameters: tuple[str, ...]
     ) -> list[tuple[Any, ...]]:
-        """Execute custom SQL query returning field values."""
+        """Execute custom SQL query returning field values.
+
+        :param sql: The SQL query statement.
+        :type sql: str
+        :param parameters: The tuple of SQL parameter values.
+        :type parameters: tuple[str, ...]
+        :returns: A list of result tuples.
+        :rtype: list[tuple[Any, ...]]
+        """
         ...
 
     @property
     def log_by_dtm(self) -> tuple[Message, ...]:
-        """Return in-memory log dictionary keyed by timestamp."""
+        """Return in-memory log dictionary keyed by timestamp.
+
+        :returns: A tuple of indexed messages.
+        :rtype: tuple[Message, ...]
+        """
         ...
 
     @property
     def state_cache(self) -> dict[StateHeader, Message]:
-        """Return in-memory state cache dictionary."""
+        """Return in-memory state cache dictionary.
+
+        :returns: The state cache dictionary mapping headers to messages.
+        :rtype: dict[StateHeader, Message]
+        """
         ...
 
     def flush(self) -> None:
@@ -171,7 +335,11 @@ class EntityInterface(Protocol):
 
     @property
     def id(self) -> DeviceIdT:
-        """Return the entity ID."""
+        """Return the entity ID.
+
+        :returns: The entity identifier string.
+        :rtype: DeviceIdT
+        """
         ...
 
 
@@ -182,15 +350,18 @@ class DeviceInterface(Protocol):
     def id(self) -> DeviceIdT:
         """Return the device ID.
 
-        :return: The Device ID.
+        :returns: The Device ID.
+        :rtype: DeviceIdT
         """
         ...
 
     async def traits(self) -> dict[str, Any]:
         """Return the device traits.
 
-        :return: A dictionary of device traits.
+        :returns: A dictionary of device traits.
+        :rtype: dict[str, Any]
         """
+        ...
 
 
 @runtime_checkable
@@ -227,23 +398,11 @@ class ParentInterface(Protocol):
         child_id: str | None = None,
         is_sensor: bool | None = None,
     ) -> None:
-        """Add a child entity to this parent registry.
-
-        :param child: The child entity instance to attach.
-        :type child: Any
-        :param child_id: The specific sub-index (e.g. F9, FA), optional.
-        :type child_id: str | None
-        :param is_sensor: Whether the child acts as a sensor, optional.
-        :type is_sensor: bool | None
-        """
+        """Add a child entity to this parent registry."""
         ...
 
     def _detach_child(self, child: Any) -> None:
-        """Detach a child device from this Parent, maintaining referential integrity.
-
-        :param child: The child entity to detach.
-        :type child: Any
-        """
+        """Detach a child device from this Parent."""
         ...
 
 
@@ -254,6 +413,10 @@ class DeviceFilterInterface(Protocol):
         """Raise a DeviceNotFoundError if a device_id is filtered out.
 
         :param device_id: The device identifier to evaluate.
+        :type device_id: DeviceIdT
+        :returns: None
+        :rtype: None
+        :raises DeviceNotFoundError: If device is filtered out.
         """
         ...
 
@@ -263,22 +426,38 @@ class DeviceRegistryInterface(Protocol):
 
     @property
     def devices(self) -> list[Any]:
-        """Return the list of devices."""
+        """Return the list of devices.
+
+        :returns: A list of registered device instances.
+        :rtype: list[Any]
+        """
         ...
 
     @property
     def device_by_id(self) -> dict[DeviceIdT, Any]:
-        """Return the mapping of device IDs to devices."""
+        """Return the mapping of device IDs to devices.
+
+        :returns: A dictionary mapping device IDs to devices.
+        :rtype: dict[DeviceIdT, Any]
+        """
         ...
 
     @property
     def system_by_id(self) -> dict[DeviceIdT, Any]:
-        """Return a mapping of device IDs to their associated systems."""
+        """Return a mapping of device IDs to their associated systems.
+
+        :returns: A dictionary mapping device IDs to systems.
+        :rtype: dict[DeviceIdT, Any]
+        """
         ...
 
     @property
     def systems(self) -> list[Any]:
-        """Return a list of all identified systems."""
+        """Return a list of all identified systems.
+
+        :returns: A list of registered system instances.
+        :rtype: list[Any]
+        """
         ...
 
     def _add_device(self, device: Any) -> None:
@@ -319,7 +498,23 @@ class DeviceRegistryInterface(Protocol):
         is_sensor: bool | None = None,
         cls: type[_DeviceT] | None = None,
     ) -> Device | _DeviceT:
-        """Return a device, creating it if it does not already exist."""
+        """Return a device, creating it if it does not already exist.
+
+        :param device_id: The identifier string for target device.
+        :type device_id: DeviceIdT | str
+        :param msg: Optional message context for creation.
+        :type msg: Message | None
+        :param parent: Optional parent entity to attach device to.
+        :type parent: Parent[Device] | None
+        :param child_id: Optional child domain or index identifier.
+        :type child_id: str | None
+        :param is_sensor: Optional flag if device acts as sensor.
+        :type is_sensor: bool | None
+        :param cls: Optional device subclass type to instantiate.
+        :type cls: type[_DeviceT] | None
+        :returns: The retrieved or newly created device instance.
+        :rtype: Device | _DeviceT
+        """
         ...
 
     async def fake_device(
@@ -327,31 +522,65 @@ class DeviceRegistryInterface(Protocol):
         device_id: DeviceIdT,
         create_device: bool = False,
     ) -> Device | Fakeable:
-        """Create a faked device."""
+        """Create a faked device.
+
+        :param device_id: The target device identifier to fake.
+        :type device_id: DeviceIdT
+        :param create_device: Whether to instantiate device if missing.
+        :type create_device: bool
+        :returns: The faked device instance.
+        :rtype: Device | Fakeable
+        """
         ...
 
     async def known_list(self) -> DeviceListT:
-        """Return the working known_list."""
+        """Return the working known_list.
+
+        :returns: The dictionary of configured known devices.
+        :rtype: DeviceListT
+        """
         ...
 
     async def get_heat_orphans(self) -> list[DeviceIdT]:
-        """Return a list of IDs for orphaned heat devices."""
+        """Return a list of IDs for orphaned heat devices.
+
+        :returns: A list of device IDs without an associated system.
+        :rtype: list[DeviceIdT]
+        """
         ...
 
     async def get_hvac_orphans(self) -> list[DeviceIdT]:
-        """Return a list of IDs for orphaned HVAC devices."""
+        """Return a list of IDs for orphaned HVAC devices.
+
+        :returns: A list of device IDs without an associated system.
+        :rtype: list[DeviceIdT]
+        """
         ...
 
     async def params(self) -> dict[str, Any]:
-        """Return the parameters for all devices."""
+        """Return the parameters for all devices.
+
+        :returns: A dictionary of parameters for all devices.
+        :rtype: dict[str, Any]
+        """
         ...
 
     async def status(self) -> dict[str, Any]:
-        """Return the status for all devices."""
+        """Return the status for all devices.
+
+        :returns: A dictionary of status data for all devices.
+        :rtype: dict[str, Any]
+        """
         ...
 
     def handle_topology_event(self, event: TopologyChangedEvent) -> None:
-        """Process an immutable structural graph mutation event."""
+        """Process an immutable structural graph mutation event.
+
+        :param event: The topology change event to handle.
+        :type event: TopologyChangedEvent
+        :returns: None
+        :rtype: None
+        """
         ...
 
 
@@ -360,22 +589,38 @@ class GatewayInterface(Protocol):
 
     @property
     def hgi(self) -> DeviceInterface | None:
-        """Return the HGI device if attached."""
+        """Return the HGI device if attached.
+
+        :returns: The attached HGI device instance, or None.
+        :rtype: DeviceInterface | None
+        """
         ...
 
     @property
     def device_registry(self) -> DeviceRegistryInterface:
-        """Return the Device Registry."""
+        """Return the Device Registry.
+
+        :returns: The device registry instance.
+        :rtype: DeviceRegistryInterface
+        """
         ...
 
     @property
     def dispatcher(self) -> CQRSDispatcher:
-        """Return the CommandDispatcher for outbound command translation."""
+        """Return the CommandDispatcher for outbound command translation.
+
+        :returns: The command dispatcher instance.
+        :rtype: CQRSDispatcher
+        """
         ...
 
     @property
     def message_store(self) -> MessageStoreInterface | None:
-        """Return the SQLite message store instance or None."""
+        """Return the SQLite message store instance or None.
+
+        :returns: The message store instance, or None if disabled.
+        :rtype: MessageStoreInterface | None
+        """
         ...
 
     @message_store.setter
@@ -383,33 +628,53 @@ class GatewayInterface(Protocol):
 
     @property
     def config(self) -> GatewayConfig:
-        """Return the gateway configuration."""
+        """Return the gateway configuration.
+
+        :returns: The gateway configuration dataclass instance.
+        :rtype: GatewayConfig
+        """
         ...
 
     @property
     def conversation_manager(self) -> ConversationManagerInterface | None:
-        """Return the ConversationManager instance."""
+        """Return the ConversationManager instance.
+
+        :returns: The conversation manager instance, or None.
+        :rtype: ConversationManagerInterface | None
+        """
         ...
 
     @property
     def schema_updated_callback(self) -> SchemaUpdatedCallback | None:
-        """Return the async callback invoked when system topology/schema updates."""
+        """Return the async callback invoked when schema updates.
+
+        :returns: The registered callback callable, or None.
+        :rtype: SchemaUpdatedCallback | None
+        """
         ...
 
     def set_schema_updated_callback(
         self, callback: SchemaUpdatedCallback | None
     ) -> None:
-        """Set the async callback invoked when system topology/schema updates."""
+        """Set the async callback invoked when system topology updates.
+
+        :param callback: The callback callable or None to clear.
+        :type callback: SchemaUpdatedCallback | None
+        :returns: None
+        :rtype: None
+        """
         ...
 
-    async def async_send_cmd(
+    async def _async_send_dto(
         self,
         command: CommandDTO,
         /,
         *,
+        gap_duration: float = 0.02,
+        num_repeats: int = 1,
         priority: Priority = Priority.DEFAULT,
-        max_retries: int = 3,
         timeout: float = 3.0,
+        max_retries: int = 3,
     ) -> Packet:
-        """Send a command asynchronously and return the resulting packet."""
+        """Send a command DTO over the physical L3 modem."""
         ...

--- a/src/ramses_rf/pipeline/ingestion.py
+++ b/src/ramses_rf/pipeline/ingestion.py
@@ -15,7 +15,6 @@ from typing import Any, Final
 
 from ramses_rf import quirks
 from ramses_rf.address import HGI_DEV_ADDR, NON_DEV_ADDR, Address
-from ramses_rf.commands.builders import build_dto
 from ramses_rf.commands.core import Command as Intent_
 from ramses_rf.const import (
     F9,
@@ -179,6 +178,7 @@ from ramses_rf.state_projector import (
     _get_dhw_zone_from_msg,
     _route_2411_to_fan,
 )
+from ramses_tx import Priority
 from ramses_tx.const import I_, RQ, Code
 
 # --- Translation Maps (Static Constant Blocks) ---
@@ -552,12 +552,16 @@ class StateProjector:
         if msg.code == Code._3EF0 and msg.verb == I_:
             src_dev = registry.device_by_id.get(msg.src.id)
             if src_dev and not getattr(src_dev, "is_faked", False):
-                from ramses_rf.devices.helpers import build_rq_cmd
-                from ramses_tx import Priority
-
                 try:
-                    command = build_rq_cmd(msg.src.id, Code._3EF1, "00")
-                    self._gateway.send_cmd(command, priority=Priority.LOW)
+                    intent_3ef1 = Intent_(
+                        src=HGI_DEV_ADDR,
+                        dst=Address(msg.src.id),
+                        action=Action.GET_RELAY_DEMAND,
+                        data={SZ_DOMAIN_INDEX: "00"},
+                    )
+                    self._gateway.dispatcher.send_background(
+                        intent_3ef1, priority=Priority.LOW
+                    )
                 except Exception as err:
                     _LOGGER.error(
                         "Failed to trigger CQRS 3EF1 reactor for %s: %s",
@@ -570,15 +574,13 @@ class StateProjector:
             src_dev = registry.device_by_id.get(msg.src.id)
             if src_dev and getattr(src_dev, "ctl", None):
                 try:
-                    dto = build_dto(
-                        Intent_(
-                            src=HGI_DEV_ADDR,
-                            dst=Address(src_dev.ctl.id),
-                            action=Action.GET_DHW_TEMP,
-                            data={SZ_DHW_INDEX: 0},
-                        )
+                    intent_1260 = Intent_(
+                        src=HGI_DEV_ADDR,
+                        dst=Address(src_dev.ctl.id),
+                        action=Action.GET_DHW_TEMP,
+                        data={SZ_DHW_INDEX: 0},
                     )
-                    self._gateway.send_cmd(dto)
+                    self._gateway.dispatcher.send_background(intent_1260)
                 except Exception as err:
                     _LOGGER.error(
                         "Failed to trigger CQRS 1260 reactor for %s: %s",

--- a/src/ramses_rf/pipeline/polling.py
+++ b/src/ramses_rf/pipeline/polling.py
@@ -513,7 +513,7 @@ class PollingManager:
                     task.device_id, task.code, payload=task.payload or "00"
                 )
                 try:
-                    await self._gateway.async_send_cmd(cmd_dto)
+                    await self._gateway._async_send_dto(cmd_dto)
                 except (RamsesException, TimeoutError) as err:
                     _LOGGER.warning(
                         "PollingManager failed to send command %s to %s: %s",

--- a/tests/tests_cli/test_client.py
+++ b/tests/tests_cli/test_client.py
@@ -53,9 +53,10 @@ async def mock_gateway() -> AsyncGenerator[MagicMock, None]:
     # Fix: Explicitly assign a MagicMock to __str__ and tell mypy to ignore the method assignment
     gateway.__str__ = MagicMock(return_value="Gateway")  # type: ignore[method-assign]
 
-    gateway.send_cmd = AsyncMock()
+    gateway._async_send_dto = AsyncMock()
     gateway.dispatcher = MagicMock()
-    gateway.dispatcher.send = MagicMock()
+    gateway.dispatcher.send = AsyncMock()
+    gateway.dispatcher.send_background = MagicMock()
     gateway.start = AsyncMock()
     gateway.stop = AsyncMock()
     gateway.get_state = AsyncMock(return_value=({}, {}))

--- a/tests/tests_cli/test_discovery.py
+++ b/tests/tests_cli/test_discovery.py
@@ -1,3 +1,7 @@
+from __future__ import annotations
+
+import asyncio
+from collections.abc import AsyncGenerator
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -35,7 +39,7 @@ DEV_ID = "01:123456"
 
 
 @pytest.fixture
-def mock_gateway() -> MagicMock:
+async def mock_gateway() -> AsyncGenerator[MagicMock, None]:
     """Create a mock Gateway instance."""
     gateway = MagicMock(spec=Gateway)
     # Important: Set the class so isinstance(gwy, Gateway) returns True
@@ -49,6 +53,10 @@ def mock_gateway() -> MagicMock:
     gateway._engine = MagicMock()
     gateway._engine._tasks = []
     gateway._engine.ser_name = "/dev/ttyUSB0"
+    gateway._engine._loop = asyncio.get_running_loop()
+    gateway.add_task = MagicMock(
+        side_effect=lambda task: gateway._engine._tasks.append(task)
+    )
 
     # Mock device retrieval
     mock_dev = MagicMock()
@@ -75,7 +83,11 @@ def mock_gateway() -> MagicMock:
     gateway.config.disable_discovery = False
     gateway.config.enable_eavesdrop = False
 
-    return gateway
+    yield gateway
+
+    for task in gateway._engine._tasks:
+        if not task.done():
+            task.cancel()
 
 
 @pytest.mark.asyncio

--- a/tests/tests_cli/test_discovery.py
+++ b/tests/tests_cli/test_discovery.py
@@ -1,6 +1,4 @@
-#!/usr/bin/env python3
-"""Unittests for the ramses_cli discovery.py module."""
-
+from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -14,8 +12,7 @@ from ramses_cli.discovery import (
     exec_cmd,
     get_faults,
     get_schedule,
-    script_bind_req,
-    script_bind_wait,
+    script_bind_device,
     script_decorator,
     script_poll_device,
     script_scan_disc,
@@ -31,6 +28,7 @@ from ramses_cli.discovery import (
 )
 from ramses_rf.const import SZ_SCHEDULE, SZ_ZONE_INDEX
 from ramses_rf.gateway import Gateway
+from ramses_tx.const import Code
 
 # Constants for testing
 DEV_ID = "01:123456"
@@ -43,8 +41,9 @@ def mock_gateway() -> MagicMock:
     # Important: Set the class so isinstance(gwy, Gateway) returns True
     gateway.__class__ = Gateway  # type: ignore[assignment]
 
-    gateway.send_cmd = MagicMock()
-    gateway.async_send_cmd = AsyncMock()
+    gateway._async_send_dto = AsyncMock()
+    gateway.dispatcher = MagicMock()
+    gateway.dispatcher.send_background = MagicMock()
 
     # Fix: explicitly attach the _engine mock to bypass the spec
     gateway._engine = MagicMock()
@@ -146,7 +145,7 @@ async def test_execution_of_exec_cmd(mock_gateway: MagicMock) -> None:
     """Test execution of exec_cmd logic."""
     kwargs = {EXEC_CMD: "RQ --- 01:123456 --:------ 01:123456 1F09 00"}
     await exec_cmd(mock_gateway, **kwargs)
-    mock_gateway.async_send_cmd.assert_awaited()
+    mock_gateway._async_send_dto.assert_awaited()
 
 
 @pytest.mark.asyncio
@@ -167,10 +166,13 @@ async def test_execution_of_get_schedule(mock_gateway: MagicMock) -> None:
 
 
 @pytest.mark.asyncio
-async def test_execution_of_set_schedule(mock_gateway: MagicMock) -> None:
+async def test_execution_of_set_schedule(
+    mock_gateway: MagicMock, tmp_path: Path
+) -> None:
     """Test execution of set_schedule logic."""
-    sched_json = f'{{"{SZ_ZONE_INDEX}": "01", "{SZ_SCHEDULE}": []}}'
-    await set_schedule(mock_gateway, DEV_ID, sched_json)  # type: ignore[arg-type]
+    sched_file = tmp_path / "sched.json"
+    sched_file.write_text(f'{{"{SZ_ZONE_INDEX}": "01", "{SZ_SCHEDULE}": []}}')
+    await set_schedule(mock_gateway, DEV_ID, str(sched_file))  # type: ignore[arg-type]
     mock_dev = mock_gateway.device_registry.get_device(DEV_ID)
     mock_zone = mock_dev.tcs.get_htg_zone("01")
     mock_zone.set_schedule.assert_awaited_once()
@@ -179,9 +181,6 @@ async def test_execution_of_set_schedule(mock_gateway: MagicMock) -> None:
 @pytest.mark.asyncio
 async def test_script_decorator_behavior(mock_gateway: MagicMock) -> None:
     """Test that script decorator sends start/end commands and executes body."""
-
-    # We define a dummy script to decorate, so we test the decorator logic itself
-    # rather than patching create_task inside it (which was incorrect)
     mock_body = AsyncMock()
 
     @script_decorator
@@ -192,8 +191,7 @@ async def test_script_decorator_behavior(mock_gateway: MagicMock) -> None:
     await dummy_script(mock_gateway, DEV_ID)
 
     # Verify: Puzzle Start -> Body -> Puzzle End
-    # We expect 2 sync send_cmd calls (puzzles) and the body to be awaited
-    assert mock_gateway.send_cmd.call_count == 2
+    assert mock_gateway.dispatcher.send_background.call_count == 2
     mock_body.assert_awaited_once_with(mock_gateway, DEV_ID)
 
 
@@ -214,7 +212,10 @@ async def test_script_scan_full(mock_gateway: MagicMock) -> None:
     with patch("ramses_cli.discovery.range", return_value=iter([1])):
         await script_scan_full(mock_gateway, DEV_ID)
 
-    assert mock_gateway.send_cmd.called
+    assert (
+        mock_gateway._async_send_dto.called
+        or mock_gateway.dispatcher.send_background.called
+    )
 
 
 @pytest.mark.asyncio
@@ -224,14 +225,14 @@ async def test_script_scan_hard(mock_gateway: MagicMock) -> None:
     with patch("ramses_cli.discovery.range", return_value=iter([0x4FFF])):
         await script_scan_hard(mock_gateway, DEV_ID)
 
-    assert mock_gateway.send_cmd.called or mock_gateway.async_send_cmd.called
+    assert mock_gateway._async_send_dto.called
 
 
 @pytest.mark.asyncio
 async def test_script_scan_fan(mock_gateway: MagicMock) -> None:
     """Test script_scan_fan."""
     await script_scan_fan(mock_gateway, DEV_ID)
-    assert mock_gateway.send_cmd.called
+    assert mock_gateway._async_send_dto.called
 
 
 @pytest.mark.asyncio
@@ -244,7 +245,11 @@ async def test_script_scan_otb_group(mock_gateway: MagicMock) -> None:
         await script_scan_otb_ramses(mock_gateway, DEV_ID)
         await script_scan_otb_hard(mock_gateway, DEV_ID)
 
-    assert mock_gateway.send_cmd.call_count > 5
+    assert (
+        mock_gateway._async_send_dto.call_count
+        + mock_gateway.dispatcher.send_background.call_count
+        > 5
+    )
 
 
 @pytest.mark.asyncio
@@ -259,11 +264,8 @@ async def test_script_binding(mock_gateway: MagicMock) -> None:
     )
 
     with patch("ramses_cli.discovery.Fakeable", MockFakeable):
-        await script_bind_req(mock_gateway, DEV_ID)  # type: ignore[arg-type]
+        await script_bind_device(mock_gateway, DEV_ID, Code._2309)  # type: ignore[arg-type]
         mock_dev = mock_gateway.device_registry.get_device(DEV_ID)
-        mock_dev._initiate_binding_process.assert_awaited()
-
-        await script_bind_wait(mock_gateway, DEV_ID)  # type: ignore[arg-type]
         mock_dev._wait_for_binding_request.assert_awaited()
 
 
@@ -279,7 +281,7 @@ async def test_script_binding_fail(mock_gateway: MagicMock) -> None:
         patch("ramses_cli.discovery.Fakeable", RealFakeable),
         pytest.raises((AssertionError, TypeError)),
     ):
-        await script_bind_req(mock_gateway, DEV_ID)  # type: ignore[arg-type]
+        await script_bind_device(mock_gateway, DEV_ID, Code._2309)  # type: ignore[arg-type]
 
 
 @pytest.mark.asyncio

--- a/tests/tests_rf/commands/test_outbound_dispatch.py
+++ b/tests/tests_rf/commands/test_outbound_dispatch.py
@@ -1,0 +1,213 @@
+#!/usr/bin/env python3
+"""RAMSES RF - Unit and parity tests for Outbound Command Dispatching."""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime as dt
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from ramses_rf.address import Address
+from ramses_rf.commands.dispatcher import CommandDispatcher
+from ramses_rf.const import SYS_MODE_MAP, ZON_MODE_MAP
+from ramses_rf.devices import Controller, HvacVentilator
+from ramses_rf.gateway import Gateway
+from ramses_rf.messages import Message
+from ramses_rf.systems import DhwZone, Evohome, Zone
+from ramses_tx import Code, Packet
+from ramses_tx.dtos import CommandDTO
+
+
+@pytest.fixture
+async def mock_gateway() -> MagicMock:
+    """Create a mock Gateway instance with dispatcher wiring."""
+    gateway = MagicMock(spec=Gateway)
+    gateway.__class__ = Gateway  # type: ignore[assignment]
+    gateway._loop = asyncio.get_running_loop()
+    gateway._async_send_dto = AsyncMock()
+    gateway.conversation_manager = None
+    gateway.add_task = MagicMock()
+    gateway.hgi = None
+    gateway.device_registry = MagicMock()
+    gateway.device_registry.system_by_id = {}
+
+    # Wire a real CommandDispatcher backed by the mock gateway
+    dispatcher = CommandDispatcher(gateway)
+    gateway.dispatcher = dispatcher
+
+    return gateway
+
+
+@pytest.mark.asyncio
+async def test_zone_set_temperature_dispatches_intent(
+    mock_gateway: MagicMock,
+) -> None:
+    """Verify Zone.set_setpoint dispatches Action.SET_TEMPERATURE via CommandDispatcher."""
+    # Arrange
+    tcs = MagicMock(spec=Evohome)
+    tcs._gateway = mock_gateway
+    tcs.ctl = MagicMock()
+    tcs.ctl.id = "01:078710"
+    tcs.id = "01:078710"
+    tcs._max_zones = 12
+    tcs.zone_by_index = {}
+    tcs.zone_by_idx = {}
+    tcs.zones = []
+    tcs.childs = []
+
+    zone = Zone(tcs, "00")
+    packet = Packet.from_port(
+        dt.now(),
+        "000  I --- 18:000730 01:078710 --:------ 2349 007 00083401078710",
+    )
+    mock_gateway._async_send_dto.return_value = packet
+
+    # Act
+    result = await zone.set_setpoint(21.0)
+
+    # Assert
+    assert isinstance(result, Message)
+    assert mock_gateway._async_send_dto.await_count == 1
+    call_dto: CommandDTO = mock_gateway._async_send_dto.call_args[0][0]
+    assert call_dto.code == Code._2309
+    assert call_dto.addr3 == "01:078710"
+
+
+@pytest.mark.asyncio
+async def test_zone_set_mode_dispatches_intent(
+    mock_gateway: MagicMock,
+) -> None:
+    """Verify Zone.set_mode dispatches Action.SET_MODE via CommandDispatcher."""
+    # Arrange
+    tcs = MagicMock(spec=Evohome)
+    tcs._gateway = mock_gateway
+    tcs.ctl = MagicMock()
+    tcs.ctl.id = "01:078710"
+    tcs.id = "01:078710"
+    tcs._max_zones = 12
+    tcs.zone_by_index = {}
+    tcs.zone_by_idx = {}
+    tcs.zones = []
+    tcs.childs = []
+
+    zone = Zone(tcs, "01")
+    packet = Packet.from_port(
+        dt.now(),
+        "000  I --- 18:000730 01:078710 --:------ 2349 007 0107D000FFFFFF",
+    )
+    mock_gateway._async_send_dto.return_value = packet
+
+    # Act
+    result = await zone.set_mode(mode=ZON_MODE_MAP.PERMANENT, setpoint=20.0)
+
+    # Assert
+    assert isinstance(result, Message)
+    assert mock_gateway._async_send_dto.await_count == 1
+    call_dto: CommandDTO = mock_gateway._async_send_dto.call_args[0][0]
+    assert call_dto.code == Code._2349
+
+
+@pytest.mark.asyncio
+async def test_hvac_ventilator_set_fan_mode_dispatches_intent(
+    mock_gateway: MagicMock,
+) -> None:
+    """Verify HvacVentilator.set_fan_mode dispatches Action.SET_FAN_MODE."""
+    # Arrange
+    vent = HvacVentilator(mock_gateway, Address("32:208628"))
+    vent.get_bound_rem = MagicMock(return_value="32:208628")  # type: ignore[method-assign]
+    packet = Packet.from_port(
+        dt.now(),
+        "000  I --- 18:000730 32:208628 --:------ 22F1 003 00020A",
+    )
+    mock_gateway._async_send_dto.return_value = packet
+
+    # Act
+    result = await vent.set_fan_mode("auto")
+
+    # Assert
+    assert isinstance(result, Message)
+    assert mock_gateway._async_send_dto.await_count == 1
+    call_dto: CommandDTO = mock_gateway._async_send_dto.call_args[0][0]
+    assert call_dto.code == Code._22F1
+    assert call_dto.addr1 == "32:208628"
+
+
+@pytest.mark.asyncio
+async def test_hvac_ventilator_probe_2411_dispatches_intent(
+    mock_gateway: MagicMock,
+) -> None:
+    """Verify HvacVentilator.async_probe_2411_support dispatches Action.GET_FAN_PARAM."""
+    # Arrange
+    vent = HvacVentilator(mock_gateway, Address("32:208628"))
+    packet = Packet.from_port(
+        dt.now(),
+        "000 RP --- 32:208628 18:000730 --:------ 2411 003 000001",
+    )
+    mock_gateway._async_send_dto.return_value = packet
+
+    # Act
+    success = await vent.async_probe_2411_support()
+
+    # Assert
+    assert success is True
+    assert mock_gateway._async_send_dto.await_count == 1
+    call_dto: CommandDTO = mock_gateway._async_send_dto.call_args[0][0]
+    assert call_dto.code == Code._2411
+    assert call_dto.addr2 == "32:208628"
+
+
+@pytest.mark.asyncio
+async def test_dhw_zone_set_mode_dispatches_intent(
+    mock_gateway: MagicMock,
+) -> None:
+    """Verify DhwZone.set_mode dispatches Action.SET_DHW_MODE."""
+    # Arrange
+    tcs = MagicMock(spec=Evohome)
+    tcs._gateway = mock_gateway
+    tcs.ctl = MagicMock()
+    tcs.ctl.id = "01:078710"
+    tcs.id = "01:078710"
+    tcs.dhw = None
+    tcs.childs = []
+
+    dhw = DhwZone(tcs)
+    packet = Packet.from_port(
+        dt.now(),
+        "000  I --- 18:000730 01:078710 --:------ 1F41 006 000100FFFFFF",
+    )
+    mock_gateway._async_send_dto.return_value = packet
+
+    # Act
+    result = await dhw.set_mode(mode=ZON_MODE_MAP.PERMANENT, active=True)
+
+    # Assert
+    assert isinstance(result, Message)
+    assert mock_gateway._async_send_dto.await_count == 1
+    call_dto: CommandDTO = mock_gateway._async_send_dto.call_args[0][0]
+    assert call_dto.code == Code._1F41
+
+
+@pytest.mark.asyncio
+async def test_tcs_set_mode_dispatches_intent(
+    mock_gateway: MagicMock,
+) -> None:
+    """Verify Evohome.set_mode dispatches Action.SET_SYSTEM_MODE."""
+    # Arrange
+    ctl = Controller(mock_gateway, Address("01:078710"))
+    tcs = Evohome(ctl)
+    packet = Packet.from_port(
+        dt.now(),
+        "000  I --- 18:000730 01:078710 --:------ 2E04 005 0000000000",
+    )
+    mock_gateway._async_send_dto.return_value = packet
+
+    # Act
+    result = await tcs.set_mode(system_mode=SYS_MODE_MAP.AUTO)
+
+    # Assert
+    assert isinstance(result, Message)
+    assert mock_gateway._async_send_dto.await_count == 1
+    call_dto: CommandDTO = mock_gateway._async_send_dto.call_args[0][0]
+    assert call_dto.code == Code._2E04

--- a/tests/tests_rf/commands/test_outbound_dispatch.py
+++ b/tests/tests_rf/commands/test_outbound_dispatch.py
@@ -10,13 +10,16 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 
 from ramses_rf.address import Address
+from ramses_rf.commands.core import Command
 from ramses_rf.commands.dispatcher import CommandDispatcher
 from ramses_rf.const import SYS_MODE_MAP, ZON_MODE_MAP
 from ramses_rf.devices import Controller, HvacVentilator
+from ramses_rf.enums import Action
 from ramses_rf.gateway import Gateway
 from ramses_rf.messages import Message
 from ramses_rf.systems import DhwZone, Evohome, Zone
 from ramses_tx import Code, Packet
+from ramses_tx.const import RQ
 from ramses_tx.dtos import CommandDTO
 
 
@@ -211,3 +214,95 @@ async def test_tcs_set_mode_dispatches_intent(
     assert mock_gateway._async_send_dto.await_count == 1
     call_dto: CommandDTO = mock_gateway._async_send_dto.call_args[0][0]
     assert call_dto.code == Code._2E04
+
+
+@pytest.mark.asyncio
+async def test_tcs_get_faultlog_dispatches_intent(
+    mock_gateway: MagicMock,
+) -> None:
+    """Verify System.get_faultlog dispatches Action.GET_FAULTLOG_ENTRY via CommandDispatcher."""
+    # Arrange
+    mock_gateway.hgi = MagicMock()
+    mock_gateway.hgi.id = "18:000730"
+    ctl = Controller(mock_gateway, Address("01:078710"))
+    tcs = Evohome(ctl)
+    packet = Packet.from_port(
+        dt.now(),
+        "000  I --- 18:000730 01:078710 --:------ 0418 003 000000",
+    )
+    mock_gateway._async_send_dto.return_value = packet
+
+    # Act
+    faultlog = await tcs.get_faultlog(limit=1, force_refresh=True)
+
+    # Assert
+    assert isinstance(faultlog, dict)
+    assert mock_gateway._async_send_dto.await_count == 1
+    call_dto: CommandDTO = mock_gateway._async_send_dto.call_args[0][0]
+    assert call_dto.code == Code._0418
+    assert call_dto.verb == RQ
+    assert call_dto.addr2 == "01:078710"
+
+
+@pytest.mark.asyncio
+async def test_dispatcher_get_system_mode_intent(
+    mock_gateway: MagicMock,
+) -> None:
+    """Verify CommandDispatcher dispatches Action.GET_SYSTEM_MODE intent."""
+    # Arrange
+    dispatcher: CommandDispatcher = mock_gateway.dispatcher
+    packet = Packet.from_port(
+        dt.now(),
+        "000  I --- 18:000730 01:078710 --:------ 2E04 005 0000000000",
+    )
+    mock_gateway._async_send_dto.return_value = packet
+    intent = Command(
+        action=Action.GET_SYSTEM_MODE,
+        src=Address("18:000730"),
+        dst=Address("01:078710"),
+        data={},
+    )
+
+    # Act
+    result = await dispatcher.send(intent)
+
+    # Assert
+    assert isinstance(result, Message)
+    assert mock_gateway._async_send_dto.await_count == 1
+    call_dto: CommandDTO = mock_gateway._async_send_dto.call_args[0][0]
+    assert call_dto.code == Code._2E04
+    assert call_dto.verb == RQ
+    assert call_dto.addr2 == "01:078710"
+    assert call_dto.payload == "FF"
+
+
+@pytest.mark.asyncio
+async def test_dispatcher_get_zone_mode_intent(
+    mock_gateway: MagicMock,
+) -> None:
+    """Verify CommandDispatcher dispatches Action.GET_MODE intent for zone."""
+    # Arrange
+    dispatcher: CommandDispatcher = mock_gateway.dispatcher
+    packet = Packet.from_port(
+        dt.now(),
+        "000  I --- 18:000730 01:078710 --:------ 2349 007 0107D000FFFFFF",
+    )
+    mock_gateway._async_send_dto.return_value = packet
+    intent = Command(
+        action=Action.GET_MODE,
+        src=Address("18:000730"),
+        dst=Address("01:078710"),
+        data={"zone_index": "01"},
+    )
+
+    # Act
+    result = await dispatcher.send(intent)
+
+    # Assert
+    assert isinstance(result, Message)
+    assert mock_gateway._async_send_dto.await_count == 1
+    call_dto: CommandDTO = mock_gateway._async_send_dto.call_args[0][0]
+    assert call_dto.code == Code._2349
+    assert call_dto.verb == RQ
+    assert call_dto.addr2 == "01:078710"
+    assert call_dto.payload == "01"

--- a/tests/tests_rf/data_driven/test_apis_binding.py
+++ b/tests/tests_rf/data_driven/test_apis_binding.py
@@ -57,9 +57,8 @@ class GatewayStub:
 
         # Explicitly type as Any to prevent strict mode from complaining about missing mock attributes
         self._engine: Any = unittest.mock.MagicMock()
-        self._engine._include = {}
-        self._engine._enforce_known_list = False
-
+        self.dispatcher = unittest.mock.MagicMock()
+        self.dispatcher.send = unittest.mock.AsyncMock()
         self.message_store = MessageStore(maintain=False)
 
     @property

--- a/tests/tests_rf/data_driven/test_systems.py
+++ b/tests/tests_rf/data_driven/test_systems.py
@@ -68,11 +68,11 @@ class AwareDatetime(dt):
 
 @pytest.fixture(autouse=True)
 def global_test_patches() -> Generator[None, None, None]:
-    original_async_send_cmd = Gateway.async_send_cmd
+    original_async_send_dto = Gateway._async_send_dto
 
-    async def patched_async_send_cmd(*args: Any, **kwargs: Any) -> Any:
+    async def patched_async_send_dto(*args: Any, **kwargs: Any) -> Any:
         try:
-            return await original_async_send_cmd(*args, **kwargs)
+            return await original_async_send_dto(*args, **kwargs)
         except NotImplementedError as err:
             if "this Protocol is Read-Only" in str(err):
                 return None
@@ -83,8 +83,8 @@ def global_test_patches() -> Generator[None, None, None]:
         patch("ramses_tx.engine.dt", AwareDatetime),
         patch("ramses_tx.packet.dt", AwareDatetime),
         patch(
-            "ramses_rf.gateway.Gateway.async_send_cmd",
-            patched_async_send_cmd,
+            "ramses_rf.gateway.Gateway._async_send_dto",
+            patched_async_send_dto,
         ),
     ):
         yield

--- a/tests/tests_rf/test_binding_fsm.py
+++ b/tests/tests_rf/test_binding_fsm.py
@@ -13,7 +13,7 @@ import asyncio
 from collections.abc import Generator
 from datetime import UTC, datetime as dt
 from typing import Any, cast
-from unittest.mock import patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -22,12 +22,17 @@ from ramses_rf.binding_fsm import (
     SZ_RESPONDENT,
     SZ_SUPPLICANT,
     BindingManager,
+    BindPhase,
     BindStateBase,
     _BindStates,
 )
+from ramses_rf.commands.builders import build_dto
+from ramses_rf.commands.core import Command
+from ramses_rf.const import SZ_OEM_CODE, SZ_PHASE
 from ramses_rf.devices import Fakeable
+from ramses_rf.enums import Action
 from ramses_rf.gateway import GatewayConfig
-from ramses_tx import Priority, QosParams
+from ramses_tx import Address, Verb
 from ramses_tx.dtos import CommandDTO
 from ramses_tx.protocol import PortProtocol
 
@@ -169,6 +174,8 @@ def patch_port_transport_delays() -> Generator[None, None, None]:
 
 def pytest_generate_tests(metafunc: pytest.Metafunc) -> None:
     """Parametrize tests dynamically based on TEST_SUITE_300."""
+    if "test_set" not in metafunc.fixturenames:
+        return
 
     def id_fnc(test_set: dict[str, Any]) -> str:
         """Generate a test ID based on the test set."""
@@ -227,25 +234,10 @@ def _setup_fakeable_device(gwy: Gateway, device_id: str) -> Fakeable:
     fake_dev = cast(Fakeable, dev)
 
     if not getattr(fake_dev, "_binding_manager", None):
-
-        async def _dispatcher(
-            cmd: CommandDTO,
-            *,
-            priority: Priority | None = None,
-            qos: QosParams | None = None,
-        ) -> Packet | None:
-            """Adapter mapping CommandDispatcher signature to Gateway.async_send_cmd."""
-            kwargs: dict[str, Any] = {}
-            if priority is not None:
-                kwargs["priority"] = priority
-            if qos is not None:
-                kwargs["max_retries"] = qos.max_retries
-                kwargs["timeout"] = qos.timeout
-
-            return await gwy.async_send_cmd(cmd, **kwargs)
-
         setattr(  # noqa: B010
-            fake_dev, "_binding_manager", BindingManager(fake_dev, _dispatcher)
+            fake_dev,
+            "_binding_manager",
+            BindingManager(fake_dev, gwy.dispatcher),
         )
 
     fake_dev._make_fake()
@@ -270,17 +262,24 @@ async def assert_context_state(
 # ### TESTS ############################################################################
 
 
-def _assert_l7_parity(msg: Message, cmd: Packet | CommandDTO) -> None:
+def _assert_l7_parity(
+    msg: Message, cmd: Packet | CommandDTO | Message
+) -> None:
     """Assert that a received L7 Message matches a transmitted L3/L4 Packet."""
     assert msg.verb == cmd.verb
     assert str(msg.code) == str(cmd.code)
-    if isinstance(cmd, CommandDTO):
+    if isinstance(cmd, Message):
+        assert msg.src.id == cmd.src.id
+        assert msg.dst.id == cmd.dst.id
+        assert msg.payload == cmd.payload
+    elif isinstance(cmd, CommandDTO):
         assert cmd.addr1 in (msg.src.id, msg.dst.id, "--:------")
         assert cmd.addr2 in (msg.src.id, msg.dst.id, "--:------")
+        assert msg._dto.payload == cmd.payload
     else:
         assert msg.src.id == cmd.src.id
         assert msg.dst.id == cmd.dst.id
-    assert msg._dto.payload == cmd.payload
+        assert msg._dto.payload == cmd.payload
 
 
 # TODO: test addenda phase of binding handshake
@@ -540,3 +539,133 @@ async def test_flow_200(test_set: dict[str, Any]) -> None:
             await gwy.stop()
         await rf.stop()
         await asyncio.sleep(0)
+
+
+def test_binding_phase_tender_intent() -> None:
+    """Verify PUT_BIND offer intent constructs a TENDER phase payload."""
+    # Arrange
+    supplicant_id = "34:259472"
+    codes = [Code._2309, Code._30C9]
+    vendor_code = "01"
+    intent = Command(
+        src=Address(supplicant_id),
+        dst=Address(supplicant_id),
+        action=Action.PUT_BIND,
+        data={
+            "verb": Verb.I_,
+            "codes": codes,
+            "vendor_code": vendor_code,
+            SZ_OEM_CODE: vendor_code,
+        },
+    )
+
+    # Act
+    dto = build_dto(intent)
+    msg = Message._from_cmd(dto)
+
+    # Assert
+    assert msg.payload[SZ_PHASE] == BindPhase.TENDER
+
+
+def test_binding_phase_accept_intent() -> None:
+    """Verify PUT_BIND accept intent constructs an ACCEPT phase payload."""
+    # Arrange
+    respondent_id = "01:220768"
+    supplicant_id = "34:259472"
+    codes = [Code._2309]
+    zone_index = "01"
+    intent = Command(
+        src=Address(respondent_id),
+        dst=Address(supplicant_id),
+        action=Action.PUT_BIND,
+        data={"verb": Verb.W_, "codes": codes, "index": zone_index},
+    )
+
+    # Act
+    dto = build_dto(intent)
+    msg = Message._from_cmd(dto)
+
+    # Assert
+    assert msg.payload[SZ_PHASE] == BindPhase.ACCEPT
+
+
+def test_binding_phase_affirm_intent() -> None:
+    """Verify PUT_BIND confirm intent constructs an AFFIRM phase payload."""
+    # Arrange
+    supplicant_id = "34:259472"
+    respondent_id = "01:220768"
+    confirm_code = Code._2309
+    index = "01"
+    intent = Command(
+        src=Address(supplicant_id),
+        dst=Address(respondent_id),
+        action=Action.PUT_BIND,
+        data={"verb": Verb.I_, "codes": confirm_code, "index": index},
+    )
+
+    # Act
+    dto = build_dto(intent)
+    msg = Message._from_cmd(dto)
+
+    # Assert
+    assert msg.payload[SZ_PHASE] == BindPhase.AFFIRM
+
+
+@pytest.mark.asyncio
+async def test_binding_manager_cast_methods_phase_parity() -> None:
+    """Verify BindingManager cast methods produce intents matching expected BindPhases."""
+    # Arrange
+    mock_dev = MagicMock()
+    mock_dev.id = "34:259472"
+    mock_dev._gateway = MagicMock()
+    mock_dispatcher = MagicMock()
+
+    sent_intents: list[Command] = []
+
+    async def _mock_send(intent: Command, **kwargs: Any) -> Message:
+        sent_intents.append(intent)
+        dto = build_dto(intent)
+        return Message._from_cmd(dto)
+
+    mock_dispatcher.send = AsyncMock(side_effect=_mock_send)
+    mgr = BindingManager(mock_dev, mock_dispatcher)
+    mgr._state = MagicMock()
+    mgr._state.cast_confirm_accept = AsyncMock()
+
+    # Act 1: Cast Offer (Tender)
+    await mgr._make_offer(codes=[Code._2309, Code._30C9], vendor_code="01")
+
+    # Assert 1
+    assert len(sent_intents) == 1
+    msg1 = Message._from_cmd(build_dto(sent_intents[0]))
+    assert msg1.payload[SZ_PHASE] == BindPhase.TENDER
+
+    # Act 2: Accept Offer (Accept)
+    offer_packet = Packet.from_port(
+        dt.now(UTC),
+        "000  I --- 34:259472 --:------ 34:259472 1FC9 012 0023098BF5900030C98BF590",
+    )
+    tender_msg = Message._from_packet(offer_packet)
+    mock_dev.id = "01:220768"
+    await mgr._accept_offer(
+        tender=tender_msg, codes=[Code._2309], zone_index="01"
+    )
+
+    # Assert 2
+    assert len(sent_intents) == 2
+    msg2 = Message._from_cmd(build_dto(sent_intents[1]))
+    assert msg2.payload[SZ_PHASE] == BindPhase.ACCEPT
+
+    # Act 3: Confirm Accept (Affirm)
+    accept_packet = Packet.from_port(
+        dt.now(UTC),
+        "000  W --- 01:220768 34:259472 --:------ 1FC9 006 012309075E60",
+    )
+    accept_msg = Message._from_packet(accept_packet)
+    mock_dev.id = "34:259472"
+    await mgr._confirm_accept(accept=accept_msg, confirm_code=Code._2309)
+
+    # Assert 3
+    assert len(sent_intents) == 3
+    msg3 = Message._from_cmd(build_dto(sent_intents[2]))
+    assert msg3.payload[SZ_PHASE] == BindPhase.AFFIRM

--- a/tests/tests_rf/test_conversation_manager.py
+++ b/tests/tests_rf/test_conversation_manager.py
@@ -259,7 +259,7 @@ async def test_live_gateway_conversation_manager_integration(
     gwy = Gateway("/dev/null")
     mock_packet = MagicMock(spec=Packet)
     monkeypatch.setattr(
-        gwy, "async_send_cmd", AsyncMock(return_value=mock_packet)
+        gwy, "_async_send_dto", AsyncMock(return_value=mock_packet)
     )
 
     intent = Command(
@@ -297,7 +297,7 @@ async def test_live_dispatcher_process_msg_routes_to_conversation_manager(
     gwy = Gateway("/dev/null")
     mock_packet = MagicMock(spec=Packet)
     monkeypatch.setattr(
-        gwy, "async_send_cmd", AsyncMock(return_value=mock_packet)
+        gwy, "_async_send_dto", AsyncMock(return_value=mock_packet)
     )
 
     intent = Command(

--- a/tests/tests_rf/test_dispatcher.py
+++ b/tests/tests_rf/test_dispatcher.py
@@ -823,7 +823,7 @@ class TestCommandDispatcherSend:
         mock_conv_mgr = MagicMock()
         mock_conv_mgr.track_intent = AsyncMock(return_value=fut)
         mock_gateway.conversation_manager = mock_conv_mgr
-        mock_gateway.async_send_cmd = AsyncMock(return_value=packet)
+        mock_gateway._async_send_dto = AsyncMock(return_value=packet)
 
         # Act
         result = await cmd_dispatcher.send(intent, wait_for_reply=True)
@@ -855,7 +855,7 @@ class TestCommandDispatcherSend:
             "000  I --- 18:000730 01:078710 --:------ 313F 009 00000400041C0A07E3",
         )
         mock_gateway.conversation_manager = None
-        mock_gateway.async_send_cmd = AsyncMock(return_value=packet)
+        mock_gateway._async_send_dto = AsyncMock(return_value=packet)
 
         # Act
         result = await cmd_dispatcher.send(intent, wait_for_reply=False)
@@ -863,6 +863,72 @@ class TestCommandDispatcherSend:
         # Assert
         assert isinstance(result, Message)
         assert result.code == Code._313F
+
+    @pytest.mark.asyncio
+    async def test_send_background_creates_task(
+        self, mock_gateway: MagicMock
+    ) -> None:
+        """Verify send_background schedules transmission via event loop task."""
+        # Arrange
+        import asyncio
+
+        from ramses_rf.commands.core import Command
+        from ramses_rf.commands.dispatcher import CommandDispatcher
+        from ramses_rf.enums import Action
+
+        cmd_dispatcher = CommandDispatcher(mock_gateway)
+        intent = Command(
+            src=Address("18:000730"),
+            dst=Address("01:078710"),
+            action=Action.GET_SYSTEM_TIME,
+            data={},
+        )
+        packet = Packet.from_port(
+            dt.now(),
+            "000  I --- 18:000730 01:078710 --:------ 313F 009 00000400041C0A07E3",
+        )
+        mock_gateway.conversation_manager = None
+        mock_gateway._loop = asyncio.get_running_loop()
+        mock_gateway._async_send_dto = AsyncMock(return_value=packet)
+        mock_gateway.add_task = MagicMock()
+
+        # Act
+        task = cmd_dispatcher.send_background(intent, wait_for_reply=False)
+
+        # Assert
+        assert isinstance(task, asyncio.Task)
+        mock_gateway.add_task.assert_called_once_with(task)
+        result = await task
+        assert isinstance(result, Message)
+
+    @pytest.mark.asyncio
+    async def test_send_deprecated_device_raises_protocol_send_failed(
+        self, mock_gateway: MagicMock
+    ) -> None:
+        """Verify sending to a deprecated device raises ProtocolSendFailed."""
+        # Arrange
+        from ramses_rf.commands.core import Command
+        from ramses_rf.commands.dispatcher import CommandDispatcher
+        from ramses_rf.enums import Action
+        from ramses_tx.exceptions import ProtocolSendFailed
+
+        target_dev = MagicMock()
+        target_dev._qos_tx_count = 15
+        mock_registry = MagicMock()
+        mock_registry.device_by_id = {"01:078710": target_dev}
+        mock_gateway.device_registry = mock_registry
+
+        cmd_dispatcher = CommandDispatcher(mock_gateway)
+        intent = Command(
+            src=Address("18:000730"),
+            dst=Address("01:078710"),
+            action=Action.GET_SYSTEM_TIME,
+            data={},
+        )
+
+        # Act & Assert
+        with pytest.raises(ProtocolSendFailed, match="Sending deprecated"):
+            await cmd_dispatcher.send(intent)
 
     @pytest.mark.asyncio
     async def test_dispatcher_state_cache_update(

--- a/tests/tests_rf/test_entity.py
+++ b/tests/tests_rf/test_entity.py
@@ -20,9 +20,10 @@ from ramses_tx import Code, DeviceIdT, Packet
 def mock_gateway() -> Generator[MagicMock, None, None]:
     """Create a mock Gateway instance for testing."""
     gateway = MagicMock(spec=Gateway)
-    gateway.send_cmd = AsyncMock()
+    gateway._async_send_dto = AsyncMock()
     gateway.dispatcher = MagicMock()
-    gateway.dispatcher.send = MagicMock()
+    gateway.dispatcher.send = AsyncMock()
+    gateway.dispatcher.send_background = MagicMock()
 
     # Add required attributes
     gateway.config = MagicMock()

--- a/tests/tests_rf/test_gateway.py
+++ b/tests/tests_rf/test_gateway.py
@@ -13,7 +13,7 @@ from ramses_rf.gateway import Gateway, GatewayConfig
 from ramses_rf.messages import Message
 from ramses_rf.models import DeviceTraits
 from ramses_rf.pipeline.polling import PollingManager
-from ramses_tx import I_, RP, RQ
+from ramses_tx import I_, RP, RQ, CommandDTO, Priority
 from ramses_tx.config import EngineConfig
 from ramses_tx.const import SZ_ACTIVE_HGI, SZ_IS_EVOFW3, Code
 from ramses_tx.packet import Packet
@@ -612,3 +612,46 @@ async def test_gateway_get_state_in_memory() -> None:
     assert packet_data["code"] == Code._1F09
     assert packet_data["verb"] == I_
     assert packet_data["src"] == "01:145038"
+
+
+@pytest.mark.asyncio
+async def test_gateway_async_send_raw_command() -> None:
+    """Verify Gateway.async_send_raw_command forwards CommandDTO to engine."""
+    # Arrange
+    gateway = Gateway("/dev/null", config=GatewayConfig(database_path=None))
+    mock_packet = MagicMock(spec=Packet)
+
+    command = CommandDTO(
+        verb=RQ,
+        addr1="18:000730",
+        addr2="01:145038",
+        addr3="--:------",
+        code=Code._10E0,
+        payload="00",
+    )
+
+    with patch.object(
+        gateway._engine, "async_send_cmd", new_callable=AsyncMock
+    ) as mock_engine_send:
+        mock_engine_send.return_value = mock_packet
+
+        # Act
+        result = await gateway.async_send_raw_command(
+            command,
+            gap_duration=0.05,
+            num_repeats=2,
+            priority=Priority.HIGH,
+            timeout=5.0,
+            max_retries=2,
+        )
+
+        # Assert
+        assert result is mock_packet
+        mock_engine_send.assert_awaited_once_with(
+            command,
+            gap_duration=0.05,
+            num_repeats=2,
+            priority=Priority.HIGH,
+            max_retries=2,
+            timeout=5.0,
+        )

--- a/tests/tests_rf/test_gateway_snapshot.py
+++ b/tests/tests_rf/test_gateway_snapshot.py
@@ -324,7 +324,7 @@ async def test_read_model_baseline_snapshot(
 
     mock_send = AsyncMock(return_value=None)
 
-    with patch.object(gwy, "async_send_cmd", mock_send):
+    with patch.object(gwy, "_async_send_dto", mock_send):
         with contextlib.suppress(TransportError):
             await gwy.start()
 

--- a/tests/tests_rf/test_polling_manager.py
+++ b/tests/tests_rf/test_polling_manager.py
@@ -66,7 +66,7 @@ def mock_gateway() -> MagicMock:
     gwy = MagicMock()
     gwy.config = GatewayConfig()
     gwy.device_registry.devices = []
-    gwy.async_send_cmd = AsyncMock()
+    gwy._async_send_dto = AsyncMock()
     gwy.add_task = MagicMock()
     return gwy
 
@@ -211,7 +211,7 @@ async def test_polling_manager_shadow_execution_parity(
     # ASSERT
     assert processed_count == len(DEFAULT_POLLING_SCHEDULES["CTL"])
     # Crucial Shadow Mode Guarantee: Zero RF network transmissions
-    mock_gateway.async_send_cmd.assert_not_called()
+    mock_gateway._async_send_dto.assert_not_called()
 
 
 @pytest.mark.asyncio
@@ -229,7 +229,7 @@ async def test_polling_manager_disabled_config_parity(
 
     # ASSERT
     assert processed_count == 0
-    mock_gateway.async_send_cmd.assert_not_called()
+    mock_gateway._async_send_dto.assert_not_called()
 
 
 @pytest.mark.asyncio
@@ -262,7 +262,7 @@ async def test_polling_manager_send_cmd_exception_handling(
     poller = PollingManager(mock_gateway, shadow_mode=False)
     bdr_dev = MockDevice(mock_gateway, "13:222222", slug="BDR")
     mock_gateway.device_registry.devices = [bdr_dev]
-    mock_gateway.async_send_cmd.side_effect = RamsesException(
+    mock_gateway._async_send_dto.side_effect = RamsesException(
         "Transmission failure"
     )
 
@@ -276,7 +276,7 @@ async def test_polling_manager_send_cmd_exception_handling(
 
     # ASSERT
     assert processed_count == 1
-    mock_gateway.async_send_cmd.assert_called_once()
+    mock_gateway._async_send_dto.assert_called_once()
 
 
 @pytest.mark.asyncio
@@ -332,9 +332,9 @@ async def test_polling_manager_live_dispatch_cutover(
 
     # ASSERT
     assert processed_count == len(DEFAULT_POLLING_SCHEDULES["CTL"])
-    assert mock_gateway.async_send_cmd.call_count == processed_count
+    assert mock_gateway._async_send_dto.call_count == processed_count
 
-    call_args = mock_gateway.async_send_cmd.call_args_list[0][0]
+    call_args = mock_gateway._async_send_dto.call_args_list[0][0]
     sent_dto: CommandDTO = call_args[0]
     assert sent_dto.verb == Verb.RQ
     assert sent_dto.addr1 == "18:000730"
@@ -487,12 +487,12 @@ async def test_polling_manager_0004_zone_uses_payload_in_cmd(
     # ASSERT: find the 0004 call and check its payload
     sent_codes = [
         call.args[0].code
-        for call in mock_gateway.async_send_cmd.call_args_list
+        for call in mock_gateway._async_send_dto.call_args_list
     ]
     assert Code._0004 in sent_codes
 
     # Find the 0004 call and verify payload contains zone_index
-    for call in mock_gateway.async_send_cmd.call_args_list:
+    for call in mock_gateway._async_send_dto.call_args_list:
         dto: CommandDTO = call.args[0]
         if dto.code == Code._0004:
             assert dto.payload == "0500", (
@@ -592,11 +592,11 @@ async def test_polling_manager_30C9_zone_uses_payload_in_cmd(
     # ASSERT: find the 30C9 call and check its payload
     sent_codes = [
         call.args[0].code
-        for call in mock_gateway.async_send_cmd.call_args_list
+        for call in mock_gateway._async_send_dto.call_args_list
     ]
     assert Code._30C9 in sent_codes
 
-    for call in mock_gateway.async_send_cmd.call_args_list:
+    for call in mock_gateway._async_send_dto.call_args_list:
         dto: CommandDTO = call.args[0]
         if dto.code == Code._30C9:
             assert dto.payload == "0B", (
@@ -645,11 +645,11 @@ async def test_polling_manager_2349_zone_uses_payload_in_cmd(
     # ASSERT: find the 2349 call and check its payload
     sent_codes = [
         call.args[0].code
-        for call in mock_gateway.async_send_cmd.call_args_list
+        for call in mock_gateway._async_send_dto.call_args_list
     ]
     assert Code._2349 in sent_codes
 
-    for call in mock_gateway.async_send_cmd.call_args_list:
+    for call in mock_gateway._async_send_dto.call_args_list:
         dto: CommandDTO = call.args[0]
         if dto.code == Code._2349:
             assert dto.payload == "0B00", (
@@ -868,11 +868,11 @@ async def test_polling_manager_otb_live_dispatch_transmits_data_id_payloads(
     # Assert
     # 2 device-level tasks + 6 Data-ID tasks = 8 total
     assert processed_count == 8
-    assert mock_gateway.async_send_cmd.call_count == 8
+    assert mock_gateway._async_send_dto.call_count == 8
 
     # Extract all 3220 commands sent
     sent_3220_payloads: set[str] = set()
-    for call in mock_gateway.async_send_cmd.call_args_list:
+    for call in mock_gateway._async_send_dto.call_args_list:
         dto: CommandDTO = call.args[0]
         assert dto.addr2 == "10:048122"
         assert dto.verb == Verb.RQ

--- a/tests/tests_rf/test_regression_rf.py
+++ b/tests/tests_rf/test_regression_rf.py
@@ -155,8 +155,9 @@ async def test_gateway_replay_regression(snapshot: SnapshotAssertion) -> None:
     # We use AsyncMock to ensure a proper coroutine is returned for asyncio.create_task.
     mock_send = AsyncMock(return_value=None)
 
-    with patch.object(gwy, "async_send_cmd", mock_send):
+    with patch.object(gwy, "_async_send_dto", mock_send):
         # 3. Start the Gateway (spawns the reader task)
+
         # The library's `start()` method has a strict 1s timeout for file parsing.
         # Large regression files take longer, raising TransportError.
         # We catch this expected timeout gracefully.

--- a/tests/tests_rf/test_virtual_rf.py
+++ b/tests/tests_rf/test_virtual_rf.py
@@ -249,7 +249,7 @@ async def test_virtual_rf_dev_disc() -> None:
         cmd = Command.from_cli(
             " I --- 01:010000 --:------ 01:010000 1F09 003 0004B5"
         )
-        gwy_0.send_cmd(cmd)
+        ser_2.write(bytes(f"{cmd}\r\n".encode("ascii")))
 
         await assert_devices(gwy_0, ["01:010000", "18:000000", "18:111111"])
         await assert_devices(gwy_1, ["01:010000", "18:000000", "18:111111"])
@@ -303,7 +303,7 @@ async def test_virtual_rf_packet_flow() -> None:
         cmd = Command.from_cli(
             " I --- 01:022222 --:------ 01:022222 1F09 003 0004B5"
         )
-        gwy_0.send_cmd(cmd, num_repeats=1)
+        await gwy_0._async_send_dto(cmd, num_repeats=1)
 
         await assert_devices(
             gwy_0, ["01:022222", "18:000000", "18:111111", "40:000000"]

--- a/tests/tests_rf/virtual_rf/helpers.py
+++ b/tests/tests_rf/virtual_rf/helpers.py
@@ -29,7 +29,7 @@ def ensure_fakeable(dev: Device, make_fake: bool = True) -> None:
     assert isinstance(dev, Fakeable)
 
     # Initialize the BindingManager requiring both the device and a dispatcher
-    dispatcher = dev._gateway.async_send_cmd
+    dispatcher = dev._gateway.dispatcher
     setattr(dev, "_bind_context", BindingManager(dev, dispatcher))  # noqa: B010
 
     if make_fake:


### PR DESCRIPTION
Addresses #1150 (Roadmap Item 8 / Phase 10: Complete outbound command bus cutover) and #1177 (Public `async_send_raw_command` escape hatch for diagnostic services).

### The Problem:
Outbound command transmission in `ramses_rf` was fragmented across legacy entrypoints (`Entity._send_cmd()`, `DeviceBase._async_send_cmd()`, `Gateway.send_cmd()`, and `Gateway.async_send_cmd()`), bypassing high-level intent validation, transmission safety guards, and central QoS scheduling. This direct transmission model prevented link-layer transport pooling (Roadmap Item 9) and multi-HGI dongle arbitration.

### The Fix:
- **Command Bus Implementation**:
  - Implemented `CommandDispatcher.send()` and `CommandDispatcher.send_background()` in `ramses_rf/commands/dispatcher.py` to translate high-level `Command` intents into compiled `CommandDTO`s via `build_dto(intent)`.
  - Integrated application-layer request/reply tracking with `ConversationManager.track_intent()`.
  - Added transmission safety policies: warning on battery-powered destination devices and raising `ProtocolSendFailed` on deprecated/unreachable destinations.
- **Gateway Send API Modernisation & Hard Cutover**:
  - Removed public `Gateway.send_cmd()` and privatised `Gateway.async_send_cmd()` to `Gateway._async_send_dto()` to guarantee that all outbound intents route through `CommandDispatcher`.
  - Added official public escape-hatch method `Gateway.async_send_raw_command()` (#1177) for developer debugging and downstream diagnostic services (e.g. `ramses_cc.send_packet`).
  - Updated `GatewayInterface` and `CommandDispatcher` protocols in `ramses_rf/interfaces.py` with full Sphinx docstrings.
- **Legacy Entity Send Deprecation**:
  - Deleted `_send_cmd` and `_async_send_cmd` from `Entity` and `DeviceBase`.
  - Migrated `Zone.set_setpoint()`, `Zone.set_mode()`, `Evohome.set_mode()`, `DhwZone.set_mode()`, `HvacVentilator.set_fan_mode()`, `HvacVentilator.async_probe_2411_support()`, and schedule setters to dispatch typed `Command` intents via `self.dispatcher.send(intent)`.
- **Binding FSM & Reactor Modernisation**:
  - Migrated `BindingManager` (`_make_offer()`, `_accept_offer()`, `_confirm_accept()`) and ingestion reactors (`3EF0`, `1260`) to `dispatcher.send()` / `dispatcher.send_background()`.
  - Standardised binding method return types to `Message` across `dev_base.py`, `hvac_sensors.py`, `hvac_remotes.py`, `heat_sensors.py`, and `heat_thermostats.py`.
  - Migrated inline debug assertions in `binding_fsm.py` into dedicated unit tests in `tests/tests_rf/test_binding_fsm.py`.
- **CLI Discovery Script Modernisation**:
  - Refactored `src/ramses_cli/discovery.py` to route scans and bindings via `dispatcher.send_background()`, `_send_probe_dto()`, and non-blocking asynchronous schedule loading.

### Technical Implementation & Differences from Original Proposal:
- **Immediate Hard Cutover vs Phased Deprecation**: Rather than maintaining a temporary dual-dispatch / warning shim layer for legacy `send_cmd()` methods, all legacy entity transmission methods were deleted immediately and `Gateway._async_send_dto()` was privatised to enforce 100% compliance at compile and test time.
- **Atomic Single-PR Consolidation**: Consolidated domain intent migration, dispatcher QoS routing, raw escape hatch (#1177), and send API deprecation into a single atomic PR.

### Testing Performed:
- **Dedicated Outbound Dispatch Test Suite**: Created `tests/tests_rf/commands/test_outbound_dispatch.py` verifying end-to-end command construction and dispatch parity across heating and HVAC domains.
- **Binding FSM Unit Tests**: Expanded `tests/tests_rf/test_binding_fsm.py` verifying tender, accept, and affirm intent construction and message payload parity.
- **Gateway Raw Send Tests**: Added `test_gateway_async_send_raw_command` in `tests/tests_rf/test_gateway.py`.
- **Pre-commit & Formatting**: `.venv/bin/prek run -a` and `.venv/bin/ruff format --check .` passed cleanly.
- **Strict Typing**: `.venv/bin/mypy --strict .` passed with 0 errors across 282 source files.
- **Full Test Suite**: `.venv/bin/python -u -m pytest -n auto` passed (2,890 passed, 105 snapshots passed, 0 regressions).

### AI Assistance Disclosure:
This contribution was developed with the assistance of Google Gemini 3.7 Flash for code generation and documentation. All logic and implementations were reviewed and verified by the author.