### PR TITLE
fix(strategy): normalise 31DA fan_info to canonical mode names

### DIFF
--- a/src/ramses_rf/strategies/base.py
+++ b/src/ramses_rf/strategies/base.py
@@ -49,6 +49,23 @@ class HvacStrategy(Protocol):
         """
         ...
 
+    def normalize_fan_info(self, fan_info: str) -> str:
+        """Normalise a 31DA fan_info string to a canonical mode name.
+
+        The 31DA parser produces descriptive strings like
+        ``"speed 1, low"`` that don't match the canonical mode names
+        (``"low"``) used in 22F1 mode maps and HA dropdowns.  This
+        method maps descriptive names back to canonical names so
+        consumers can compare fan_info against fan_modes.
+
+        :param fan_info: The descriptive fan_info string from 31DA.
+        :type fan_info: str
+        :returns: The canonical mode name, or the original string if
+            no mapping is known.
+        :rtype: str
+        """
+        ...
+
     @property
     def mode_max(self) -> str | None:
         """Max mode byte for this scheme (e.g. ``"07"`` for orcon)."""
@@ -186,6 +203,30 @@ class HvacStrategyBase:
         """
         return self._mode_map.get(hex_code, hex_code)
 
+    #: Descriptive 31DA fan_info strings → canonical mode names.
+    #: The 31DA parser uses ``_31DA_FAN_INFO`` which produces
+    #: descriptive strings (e.g. ``"speed 1, low"``).  These don't
+    #: match the canonical names in ``_mode_map`` (e.g. ``"low"``)
+    #: that 22F1 uses and that HA dropdowns display.  This map
+    #: normalises 31DA fan_info to canonical names so consumers can
+    #: compare fan_info against fan_modes.  See ramses_cc issue 1116.
+    _FAN_INFO_NORMALISE: dict[str, str] = {
+        "speed 1, low": "low",
+        "speed 2, medium": "medium",
+        "speed 3, high": "high",
+    }
+
+    def normalize_fan_info(self, fan_info: str) -> str:
+        """Normalise a 31DA fan_info string to a canonical mode name.
+
+        :param fan_info: The descriptive fan_info string from 31DA.
+        :type fan_info: str
+        :returns: The canonical mode name, or the original string if
+            no mapping is known.
+        :rtype: str
+        """
+        return self._FAN_INFO_NORMALISE.get(fan_info, fan_info)
+
     @property
     def mode_max(self) -> str | None:
         """Max mode byte for this scheme."""
@@ -260,6 +301,11 @@ class HvacStrategyBase:
                     pass  # semantic string, keep it
 
         if not current_state:
+            # Still normalise fan_info even without current state.
+            if msg_code == Code._31DA and "fan_info" in mutated:
+                incoming = mutated["fan_info"]
+                if isinstance(incoming, str):
+                    mutated["fan_info"] = self.normalize_fan_info(incoming)
             return mutated
 
         # QUIRK: 31DA 'fan_info' precedence over 22F1/22F4
@@ -284,6 +330,12 @@ class HvacStrategyBase:
                     and not current_state.fan_info.startswith("-unknown")
                 ):
                     mutated["fan_info"] = current_state.fan_info
+            elif isinstance(incoming, str):
+                # Normalise descriptive 31DA fan_info (e.g.
+                # "speed 1, low") to canonical mode names (e.g.
+                # "low") so consumers can match against fan_modes.
+                # See ramses_cc issue 1116.
+                mutated["fan_info"] = self.normalize_fan_info(incoming)
 
         return mutated
 

--- a/tests/tests_rf/test_strategies/test_strategies.py
+++ b/tests/tests_rf/test_strategies/test_strategies.py
@@ -474,3 +474,142 @@ class TestQuirkDispatch:
         result = apply_hvac_quirks(payload, None, Code._12A0)
 
         assert result["supply_temp"] == 18.5
+
+
+# ---------------------------------------------------------------------------
+# normalize_fan_info: 31DA descriptive names → canonical mode names
+# (ramses_cc issue 1116 — "speed 1, low" → "low")
+# ---------------------------------------------------------------------------
+
+
+class TestNormalizeFanInfo:
+    """normalize_fan_info maps 31DA descriptive strings to canonical names."""
+
+    @pytest.mark.parametrize(
+        "strategy_cls",
+        [
+            OrconStrategy,
+            ClimaRadStrategy,
+            IthoStrategy,
+            NuaireStrategy,
+            VascoStrategy,
+        ],
+    )
+    def test_normalize_speed_low(
+        self, strategy_cls: type[HvacStrategyBase]
+    ) -> None:
+        assert strategy_cls().normalize_fan_info("speed 1, low") == "low"
+
+    @pytest.mark.parametrize(
+        "strategy_cls",
+        [
+            OrconStrategy,
+            ClimaRadStrategy,
+            IthoStrategy,
+            NuaireStrategy,
+            VascoStrategy,
+        ],
+    )
+    def test_normalize_speed_medium(
+        self, strategy_cls: type[HvacStrategyBase]
+    ) -> None:
+        assert strategy_cls().normalize_fan_info("speed 2, medium") == "medium"
+
+    @pytest.mark.parametrize(
+        "strategy_cls",
+        [
+            OrconStrategy,
+            ClimaRadStrategy,
+            IthoStrategy,
+            NuaireStrategy,
+            VascoStrategy,
+        ],
+    )
+    def test_normalize_speed_high(
+        self, strategy_cls: type[HvacStrategyBase]
+    ) -> None:
+        assert strategy_cls().normalize_fan_info("speed 3, high") == "high"
+
+    @pytest.mark.parametrize(
+        "strategy_cls",
+        [
+            OrconStrategy,
+            ClimaRadStrategy,
+            IthoStrategy,
+            NuaireStrategy,
+            VascoStrategy,
+        ],
+    )
+    def test_normalize_passthrough(
+        self, strategy_cls: type[HvacStrategyBase]
+    ) -> None:
+        """Unknown strings pass through unchanged."""
+        s = strategy_cls()
+        assert s.normalize_fan_info("auto") == "auto"
+        assert s.normalize_fan_info("away") == "away"
+        assert s.normalize_fan_info("boost") == "boost"
+        assert s.normalize_fan_info("off") == "off"
+        assert s.normalize_fan_info("custom_string") == "custom_string"
+
+
+class TestApplyQuirkFanInfoNormalization:
+    """apply_quirk normalises 31DA fan_info in the payload pipeline."""
+
+    def test_31da_fan_info_low_normalized(self) -> None:
+        """31DA 'speed 1, low' is normalised to 'low'."""
+        payload = {"fan_info": "speed 1, low"}
+        result = apply_hvac_quirks(
+            payload, None, Code._31DA, strategy=OrconStrategy()
+        )
+        assert result["fan_info"] == "low"
+
+    def test_31da_fan_info_medium_normalized(self) -> None:
+        """31DA 'speed 2, medium' is normalised to 'medium'."""
+        payload = {"fan_info": "speed 2, medium"}
+        result = apply_hvac_quirks(
+            payload, None, Code._31DA, strategy=OrconStrategy()
+        )
+        assert result["fan_info"] == "medium"
+
+    def test_31da_fan_info_high_normalized(self) -> None:
+        """31DA 'speed 3, high' is normalised to 'high'."""
+        payload = {"fan_info": "speed 3, high"}
+        result = apply_hvac_quirks(
+            payload, None, Code._31DA, strategy=OrconStrategy()
+        )
+        assert result["fan_info"] == "high"
+
+    def test_31da_fan_info_auto_passthrough(self) -> None:
+        """31DA 'auto' passes through unchanged."""
+        payload = {"fan_info": "auto"}
+        result = apply_hvac_quirks(
+            payload, None, Code._31DA, strategy=OrconStrategy()
+        )
+        assert result["fan_info"] == "auto"
+
+    def test_31da_fan_info_off_with_current_state(
+        self,
+    ) -> None:
+        """31DA 'off' with valid current_state keeps current fan_info."""
+        from ramses_rf.models import HvacState
+
+        current = HvacState(fan_info="low")
+        payload = {"fan_info": "off"}
+        result = apply_hvac_quirks(
+            payload, current, Code._31DA, strategy=OrconStrategy()
+        )
+        # 'off' is a null marker — keep the current valid state
+        assert result["fan_info"] == "low"
+
+    def test_31da_fan_info_normalized_with_current_state(
+        self,
+    ) -> None:
+        """31DA normalisation works even when current_state is present."""
+        from ramses_rf.models import HvacState
+
+        current = HvacState(fan_info="auto")
+        payload = {"fan_info": "speed 1, low"}
+        result = apply_hvac_quirks(
+            payload, current, Code._31DA, strategy=OrconStrategy()
+        )
+        assert result["fan_info"] == "low"


### PR DESCRIPTION
## Summary

The 31DA parser produces descriptive `fan_info` strings like `"speed 1, low"` / `"speed 2, medium"` / `"speed 3, high"` that don't match the canonical mode names (`"low"` / `"medium"` / `"high"`) used in 22F1 mode maps and HA dropdowns. This caused the `fan_mode` dropdown in ramses_cc to revert to blank after selecting a mode — the real 31DA broadcast overwrote the optimistic value with a string the dropdown couldn't display (ramses_cc issue 1116).

Add `normalize_fan_info()` to `HvacStrategyBase` and the `HvacStrategy` protocol. Call it in `apply_quirk()` for 31DA packets, mapping descriptive names back to canonical names. Unknown strings pass through unchanged.

This is the ramses_rf half of the fix for ramses-rf/ramses_cc#1116. The ramses_cc half (optimistic state update + fan_modes filtering) is in ramses-rf/ramses_cc#1117.

#### Test plan

- [x] 26 unit tests added (15 for `normalize_fan_info` across all vendor strategies, 6 for `apply_quirk` integration, 5 passthrough)
- [x] `ruff check` — passed
- [x] `mypy` — passed (0 issues)
- [x] `pytest` (full suite) — 2922 passed, 8 skipped, 0 failures
- [x] Manual test on hass: select "low" from dropdown, verify it sticks after 31DA broadcast arrives