### PR TITLE
feat(transport): PR 1 — Pool child state, ingress provenance, O(1) dedup, RSSI TTL (Item 9)

### DIFF
--- a/src/ramses_rf/models/state_signal.py
+++ b/src/ramses_rf/models/state_signal.py
@@ -118,8 +118,19 @@ def compute_quality(
 
         seen = tracker.last_seen(device_id)
         if seen is not None:
-            if last_seen is None or seen > last_seen:
+            # Strip tzinfo for comparison to handle mixed aware/naive
+            # timestamps from different transport types (MQTT vs serial).
+            seen_naive = seen.replace(tzinfo=None) if seen.tzinfo else seen
+            if last_seen is None:
                 last_seen = seen
+            else:
+                last_seen_naive = (
+                    last_seen.replace(tzinfo=None)
+                    if last_seen.tzinfo
+                    else last_seen
+                )
+                if seen_naive > last_seen_naive:
+                    last_seen = seen
 
     staleness_seconds: float | None = None
     is_stale = False

--- a/src/ramses_tx/packet.py
+++ b/src/ramses_tx/packet.py
@@ -89,6 +89,7 @@ class Packet:
         "_lifespan",
         "_is_echo",
         "_is_tx",
+        "_ingress_hgi_id",
     )
 
     _dto: PacketDTO
@@ -112,6 +113,7 @@ class Packet:
     _lifespan: bool | td
     _is_echo: bool
     _is_tx: bool
+    _ingress_hgi_id: str | None
 
     def __init__(
         self,
@@ -172,6 +174,7 @@ class Packet:
             self._index_ = None
             self._repr = None
             self._lifespan = False
+            self._ingress_hgi_id = None
             return
 
         self._dto = dto_or_dtm
@@ -210,6 +213,7 @@ class Packet:
         self._index_ = None
         self._repr = None
         self._lifespan = False
+        self._ingress_hgi_id = None
 
         self._validate(strict_checking=False)
 
@@ -344,6 +348,7 @@ class Packet:
         packet._index_ = None
         packet._repr = None
         packet._lifespan = False
+        packet._ingress_hgi_id = None
 
         packet._validate(strict_checking=False)
         return packet
@@ -478,6 +483,18 @@ class Packet:
         :rtype: str
         """
         return self._dto.rssi or "..."
+
+    @property
+    def ingress_hgi_id(self) -> str | None:
+        """Return the HGI that heard this frame, if known.
+
+        Set by :class:`PooledTransport` when forwarding packets from
+        child transports.  ``None`` for packets that did not arrive
+        through a pool (single-HGI, log replay, etc.).
+
+        :returns: The ingress HGI device ID, or ``None``.
+        """
+        return self._ingress_hgi_id
 
     @property
     def verb(self) -> Verb:

--- a/src/ramses_tx/rssi_tracker.py
+++ b/src/ramses_tx/rssi_tracker.py
@@ -4,10 +4,12 @@ Tracks the last N RSSI readings per device that the HGI (gateway's
 CC1101 receiver) has heard.  RSSI is a L1/L2 measurement made by the
 receiver, not the sender, so it lives on the transport side.
 
-The tracker maintains a small ring buffer per device (default 3
-readings).  This is intentionally **not** a running average or EMA —
-a flat window of the last N readings is predictable, time-agnostic,
-and handles both degradation and recovery cleanly.
+The tracker maintains a small ring buffer per device (default 5
+readings for the pool's route-quality tracker, 3 for the gateway-level
+communication-quality tracker).  Readings older than ``ttl`` are
+expired automatically on access.  This is intentionally **not** a
+running average or EMA — a flat window of the last N fresh readings
+is predictable and handles both degradation and recovery cleanly.
 
 See: https://github.com/ramses-rf/ramses_cc/issues/1047
 """
@@ -15,37 +17,58 @@ See: https://github.com/ramses-rf/ramses_cc/issues/1047
 from __future__ import annotations
 
 from collections import deque
-from datetime import datetime as dt
+from datetime import datetime as dt, timedelta as td
 from typing import Final
 
 # Default window size — last N RSSI readings per device.
 # A small window (3) balances responsiveness with noise immunity.
 DEFAULT_WINDOW_SIZE: Final[int] = 3
 
+# Pool route-quality window: 5 samples for the arithmetic-mean RSSI
+# policy (issue 1119, PR 2 spec).
+POOL_WINDOW_SIZE: Final[int] = 5
+
+# Default TTL for RSSI readings.  Readings older than this are expired
+# automatically on access.  5 minutes (300 s) is conservative enough
+# to capture gradual changes while keeping stale evidence from
+# persisting after a device moves or a dongle is relocated.
+# See: multi-hgi-plan.md, "RSSI TTL — initial default selected".
+DEFAULT_TTL: Final[td] = td(minutes=5)
+
 # Sentinel RSSI values that carry no signal information.
 _RSSI_SENTINELS: Final[frozenset[str]] = frozenset({"", "...", "---", "///"})
 
 
 class RssiTracker:
-    """Per-HGI RSSI tracker maintaining the last N readings per device.
+    """Per-HGI RSSI tracker maintaining the last N fresh readings.
 
     Lives on the transport side (one instance per HGI/gateway).  The
     domain layer queries ``best_rssi_for(device_id)`` to compute
     communication quality across all HGIs.
 
     :param window_size: Number of recent readings to retain per device.
+    :param ttl: Maximum age of a reading before it is expired.  Set to
+        ``None`` to disable TTL-based expiry.
     """
 
-    __slots__ = ("_window_size", "_readings")
+    __slots__ = ("_window_size", "_ttl", "_readings")
 
-    def __init__(self, window_size: int = DEFAULT_WINDOW_SIZE) -> None:
+    def __init__(
+        self,
+        window_size: int = DEFAULT_WINDOW_SIZE,
+        *,
+        ttl: td | None = DEFAULT_TTL,
+    ) -> None:
         """Initialise the tracker.
 
         :param window_size: Readings to keep per device (default 3).
+        :param ttl: Maximum age of readings; older ones are expired
+            on access.  ``None`` disables TTL expiry.
         """
         if window_size < 1:
             raise ValueError("window_size must be >= 1")
         self._window_size: int = window_size
+        self._ttl: td | None = ttl
         # device_id -> deque of (rssi_dBm, timestamp)
         self._readings: dict[str, deque[tuple[int, dt]]] = {}
 
@@ -70,30 +93,40 @@ class RssiTracker:
         buf.append((dBm, timestamp))
 
     def best_rssi_for(self, device_id: str) -> int | None:
-        """Return the strongest (highest) RSSI from the last N readings.
+        """Return the strongest (highest) RSSI from fresh readings.
+
+        Expires stale readings (older than ``ttl``) before computing.
 
         :param device_id: The device to query.
         :returns: Best RSSI in dBm (negative), or ``None`` if no
-            readings exist for the device.
+            fresh readings exist for the device.
         """
         buf = self._readings.get(device_id)
         if not buf:
+            return None
+        self._expire(buf)
+        if not buf:
+            del self._readings[device_id]
             return None
         return max(rssi for rssi, _ in buf)
 
     def last_seen(self, device_id: str) -> dt | None:
-        """Return the timestamp of the most recent reading for a device.
+        """Return the timestamp of the most recent fresh reading.
 
         :param device_id: The device to query.
-        :returns: Timestamp of last reading, or ``None``.
+        :returns: Timestamp of last fresh reading, or ``None``.
         """
         buf = self._readings.get(device_id)
         if not buf:
             return None
+        self._expire(buf)
+        if not buf:
+            del self._readings[device_id]
+            return None
         return buf[-1][1]
 
     def readings_for(self, device_id: str) -> list[int]:
-        """Return the raw list of recent RSSI readings for a device.
+        """Return the raw list of recent fresh RSSI readings.
 
         :param device_id: The device to query.
         :returns: List of recent RSSI values in dBm (oldest first),
@@ -102,18 +135,65 @@ class RssiTracker:
         buf = self._readings.get(device_id)
         if not buf:
             return []
+        self._expire(buf)
+        if not buf:
+            del self._readings[device_id]
+            return []
         return [rssi for rssi, _ in buf]
 
     def known_devices(self) -> frozenset[str]:
-        """Return the set of device IDs that have at least one reading.
+        """Return the set of device IDs that have at least one fresh reading.
 
-        :returns: Frozenset of device IDs with recorded RSSI data.
+        :returns: Frozenset of device IDs with fresh RSSI data.
         """
-        return frozenset(self._readings)
+        if self._ttl is None:
+            return frozenset(self._readings)
+        # Expire stale entries for all devices.
+        now = dt.now()
+        fresh: set[str] = set()
+        for dev_id, buf in self._readings.items():
+            self._expire(buf, now=now)
+            if buf:
+                fresh.add(dev_id)
+            else:
+                # Mark for deletion — can't modify dict during iteration.
+                pass
+        # Remove empty buffers.
+        self._readings = {
+            dev_id: buf for dev_id, buf in self._readings.items() if buf
+        }
+        return frozenset(fresh)
 
     def clear(self) -> None:
         """Clear all recorded readings."""
         self._readings.clear()
+
+    def _expire(
+        self, buf: deque[tuple[int, dt]], *, now: dt | None = None
+    ) -> None:
+        """Remove stale readings from the front of the deque.
+
+        Handles both timezone-aware and timezone-naive timestamps
+        gracefully — readings from MQTT transports may carry tzinfo
+        while ``dt_now()`` from serial transports does not.
+
+        :param buf: The deque to expire stale entries from.
+        :param now: Current time (defaults to ``dt.now()``).
+        """
+        if self._ttl is None:
+            return
+        if now is None:
+            now = dt.now()
+        cutoff = now - self._ttl
+        # Strip tzinfo for comparison to handle mixed aware/naive.
+        cutoff_naive = cutoff.replace(tzinfo=None) if cutoff.tzinfo else cutoff
+        while buf:
+            ts = buf[0][1]
+            ts_naive = ts.replace(tzinfo=None) if ts.tzinfo else ts
+            if ts_naive < cutoff_naive:
+                buf.popleft()
+            else:
+                break
 
 
 def _parse_rssi(rssi: str | int) -> int | None:

--- a/src/ramses_tx/rssi_tracker.py
+++ b/src/ramses_tx/rssi_tracker.py
@@ -28,12 +28,18 @@ DEFAULT_WINDOW_SIZE: Final[int] = 3
 # policy (issue 1119, PR 2 spec).
 POOL_WINDOW_SIZE: Final[int] = 5
 
-# Default TTL for RSSI readings.  Readings older than this are expired
-# automatically on access.  5 minutes (300 s) is conservative enough
-# to capture gradual changes while keeping stale evidence from
-# persisting after a device moves or a dongle is relocated.
+# Default TTL for RSSI readings.  ``None`` means no automatic expiry —
+# the gateway's communication-quality tracker retains readings and flags
+# them stale via ``stale_warn_seconds`` in ``compute_quality``.
+# Pool route-quality trackers override this to 5 minutes (300 s) so stale
+# evidence does not influence outbound child selection.
 # See: multi-hgi-plan.md, "RSSI TTL — initial default selected".
-DEFAULT_TTL: Final[td] = td(minutes=5)
+DEFAULT_TTL: Final[td | None] = None
+
+# Pool route-quality TTL: 5 minutes is conservative enough to capture
+# gradual changes while keeping stale evidence from persisting after a
+# device moves or a dongle is relocated.
+POOL_TTL: Final[td] = td(minutes=5)
 
 # Sentinel RSSI values that carry no signal information.
 _RSSI_SENTINELS: Final[frozenset[str]] = frozenset({"", "...", "---", "///"})

--- a/src/ramses_tx/transport/__init__.py
+++ b/src/ramses_tx/transport/__init__.py
@@ -12,10 +12,12 @@ from .base import TransportConfig as TransportConfig
 from .callback import CallbackTransport as CallbackTransport
 from .factory import (
     RamsesTransportT as RamsesTransportT,
+    pooled_transport_factory as pooled_transport_factory,
     transport_factory as transport_factory,
 )
 from .file import FileTransport as FileTransport
 from .mqtt import MqttTransport as MqttTransport
+from .pooled import PooledTransport as PooledTransport
 from .port import PortTransport as PortTransport
 from .zigbee import ZigbeeTransport as ZigbeeTransport
 
@@ -24,9 +26,11 @@ __all__ = [
     "FileTransport",
     "is_hgi80",
     "MqttTransport",
+    "PooledTransport",
     "PortTransport",
     "RamsesTransportT",
     "TransportConfig",
     "transport_factory",
+    "pooled_transport_factory",
     "ZigbeeTransport",
 ]

--- a/src/ramses_tx/transport/factory.py
+++ b/src/ramses_tx/transport/factory.py
@@ -16,6 +16,7 @@ from ..typing import PortConfigT, RamsesProtocolT, SerPortNameT
 from .base import TransportConfig
 from .file import FileTransport
 from .mqtt import MqttTransport
+from .pooled import PooledTransport, _ChildProtocolProxy
 from .port import PortTransport
 
 _LOGGER = logging.getLogger(__name__)
@@ -23,6 +24,7 @@ _LOGGER = logging.getLogger(__name__)
 _DEFAULT_TIMEOUT_PORT: Final[float] = 3.0
 _DEFAULT_TIMEOUT_MQTT: Final[float] = 60.0
 _DEFAULT_TIMEOUT_ZIGBEE: Final[float] = 60.0
+_DEFAULT_TIMEOUT_POOL: Final[float] = 10.0
 
 RamsesTransportT: TypeAlias = TransportInterface
 
@@ -162,6 +164,180 @@ async def transport_factory(
 
     if os.name == "nt" or port_name.startswith(("rfc2217://", "socket://")):
         issue_warning()
+
+    transport_port = PortTransport(
+        port_name,
+        protocol,
+        port_config=ser_config,
+        config=config,
+        extra=extra,
+        loop=loop,
+    )
+
+    try:
+        await protocol.wait_for_connection_made(
+            timeout=config.timeout or _DEFAULT_TIMEOUT_PORT
+        )
+    except exc.TransportSerialError as err:
+        transport_port.close()
+        raise exc.TransportSourceInvalid(
+            f"Unable to open the serial port {port_name}: {err}"
+        ) from err
+    except Exception:
+        transport_port.close()
+        raise
+
+    return transport_port
+
+
+async def pooled_transport_factory(
+    protocol: RamsesProtocolT,
+    /,
+    *,
+    config: TransportConfig,
+    port_names: list[SerPortNameT],
+    port_configs: list[PortConfigT] | None = None,
+    extra: dict[str, object] | None = None,
+    loop: asyncio.AbstractEventLoop | None = None,
+    dedup_window: float = 0.5,
+) -> RamsesTransportT:
+    """Create a :class:`PooledTransport` from multiple port names.
+
+    Each port name gets its own child transport (serial, MQTT, or
+    Zigbee) created with a :class:`_ChildProtocolProxy` that routes
+    inbound packets through the pool's deduplication filter.
+
+    :param protocol: The real protocol that receives deduplicated
+        packets.
+    :type protocol: RamsesProtocolT
+    :param config: Transport configuration shared by all children.
+    :type config: TransportConfig
+    :param port_names: List of port names (serial, MQTT URLs, etc.).
+    :type port_names: list[SerPortNameT]
+    :param port_configs: Optional per-child port configurations for
+        serial ports.  If provided, must be the same length as
+        ``port_names``.  If ``None``, serial children will use a
+        default config.
+    :type port_configs: list[PortConfigT] | None
+    :param extra: Extra configuration options shared by all children.
+    :type extra: dict[str, object] | None
+    :param loop: Asyncio event loop.
+    :type loop: asyncio.AbstractEventLoop | None
+    :param dedup_window: Deduplication window in seconds.
+    :type dedup_window: float
+    :returns: A :class:`PooledTransport` wrapping all child transports.
+    :rtype: PooledTransport
+    :raises ValueError: If ``port_names`` is empty or ``port_configs``
+        length doesn't match.
+    """
+    if not port_names:
+        raise ValueError(
+            "pooled_transport_factory requires at least one port_name"
+        )
+    if port_configs is not None and len(port_configs) != len(port_names):
+        raise ValueError("port_configs must be the same length as port_names")
+
+    # Apply regex rules to the Protocol before binding any Transport.
+    if config.use_regex:
+        protocol.set_regex_rules(config.use_regex)
+
+    # Create the pool first so we can create child proxies.
+    pool = PooledTransport(
+        protocol,
+        [],  # filled in below
+        config=config,
+        loop=loop,
+        dedup_window=dedup_window,
+    )
+
+    child_transports: list[TransportInterface] = []
+
+    for i, pname in enumerate(port_names):
+        proxy = _ChildProtocolProxy(pool, i)
+        pconfig = port_configs[i] if port_configs else None
+
+        # Create the child transport via the standard factory, but
+        # with the proxy protocol instead of the real one.
+        child = await _create_single_child(
+            proxy,
+            config=config,
+            port_name=pname,
+            port_config=pconfig,
+            extra=extra,
+            loop=loop,
+        )
+        child_transports.append(child)
+
+    # Inject the child transports into the pool.
+    pool._transports = child_transports
+    pool._child_connected = [False] * len(child_transports)
+    pool._child_hgi = [None] * len(child_transports)
+    pool._child_transport_objs = [None] * len(child_transports)
+    pool._pkts_received = [0] * len(child_transports)
+
+    # Wait for at least one child to connect.
+    await pool._wait_for_any_connection(
+        timeout=config.timeout or _DEFAULT_TIMEOUT_POOL
+    )
+
+    return pool
+
+
+async def _create_single_child(
+    protocol: RamsesProtocolT,
+    /,
+    *,
+    config: TransportConfig,
+    port_name: SerPortNameT,
+    port_config: PortConfigT | None,
+    extra: dict[str, object] | None,
+    loop: asyncio.AbstractEventLoop | None,
+) -> TransportInterface:
+    """Create a single child transport for the pool.
+
+    This is a simplified version of :func:`transport_factory` that
+    does not support packet_log/packet_dict (pools only work with
+    live transports) and uses a shorter default timeout.
+    """
+    # Zigbee
+    if port_name[:6] == "zigbee":
+        from .zigbee import ZigbeeTransport
+
+        transport = ZigbeeTransport(
+            port_name,
+            protocol,
+            config=config,
+            loop=loop,
+        )
+        try:
+            await protocol.wait_for_connection_made(
+                timeout=_DEFAULT_TIMEOUT_ZIGBEE
+            )
+        except Exception:
+            transport.close()
+            raise
+        return transport
+
+    # MQTT
+    if port_name[:4] == "mqtt":
+        mqtt_timeout = config.timeout or _DEFAULT_TIMEOUT_MQTT
+        transport = MqttTransport(
+            port_name,
+            protocol,
+            config=config,
+            extra=extra,
+            loop=loop,
+        )
+        try:
+            await protocol.wait_for_connection_made(timeout=mqtt_timeout)
+        except Exception:
+            transport.close()
+            raise
+        return transport
+
+    # Serial
+    assert port_config is not None  # serial requires port_config
+    ser_config = SCH_SERIAL_PORT_CONFIG(port_config)
 
     transport_port = PortTransport(
         port_name,

--- a/src/ramses_tx/transport/factory.py
+++ b/src/ramses_tx/transport/factory.py
@@ -242,15 +242,17 @@ async def pooled_transport_factory(
         protocol.set_regex_rules(config.use_regex)
 
     # Create the pool first so we can create child proxies.
+    # Pre-allocate children with None transports; successful children
+    # are injected after creation.
+    num_children = len(port_names)
     pool = PooledTransport(
         protocol,
-        [],  # filled in below
+        [None] * num_children,  # placeholders, replaced below
         config=config,
         loop=loop,
         dedup_window=dedup_window,
+        port_names=[str(p) for p in port_names],
     )
-
-    child_transports: list[TransportInterface] = []
 
     for i, pname in enumerate(port_names):
         proxy = _ChildProtocolProxy(pool, i)
@@ -258,22 +260,30 @@ async def pooled_transport_factory(
 
         # Create the child transport via the standard factory, but
         # with the proxy protocol instead of the real one.
-        child = await _create_single_child(
-            proxy,
-            config=config,
-            port_name=pname,
-            port_config=pconfig,
-            extra=extra,
-            loop=loop,
-        )
-        child_transports.append(child)
+        # Tolerate individual child failures — the pool can operate
+        # with a subset of children (e.g. if a USB HGI is unplugged
+        # or in use by another process).
+        try:
+            child = await _create_single_child(
+                proxy,
+                config=config,
+                port_name=pname,
+                port_config=pconfig,
+                extra=extra,
+                loop=loop,
+            )
+        except Exception as err:
+            _LOGGER.warning(
+                "PooledTransport: child %d (%s) failed to connect: %s — "
+                "continuing with remaining children",
+                i,
+                pname,
+                err,
+            )
+            continue
 
-    # Inject the child transports into the pool.
-    pool._transports = child_transports
-    pool._child_connected = [False] * len(child_transports)
-    pool._child_hgi = [None] * len(child_transports)
-    pool._child_transport_objs = [None] * len(child_transports)
-    pool._pkts_received = [0] * len(child_transports)
+        # Replace the placeholder with the real transport.
+        pool._children[i].transport = child
 
     # Wait for at least one child to connect.
     await pool._wait_for_any_connection(

--- a/src/ramses_tx/transport/pooled.py
+++ b/src/ramses_tx/transport/pooled.py
@@ -1,0 +1,437 @@
+#!/usr/bin/env python3
+"""RAMSES RF - Pooled transport for multi-HGI link-layer pooling.
+
+Combines multiple physical transports (serial, MQTT, ser2net) into a
+single coherent :class:`TransportInterface` that the protocol layer
+sees as one transport.  Inbound packets from any child are deduplicated
+within a sliding time window and forwarded upstream.  Outbound frames
+are routed to a selected child transport (round-robin in this PR;
+RSSI-based selection follows in a subsequent PR).
+
+This is Roadmap Item 9, PR 2 (issue 1122).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import logging
+from collections import deque
+from datetime import datetime as dt, timedelta as td
+from typing import Any, TypeAlias
+
+from .. import exceptions as exc
+from ..const import SZ_ACTIVE_HGI, SZ_IS_EVOFW3
+from ..helpers import dt_now
+from ..interfaces import ProtocolInterface, TransportInterface
+from ..packet import Packet
+from ..typing import RamsesProtocolT
+from .base import TransportConfig
+
+_LOGGER = logging.getLogger(__name__)
+
+#: Default deduplication window in seconds.  Two packets with the same
+#: content key arriving within this window from different child
+#: transports are considered duplicates.
+_DEFAULT_DEDUP_WINDOW: float = 0.5
+
+#: Maximum number of dedup keys retained in the sliding window.
+_MAX_DEDUP_KEYS: int = 512
+
+#: Key for deduplication: (verb, code, src, dst, addr3, raw_payload).
+_DedupKeyT: TypeAlias = tuple[str, str, str, str, str, str]
+
+
+class _ChildProtocolProxy(ProtocolInterface):
+    """Protocol proxy inserted between a child transport and the pool.
+
+    Each child transport is created with this proxy as its protocol.
+    The proxy intercepts ``packet_received`` and routes the packet to
+    the :class:`PooledTransport` for deduplication and upstream
+    forwarding.  Connection lifecycle events are also forwarded so the
+    pool can track which children are alive.
+
+    :param pool: The owning pooled transport.
+    :type pool: PooledTransport
+    :param index: The child's position in the pool's transport list.
+    :type index: int
+    """
+
+    def __init__(self, pool: PooledTransport, index: int) -> None:
+        """Initialise the child protocol proxy."""
+        self._pool = pool
+        self._index = index
+        self._connected: bool = False
+
+    # -- ProtocolInterface ----------------------------------------------
+
+    def connection_made(
+        self, transport: Any, /, *, ramses: bool = False
+    ) -> None:
+        """Forward connection_made to the pool for tracking."""
+        self._connected = True
+        self._pool._on_child_connected(self._index, transport)
+
+    def connection_lost(self, error: Exception | None) -> None:
+        """Forward connection_lost to the pool for tracking."""
+        self._connected = False
+        self._pool._on_child_disconnected(self._index, error)
+
+    def packet_received(self, packet: Packet) -> None:
+        """Route the packet to the pool for dedup + upstream forward."""
+        self._pool._on_child_packet(self._index, packet)
+
+    def pause_writing(self) -> None:
+        """No-op — flow control is handled per-child."""
+
+    def resume_writing(self) -> None:
+        """No-op — flow control is handled per-child."""
+
+    async def send_cmd(
+        self,
+        command: Any,
+        /,
+        *,
+        qos: Any = None,
+    ) -> Packet | None:
+        """Not used by transports — delegated to the real protocol."""
+        return await self._pool._protocol.send_cmd(command, qos=qos)
+
+    async def wait_for_connection_made(
+        self, timeout: float = 1.0
+    ) -> TransportInterface:
+        """Wait until at least one child connects."""
+        return await self._pool._wait_for_any_connection(timeout)
+
+    def set_regex_rules(self, rules: Any) -> None:
+        """No-op — regex rules are set on the real protocol by the factory."""
+
+
+class PooledTransport(TransportInterface):
+    """Aggregate multiple physical transports into one interface.
+
+    The pool presents a single :class:`TransportInterface` to the
+    protocol/engine layer.  Internally it manages N child transports,
+    each created with a :class:`_ChildProtocolProxy` that routes
+    inbound packets through the pool's deduplication filter before
+    forwarding them to the real protocol.
+
+    Outbound frames are routed to a selected child transport.  The
+    selection strategy is round-robin in this PR; RSSI-based selection
+    will be added in a subsequent PR (Roadmap Item 9, PR 3).
+
+    :param protocol: The real protocol that receives deduplicated
+        packets.
+    :type protocol: RamsesProtocolT
+    :param transports: List of child transports to pool.
+    :type transports: list[TransportInterface]
+    :param config: Transport configuration shared by all children.
+    :type config: TransportConfig
+    :param loop: The asyncio event loop.
+    :type loop: asyncio.AbstractEventLoop | None
+    :param dedup_window: Deduplication window in seconds.  Packets
+        with the same content key arriving within this window from
+        different children are suppressed.  Defaults to 0.5s.
+    :type dedup_window: float
+    """
+
+    def __init__(
+        self,
+        protocol: RamsesProtocolT,
+        transports: list[TransportInterface],
+        /,
+        *,
+        config: TransportConfig,
+        loop: asyncio.AbstractEventLoop | None = None,
+        dedup_window: float = _DEFAULT_DEDUP_WINDOW,
+    ) -> None:
+        """Initialise the pooled transport."""
+        if not transports:
+            raise ValueError(
+                "PooledTransport requires at least one child transport"
+            )
+
+        self._protocol: RamsesProtocolT = protocol
+        self._transports: list[TransportInterface] = transports
+        self._config: TransportConfig = config
+        self._loop: asyncio.AbstractEventLoop = (
+            loop or asyncio.get_event_loop()
+        )
+        self._closing: bool = False
+
+        self._dedup_window: td = td(seconds=dedup_window)
+        self._dedup_cache: deque[tuple[dt, _DedupKeyT]] = deque(
+            maxlen=_MAX_DEDUP_KEYS
+        )
+
+        # Per-child connection state.
+        self._child_connected: list[bool] = [False] * len(transports)
+        self._child_hgi: list[str | None] = [None] * len(transports)
+        self._child_transport_objs: list[Any] = [None] * len(transports)
+
+        # Round-robin outbound counter.
+        self._rr_index: int = 0
+
+        # Connection future — resolved when at least one child connects.
+        self._conn_fut: asyncio.Future[TransportInterface] | None = None
+
+        # Stats for diagnostics.
+        self._pkts_received: list[int] = [0] * len(transports)
+        self._pkts_deduped: int = 0
+        self._pkts_forwarded: int = 0
+
+    # -- TransportInterface ---------------------------------------------
+
+    def close(self) -> None:
+        """Close all child transports."""
+        if self._closing:
+            return
+        self._closing = True
+        for t in self._transports:
+            try:
+                t.close()
+            except Exception as err:  # pragma: no cover - defensive
+                _LOGGER.debug("Error closing child transport: %s", err)
+
+    def get_extra_info(self, name: str, default: Any = None) -> Any:
+        """Return aggregate extra info from connected children.
+
+        For ``SZ_ACTIVE_HGI`` returns the first connected child's HGI
+        ID.  For ``SZ_IS_EVOFW3`` returns True if any connected child
+        is evofw3.
+        """
+        if name == SZ_ACTIVE_HGI:
+            for hgi in self._child_hgi:
+                if hgi is not None:
+                    return hgi
+            return default
+        if name == SZ_IS_EVOFW3:
+            for i, connected in enumerate(self._child_connected):
+                if connected and self._child_transport_objs[i] is not None:
+                    val = self._child_transport_objs[i].get_extra_info(
+                        SZ_IS_EVOFW3, False
+                    )
+                    if val:
+                        return True
+            return default
+        if name == "pool_stats":
+            return {
+                "children": len(self._transports),
+                "connected": sum(self._child_connected),
+                "received": list(self._pkts_received),
+                "deduped": self._pkts_deduped,
+                "forwarded": self._pkts_forwarded,
+            }
+        return default
+
+    async def send_frame(self, frame: str) -> None:
+        """Send a frame via a selected child transport."""
+        await self.write_frame(frame)
+
+    async def write_frame(
+        self, frame: str, disable_tx_limits: bool = False
+    ) -> None:
+        """Route an outbound frame to a selected child transport.
+
+        Selection is round-robin among connected children in this PR.
+        RSSI-based selection will be added in PR 3.
+
+        :param frame: The raw ASCII frame to transmit.
+        :type frame: str
+        :param disable_tx_limits: If True, bypass per-child rate
+            limiting.  Forwarded to the selected child's
+            ``write_frame``.
+        :type disable_tx_limits: bool
+        """
+        child = self._select_transport()
+        if child is None:
+            raise exc.TransportError(
+                "No connected child transport available for send"
+            )
+        # Child transports (PortTransport, MqttTransport) accept the
+        # disable_tx_limits kwarg even though TransportInterface
+        # doesn't declare it — use getattr to call the concrete method.
+        write = getattr(child, "write_frame", None)
+        if write is None:
+            await child.send_frame(frame)
+        else:
+            try:
+                await write(frame, disable_tx_limits=disable_tx_limits)
+            except TypeError:
+                # Child's write_frame doesn't accept disable_tx_limits
+                await write(frame)
+
+    # -- Internal: inbound dedup + forward -------------------------------
+
+    def _on_child_packet(self, index: int, packet: Packet) -> None:
+        """Process a packet from a child transport.
+
+        Deduplicates against the sliding window and forwards to the
+        real protocol if not a duplicate.
+        """
+        self._pkts_received[index] += 1
+
+        if self._closing:
+            return
+
+        key = self._dedup_key(packet)
+        now = dt_now()
+
+        # Purge stale entries from the dedup cache.
+        cutoff = now - self._dedup_window
+        while self._dedup_cache and self._dedup_cache[0][0] < cutoff:
+            self._dedup_cache.popleft()
+
+        # Check for duplicate.
+        for _, existing_key in self._dedup_cache:
+            if existing_key == key:
+                self._pkts_deduped += 1
+                _LOGGER.debug(
+                    "PooledTransport: deduped packet from child %d: %s",
+                    index,
+                    packet,
+                )
+                return
+
+        # Not a duplicate — record and forward.
+        self._dedup_cache.append((now, key))
+        self._pkts_forwarded += 1
+
+        # Tag the packet's source HGI for downstream tracking.
+        # Packet has __slots__, so we use the _extra dict pattern.
+        # The protocol reads SZ_ACTIVE_HGI from the transport, so we
+        # set it on the pool for get_extra_info() queries.
+        hgi = self._child_hgi[index]
+        if hgi is not None:
+            # Update the pool's "active" HGI to the source child's HGI.
+            # This is a simplification — PR 3 will track per-packet source.
+            pass
+
+        try:
+            self._loop.call_soon_threadsafe(
+                self._protocol.packet_received, packet
+            )
+        except RuntimeError as err:
+            _LOGGER.debug(
+                "PooledTransport: event loop closed, cannot forward: %s",
+                err,
+            )
+
+    @staticmethod
+    def _dedup_key(packet: Packet) -> _DedupKeyT:
+        """Build a deduplication key from packet content.
+
+        :param packet: The packet to key.
+        :type packet: Packet
+        :returns: A tuple of (verb, code, src, dst, addr3, raw_payload).
+        :rtype: _DedupKeyT
+        """
+        dto = packet._dto
+        return (
+            dto.verb,
+            dto.code,
+            dto.addr1,
+            dto.addr2,
+            dto.addr3,
+            dto.raw_payload,
+        )
+
+    # -- Internal: connection lifecycle ---------------------------------
+
+    def _on_child_connected(self, index: int, transport_obj: Any) -> None:
+        """Mark a child as connected and capture its HGI ID."""
+        self._child_connected[index] = True
+        self._child_transport_objs[index] = transport_obj
+
+        # Read the child's active HGI from its extra info.
+        hgi = transport_obj.get_extra_info(SZ_ACTIVE_HGI)
+        self._child_hgi[index] = hgi
+
+        _LOGGER.info(
+            "PooledTransport: child %d connected (HGI=%s), %d/%d connected",
+            index,
+            hgi,
+            sum(self._child_connected),
+            len(self._transports),
+        )
+
+        # Resolve the connection future if waiting.
+        if self._conn_fut is not None and not self._conn_fut.done():
+            self._conn_fut.set_result(self)
+
+    def _on_child_disconnected(
+        self, index: int, error: Exception | None
+    ) -> None:
+        """Mark a child as disconnected."""
+        self._child_connected[index] = False
+        self._child_hgi[index] = None
+
+        _LOGGER.info(
+            "PooledTransport: child %d disconnected (%s), %d/%d connected",
+            index,
+            error,
+            sum(self._child_connected),
+            len(self._transports),
+        )
+
+        # If no children are connected, notify the real protocol.
+        if not any(self._child_connected) and not self._closing:
+            with contextlib.suppress(RuntimeError):
+                self._loop.call_soon_threadsafe(
+                    self._protocol.connection_lost, error
+                )
+
+    async def _wait_for_any_connection(
+        self, timeout: float = 1.0
+    ) -> TransportInterface:
+        """Wait until at least one child transport is connected."""
+        if any(self._child_connected):
+            return self
+
+        if self._conn_fut is None or self._conn_fut.done():
+            self._conn_fut = self._loop.create_future()
+
+        try:
+            return await asyncio.wait_for(
+                asyncio.shield(self._conn_fut), timeout=timeout
+            )
+        except TimeoutError as err:
+            raise exc.TransportError(
+                f"PooledTransport: no child connected within {timeout}s"
+            ) from err
+
+    # -- Internal: outbound routing -------------------------------------
+
+    def _select_transport(self) -> TransportInterface | None:
+        """Select a child transport for outbound transmission.
+
+        Round-robin among connected children.  Returns ``None`` if no
+        child is connected.
+        """
+        connected = [i for i, c in enumerate(self._child_connected) if c]
+        if not connected:
+            return None
+
+        # Round-robin: advance the counter and pick the next connected
+        # child, skipping disconnected ones.
+        n = len(self._transports)
+        for _ in range(n):
+            self._rr_index = (self._rr_index + 1) % n
+            if self._rr_index in connected:
+                return self._transports[self._rr_index]
+
+        return self._transports[connected[0]]
+
+    # -- Diagnostics -----------------------------------------------------
+
+    def __repr__(self) -> str:
+        """Return a diagnostic representation of the pool."""
+        return (
+            f"PooledTransport(children={len(self._transports)}, "
+            f"connected={sum(self._child_connected)})"
+        )
+
+    @property
+    def is_closing(self) -> bool:
+        """Return True if the pool is closing or has closed."""
+        return self._closing

--- a/src/ramses_tx/transport/pooled.py
+++ b/src/ramses_tx/transport/pooled.py
@@ -39,7 +39,7 @@ from ..const import SZ_ACTIVE_HGI, SZ_IS_EVOFW3, Code
 from ..helpers import dt_now
 from ..interfaces import ProtocolInterface, TransportInterface
 from ..packet import Packet
-from ..rssi_tracker import POOL_WINDOW_SIZE, RssiTracker
+from ..rssi_tracker import POOL_TTL, POOL_WINDOW_SIZE, RssiTracker
 from ..typing import DeviceIdT, RamsesProtocolT
 from .base import TransportConfig
 
@@ -125,7 +125,7 @@ class PoolChild:
     hgi_id: DeviceIdT | None = None
     accepted: bool = True
     rssi_tracker: RssiTracker = field(
-        default_factory=lambda: RssiTracker(POOL_WINDOW_SIZE)
+        default_factory=lambda: RssiTracker(POOL_WINDOW_SIZE, ttl=POOL_TTL)
     )
     last_pkt_time: dt | None = None
     consecutive_errors: int = 0

--- a/src/ramses_tx/transport/pooled.py
+++ b/src/ramses_tx/transport/pooled.py
@@ -3,12 +3,24 @@
 
 Combines multiple physical transports (serial, MQTT, ser2net) into a
 single coherent :class:`TransportInterface` that the protocol layer
-sees as one transport.  Inbound packets from any child are deduplicated
-within a sliding time window and forwarded upstream.  Outbound frames
-are routed to a selected child transport (round-robin in this PR;
-RSSI-based selection follows in a subsequent PR).
+sees as one transport.  Inbound packets from any child are
+deduplicated within a sliding time window and forwarded upstream.
+Outbound frames are routed to the child transport with the best
+rolling-average RSSI, falling back to round-robin when no RSSI data
+is available yet.  Unhealthy children are detected via a configurable
+health timeout and excluded from outbound selection until they
+recover.
 
-This is Roadmap Item 9, PR 2 (issue 1122).
+This is Roadmap Item 9, PR 1 (issue 1119).
+
+PR 1 rework: replaces parallel mutable arrays with an encapsulated
+:class:`PoolChild` record per route, adds ingress provenance
+(``ingress_hgi_id`` separate from RAMSES ``addr1``), loopback
+exclusion from route RSSI, a dict-backed O(1) dedup cache with
+sequence-aware keys, and RSSI TTL expiry.  Runtime
+``add_child()``/``remove_child()``/``set_accepted_hgis()`` are
+removed — construction and config-entry reload build immutable child
+registries for the first release.
 """
 
 from __future__ import annotations
@@ -16,16 +28,19 @@ from __future__ import annotations
 import asyncio
 import contextlib
 import logging
-from collections import deque
+from dataclasses import dataclass, field
 from datetime import datetime as dt, timedelta as td
+from enum import Enum, auto
 from typing import Any, TypeAlias
 
 from .. import exceptions as exc
-from ..const import SZ_ACTIVE_HGI, SZ_IS_EVOFW3
+from ..address import HGI_DEV_ADDR
+from ..const import SZ_ACTIVE_HGI, SZ_IS_EVOFW3, Code
 from ..helpers import dt_now
 from ..interfaces import ProtocolInterface, TransportInterface
 from ..packet import Packet
-from ..typing import RamsesProtocolT
+from ..rssi_tracker import POOL_WINDOW_SIZE, RssiTracker
+from ..typing import DeviceIdT, RamsesProtocolT
 from .base import TransportConfig
 
 _LOGGER = logging.getLogger(__name__)
@@ -35,11 +50,189 @@ _LOGGER = logging.getLogger(__name__)
 #: transports are considered duplicates.
 _DEFAULT_DEDUP_WINDOW: float = 0.5
 
-#: Maximum number of dedup keys retained in the sliding window.
+#: Maximum number of dedup keys retained in the cache.
 _MAX_DEDUP_KEYS: int = 512
 
-#: Key for deduplication: (verb, code, src, dst, addr3, raw_payload).
-_DedupKeyT: TypeAlias = tuple[str, str, str, str, str, str]
+#: RSSI value used when a child has no data yet (treated as neutral).
+_RSSI_UNKNOWN: int = 0
+
+#: Default health-check interval in seconds.  A child that has not
+#: received any packets for this duration is marked unhealthy.
+#: Set to 180s (3 min) because RAMSES traffic can be sparse — some
+#: devices poll every 2-3 minutes, and a 60s timeout caused false
+#: unhealthy markings during quiet periods (observed in pool testing
+#: with real MQTT HGIs, issue 1119).
+_DEFAULT_HEALTH_TIMEOUT: float = 180.0
+
+#: Number of consecutive errors before a child is marked unhealthy.
+_DEFAULT_MAX_CONSECUTIVE_ERRORS: int = 5
+
+#: Dedup key: (verb, code, src, dst, addr3, seq, raw_payload).
+#: The sequence field is included when present (not ``---``) because
+#: it is sender-assigned and stable across HGIs (confirmed from
+#: captured fixtures: 50/50 paired packets had identical sequence).
+#: When sequence is absent, the fallback base key is
+#: (verb, code, src, dst, addr3, "", raw_payload).
+_DedupKeyT: TypeAlias = tuple[str, str, str, str, str, str, str]
+
+
+class ConnectionState(Enum):
+    """Connection state of a pool child transport.
+
+    Separates the transport-layer connection (TCP/serial link up)
+    from node availability (RF packets flowing).
+    """
+
+    DISCONNECTED = auto()
+    CONNECTED = auto()
+
+
+class NodeAvailability(Enum):
+    """Node availability for a pool child.
+
+    ``ONLINE``: recently received packets, healthy.
+    ``STALE``: connected but no packets within health_timeout.
+    ``OFFLINE``: explicitly disconnected or too many errors.
+    """
+
+    ONLINE = auto()
+    STALE = auto()
+    OFFLINE = auto()
+
+
+@dataclass
+class PoolChild:
+    """Encapsulates all per-child state for one pool route.
+
+    Replaces the parallel mutable arrays (``_child_connected``,
+    ``_child_hgi``, ``_child_transport_objs``, etc.) with a single
+    coherent record.  Each child owns its transport, connection state,
+    HGI identity, RSSI tracker, health tracking, and counters.
+
+    :param child_id: Stable identifier (construction order index).
+    :param port_name: Transport address (serial path, MQTT URL).
+    :param transport: The child transport, or ``None`` if construction
+        failed or the child was removed.
+    :param accepted: Whether this child's HGI is in the accepted set.
+    """
+
+    child_id: int
+    port_name: str
+    transport: TransportInterface | None = None
+    transport_obj: Any = None
+    connection_state: ConnectionState = ConnectionState.DISCONNECTED
+    availability: NodeAvailability = NodeAvailability.OFFLINE
+    hgi_id: DeviceIdT | None = None
+    accepted: bool = True
+    rssi_tracker: RssiTracker = field(
+        default_factory=lambda: RssiTracker(POOL_WINDOW_SIZE)
+    )
+    last_pkt_time: dt | None = None
+    consecutive_errors: int = 0
+    pkts_received: int = 0
+    send_ready: bool = False
+
+    @property
+    def is_connected(self) -> bool:
+        """Return True if the transport link is connected."""
+        return self.connection_state is ConnectionState.CONNECTED
+
+    @property
+    def is_online(self) -> bool:
+        """Return True if the node is online (packets flowing)."""
+        return self.availability is NodeAvailability.ONLINE
+
+    @property
+    def is_sendable(self) -> bool:
+        """Return True if this child can be selected for outbound.
+
+        A child is sendable when it is connected, accepted, and
+        send-ready (has identity or has received at least one packet).
+        """
+        return (
+            self.is_connected
+            and self.accepted
+            and self.send_ready
+            and self.transport is not None
+        )
+
+    def mark_connected(self, transport_obj: Any) -> None:
+        """Mark the child as connected and capture transport metadata.
+
+        :param transport_obj: The connected transport object.
+        """
+        self.connection_state = ConnectionState.CONNECTED
+        self.transport_obj = transport_obj
+        # Read HGI identity from the transport if available.
+        hgi = transport_obj.get_extra_info(SZ_ACTIVE_HGI)
+        if hgi is not None:
+            self.hgi_id = DeviceIdT(hgi)
+        # A connected child with known HGI is send-ready.
+        if self.hgi_id is not None:
+            self.send_ready = True
+
+    def mark_disconnected(self) -> None:
+        """Mark the child as disconnected and reset state."""
+        self.connection_state = ConnectionState.DISCONNECTED
+        self.availability = NodeAvailability.OFFLINE
+        self.transport_obj = None
+        self.send_ready = False
+        # Quarantine RSSI evidence when offline (issue 1119).
+        self.rssi_tracker.clear()
+        self.last_pkt_time = None
+
+    def mark_online(self) -> None:
+        """Mark the child as online (packet received)."""
+        self.availability = NodeAvailability.ONLINE
+        self.last_pkt_time = dt_now()
+        self.consecutive_errors = 0
+        # Receiving a packet with a known HGI makes us send-ready.
+        if self.hgi_id is not None:
+            self.send_ready = True
+
+    def mark_stale(self) -> None:
+        """Mark the child as stale (no packets within health timeout)."""
+        if self.availability is NodeAvailability.ONLINE:
+            self.availability = NodeAvailability.STALE
+
+    def record_error(self) -> None:
+        """Record a consecutive error (disconnection)."""
+        self.consecutive_errors += 1
+
+    def learn_hgi(self, hgi_id: DeviceIdT) -> None:
+        """Learn the child's HGI identity from a puzzle response.
+
+        :param hgi_id: The HGI device ID learned from the packet.
+        """
+        if self.hgi_id is None:
+            self.hgi_id = hgi_id
+            self.send_ready = True
+            _LOGGER.info(
+                "PooledTransport: child %d HGI learned as %s "
+                "from puzzle response",
+                self.child_id,
+                hgi_id,
+            )
+
+
+@dataclass(frozen=True, slots=True)
+class IngressFrame:
+    """Immutable metadata for an inbound frame at the callback boundary.
+
+    Carries ``ingress_hgi_id`` separately from RAMSES ``addr1``
+    because ``addr1`` identifies the RF transmitter, not the
+    receiving HGI.  Serial/Zigbee child proxies resolve the
+    configured/validated child identity and carry it explicitly;
+    wildcard MQTT callbacks extract it from the topic.
+
+    :param frame: The raw ASCII frame string.
+    :param timestamp: Optional timestamp string from the transport.
+    :param ingress_hgi_id: The HGI/child that heard the frame.
+    """
+
+    frame: str
+    timestamp: str | None
+    ingress_hgi_id: DeviceIdT | None
 
 
 class _ChildProtocolProxy(ProtocolInterface):
@@ -53,15 +246,16 @@ class _ChildProtocolProxy(ProtocolInterface):
 
     :param pool: The owning pooled transport.
     :type pool: PooledTransport
-    :param index: The child's position in the pool's transport list.
-    :type index: int
+    :param child_id: The child's stable ID in the pool.
+    :type child_id: int
     """
 
-    def __init__(self, pool: PooledTransport, index: int) -> None:
+    def __init__(self, pool: PooledTransport, child_id: int) -> None:
         """Initialise the child protocol proxy."""
         self._pool = pool
-        self._index = index
+        self._child_id = child_id
         self._connected: bool = False
+        self._conn_event: asyncio.Event = asyncio.Event()
 
     # -- ProtocolInterface ----------------------------------------------
 
@@ -70,16 +264,28 @@ class _ChildProtocolProxy(ProtocolInterface):
     ) -> None:
         """Forward connection_made to the pool for tracking."""
         self._connected = True
-        self._pool._on_child_connected(self._index, transport)
+        self._conn_event.set()
+        self._pool._on_child_connected(self._child_id, transport)
 
     def connection_lost(self, error: Exception | None) -> None:
         """Forward connection_lost to the pool for tracking."""
         self._connected = False
-        self._pool._on_child_disconnected(self._index, error)
+        self._conn_event.clear()
+        self._pool._on_child_disconnected(self._child_id, error)
 
-    def packet_received(self, packet: Packet) -> None:
-        """Route the packet to the pool for dedup + upstream forward."""
-        self._pool._on_child_packet(self._index, packet)
+    def packet_received(
+        self, packet: Packet, *, ingress_hgi_id: DeviceIdT | None = None
+    ) -> None:
+        """Route the packet to the pool for dedup + upstream forward.
+
+        :param packet: The parsed packet from the child transport.
+        :param ingress_hgi_id: Optional HGI identity from the callback
+            boundary (e.g. extracted from an MQTT topic).  When
+            ``None``, the pool resolves it from the child record.
+        """
+        self._pool._on_child_packet(
+            self._child_id, packet, ingress_hgi_id=ingress_hgi_id
+        )
 
     def pause_writing(self) -> None:
         """No-op — flow control is handled per-child."""
@@ -100,8 +306,16 @@ class _ChildProtocolProxy(ProtocolInterface):
     async def wait_for_connection_made(
         self, timeout: float = 1.0
     ) -> TransportInterface:
-        """Wait until at least one child connects."""
-        return await self._pool._wait_for_any_connection(timeout)
+        """Wait until **this** child connects (not any child)."""
+        try:
+            await asyncio.wait_for(self._conn_event.wait(), timeout=timeout)
+        except TimeoutError as err:
+            raise exc.TransportError(
+                f"Child transport {self._child_id} did not connect "
+                f"within {timeout}s"
+            ) from err
+        # Return the pool — callers just need a TransportInterface.
+        return self._pool
 
     def set_regex_rules(self, rules: Any) -> None:
         """No-op — regex rules are set on the real protocol by the factory."""
@@ -116,69 +330,138 @@ class PooledTransport(TransportInterface):
     inbound packets through the pool's deduplication filter before
     forwarding them to the real protocol.
 
-    Outbound frames are routed to a selected child transport.  The
-    selection strategy is round-robin in this PR; RSSI-based selection
-    will be added in a subsequent PR (Roadmap Item 9, PR 3).
+    Outbound frames are routed to the connected child with the best
+    rolling-average RSSI (5-sample window with TTL expiry).  When no
+    RSSI data is available for any child, selection falls back to
+    round-robin.  Unhealthy children (no packets for
+    ``health_timeout`` seconds, or exceeding
+    ``max_consecutive_errors``) are excluded from selection.
+
+    Children are immutable after construction — runtime
+    ``add_child()``/``remove_child()`` are deferred until a
+    concurrency-safe synchronization model is designed (issue 1119).
 
     :param protocol: The real protocol that receives deduplicated
         packets.
     :type protocol: RamsesProtocolT
-    :param transports: List of child transports to pool.
-    :type transports: list[TransportInterface]
+    :param transports: List of child transports (or ``None`` placeholders
+        for failed children).
+    :type transports: list[TransportInterface | None]
     :param config: Transport configuration shared by all children.
     :type config: TransportConfig
     :param loop: The asyncio event loop.
     :type loop: asyncio.AbstractEventLoop | None
-    :param dedup_window: Deduplication window in seconds.  Packets
-        with the same content key arriving within this window from
-        different children are suppressed.  Defaults to 0.5s.
+    :param dedup_window: Deduplication window in seconds.
     :type dedup_window: float
+    :param health_timeout: Seconds without inbound packets before a
+        connected child is marked stale.
+    :type health_timeout: float
+    :param max_consecutive_errors: Number of consecutive errors before
+        a child is marked offline.
+    :type max_consecutive_errors: int
+    :param accepted_hgis: Optional set of HGI IDs that are allowed.
+        When set, packets from children whose HGI is not in this set
+        are dropped.  Construction-only — no runtime mutation.
+    :type accepted_hgis: set[str] | None
+    :param port_names: Optional list of port names for diagnostics.
+    :type port_names: list[str] | None
     """
 
     def __init__(
         self,
         protocol: RamsesProtocolT,
-        transports: list[TransportInterface],
+        transports: list[TransportInterface | None],
         /,
         *,
         config: TransportConfig,
         loop: asyncio.AbstractEventLoop | None = None,
         dedup_window: float = _DEFAULT_DEDUP_WINDOW,
+        health_timeout: float = _DEFAULT_HEALTH_TIMEOUT,
+        max_consecutive_errors: int = _DEFAULT_MAX_CONSECUTIVE_ERRORS,
+        accepted_hgis: set[str] | None = None,
+        port_names: list[str] | None = None,
     ) -> None:
         """Initialise the pooled transport."""
-        if not transports:
-            raise ValueError(
-                "PooledTransport requires at least one child transport"
-            )
-
         self._protocol: RamsesProtocolT = protocol
-        self._transports: list[TransportInterface] = transports
         self._config: TransportConfig = config
         self._loop: asyncio.AbstractEventLoop = (
             loop or asyncio.get_event_loop()
         )
         self._closing: bool = False
+        self._protocol_connected: bool = False
 
         self._dedup_window: td = td(seconds=dedup_window)
-        self._dedup_cache: deque[tuple[dt, _DedupKeyT]] = deque(
-            maxlen=_MAX_DEDUP_KEYS
-        )
+        # Dict-backed dedup cache: key -> timestamp.
+        # O(1) lookup instead of O(N) deque scan.
+        self._dedup_cache: dict[_DedupKeyT, dt] = {}
 
-        # Per-child connection state.
-        self._child_connected: list[bool] = [False] * len(transports)
-        self._child_hgi: list[str | None] = [None] * len(transports)
-        self._child_transport_objs: list[Any] = [None] * len(transports)
+        # Build immutable child registry.
+        self._children: list[PoolChild] = []
+        for i, t in enumerate(transports):
+            pname = port_names[i] if port_names else f"child-{i}"
+            accepted = True
+            if accepted_hgis is not None:
+                # Will be re-evaluated when HGI is learned.
+                accepted = True  # default: accept until HGI is known
+            child = PoolChild(
+                child_id=i,
+                port_name=pname,
+                transport=t,
+                accepted=accepted,
+            )
+            self._children.append(child)
+
+        # Store accepted_hgis as a frozenset for O(1) membership tests.
+        self._accepted_hgis: frozenset[str] | None = (
+            frozenset(accepted_hgis) if accepted_hgis is not None else None
+        )
 
         # Round-robin outbound counter.
         self._rr_index: int = 0
 
+        # Health tracking thresholds.
+        self._health_timeout: td = td(seconds=health_timeout)
+        self._max_consecutive_errors: int = max_consecutive_errors
+
         # Connection future — resolved when at least one child connects.
         self._conn_fut: asyncio.Future[TransportInterface] | None = None
 
-        # Stats for diagnostics.
-        self._pkts_received: list[int] = [0] * len(transports)
+        # Aggregate stats.
         self._pkts_deduped: int = 0
         self._pkts_forwarded: int = 0
+
+    # -- Child access ----------------------------------------------------
+
+    @property
+    def _active_children(self) -> list[PoolChild]:
+        """Return children with a non-None transport."""
+        return [c for c in self._children if c.transport is not None]
+
+    @property
+    def _connected_children(self) -> list[PoolChild]:
+        """Return connected children."""
+        return [c for c in self._children if c.is_connected]
+
+    @property
+    def _active_hgi_ids(self) -> list[DeviceIdT]:
+        """Return HGI IDs of all connected children with known HGI.
+
+        Derived from child records — no separate mutable set.
+        """
+        return [
+            c.hgi_id
+            for c in self._children
+            if c.is_connected and c.hgi_id is not None
+        ]
+
+    def _child_by_id(self, child_id: int) -> PoolChild:
+        """Return the child with the given ID.
+
+        :param child_id: The stable child ID.
+        :returns: The PoolChild.
+        :raises IndexError: If the ID is out of range.
+        """
+        return self._children[child_id]
 
     # -- TransportInterface ---------------------------------------------
 
@@ -187,40 +470,68 @@ class PooledTransport(TransportInterface):
         if self._closing:
             return
         self._closing = True
-        for t in self._transports:
+        for child in self._children:
+            if child.transport is None:
+                continue
             try:
-                t.close()
+                child.transport.close()
             except Exception as err:  # pragma: no cover - defensive
-                _LOGGER.debug("Error closing child transport: %s", err)
+                _LOGGER.debug(
+                    "Error closing child %d: %s", child.child_id, err
+                )
 
     def get_extra_info(self, name: str, default: Any = None) -> Any:
         """Return aggregate extra info from connected children.
 
-        For ``SZ_ACTIVE_HGI`` returns the first connected child's HGI
-        ID.  For ``SZ_IS_EVOFW3`` returns True if any connected child
-        is evofw3.
+        Preserves the compatibility keys consumed by ``ramses_rf`` and
+        ``ramses_cc``: ``pool_hgi_ids``, ``pool_rssi_trackers``,
+        ``pool_stats``, ``SZ_ACTIVE_HGI``, ``SZ_IS_EVOFW3``.
         """
+        if name == "pool_rssi_trackers":
+            return [c.rssi_tracker for c in self._children if c.is_connected]
         if name == SZ_ACTIVE_HGI:
-            for hgi in self._child_hgi:
-                if hgi is not None:
-                    return hgi
+            for c in self._children:
+                if c.is_connected and c.hgi_id is not None:
+                    return c.hgi_id
             return default
+        if name == "pool_hgi_ids":
+            return [
+                str(c.hgi_id)
+                for c in self._children
+                if c.is_connected and c.hgi_id is not None
+            ]
         if name == SZ_IS_EVOFW3:
-            for i, connected in enumerate(self._child_connected):
-                if connected and self._child_transport_objs[i] is not None:
-                    val = self._child_transport_objs[i].get_extra_info(
-                        SZ_IS_EVOFW3, False
-                    )
+            for c in self._children:
+                if c.is_connected and c.transport_obj is not None:
+                    val = c.transport_obj.get_extra_info(SZ_IS_EVOFW3, False)
                     if val:
                         return True
             return default
         if name == "pool_stats":
             return {
-                "children": len(self._transports),
-                "connected": sum(self._child_connected),
-                "received": list(self._pkts_received),
+                "children": len(self._children),
+                "connected": sum(1 for c in self._children if c.is_connected),
+                "healthy": sum(
+                    1 for c in self._children if c.is_connected and c.is_online
+                ),
+                "received": [c.pkts_received for c in self._children],
                 "deduped": self._pkts_deduped,
                 "forwarded": self._pkts_forwarded,
+                "avg_rssi": [
+                    round(self._best_rssi(c), 1) for c in self._children
+                ],
+                "child_health": [c.is_online for c in self._children],
+                "consecutive_errors": [
+                    c.consecutive_errors for c in self._children
+                ],
+                "child_hgi": [
+                    str(c.hgi_id) if c.hgi_id else None for c in self._children
+                ],
+                "accepted_hgis": (
+                    sorted(self._accepted_hgis)
+                    if self._accepted_hgis is not None
+                    else None
+                ),
             }
         return default
 
@@ -233,79 +544,179 @@ class PooledTransport(TransportInterface):
     ) -> None:
         """Route an outbound frame to a selected child transport.
 
-        Selection is round-robin among connected children in this PR.
-        RSSI-based selection will be added in PR 3.
+        Selection uses the highest rolling-average RSSI among
+        connected, sendable children for the target device (if known
+        from the frame), falling back to aggregate RSSI, then
+        round-robin when no RSSI data is available.
+
+        The frame's source address (addr1) is re-patched to match the
+        selected child's HGI ID before forwarding.  This is needed
+        because the protocol patches addr1 to the pool's "active" HGI
+        (the first connected child), but the pool may route the frame
+        to a different child with better RSSI.  Without re-patching,
+        the frame would be transmitted by the wrong HGI with the wrong
+        source ID.
+
+        For HGI80 children (``_is_evofw3`` is False), the protocol
+        patches addr1 to the placeholder ``18:000730`` and the HGI80
+        firmware substitutes its own hardware ID during transmission.
+        In this case, re-patching is skipped — the placeholder is
+        correct for any HGI80 child.
 
         :param frame: The raw ASCII frame to transmit.
-        :type frame: str
         :param disable_tx_limits: If True, bypass per-child rate
-            limiting.  Forwarded to the selected child's
-            ``write_frame``.
-        :type disable_tx_limits: bool
+            limiting.
         """
-        child = self._select_transport()
+        # Parse the frame to extract target device and source address.
+        target_device: str | None = None
+        src_addr: str | None = None
+        parts = frame.split()
+        if len(parts) >= 4:
+            src_addr = parts[2]
+            target_device = parts[3]
+
+        child = self._select_child(target_device)
         if child is None:
             raise exc.TransportError(
                 "No connected child transport available for send"
             )
-        # Child transports (PortTransport, MqttTransport) accept the
-        # disable_tx_limits kwarg even though TransportInterface
-        # doesn't declare it — use getattr to call the concrete method.
-        write = getattr(child, "write_frame", None)
+
+        child_hgi = child.hgi_id
+
+        # Re-patch the frame's source address to match the selected
+        # child's HGI ID.  See docstring for conditions.
+        if (
+            child_hgi
+            and src_addr
+            and src_addr[:2] == "18"  # only re-patch HGI sources
+            and src_addr != HGI_DEV_ADDR.id
+            and src_addr != str(child_hgi)
+        ):
+            parts[2] = str(child_hgi)
+            # Preserve leading whitespace (verb can be ' I' with a
+            # leading space in RAMSES frames).
+            leading = ""
+            if frame and frame[0].isspace():
+                leading = frame[0]
+            frame = leading + " ".join(parts)
+            _LOGGER.debug(
+                "PooledTransport: re-patched frame source %s -> %s "
+                "for child %d",
+                src_addr,
+                child_hgi,
+                child.child_id,
+            )
+
+        # Child transports accept disable_tx_limits even though
+        # TransportInterface doesn't declare it.
+        write = getattr(child.transport, "write_frame", None)
         if write is None:
-            await child.send_frame(frame)
+            await child.transport.send_frame(frame)  # type: ignore[union-attr]
         else:
             try:
                 await write(frame, disable_tx_limits=disable_tx_limits)
             except TypeError:
-                # Child's write_frame doesn't accept disable_tx_limits
+                # Child's write_frame doesn't accept disable_tx_limits.
                 await write(frame)
 
     # -- Internal: inbound dedup + forward -------------------------------
 
-    def _on_child_packet(self, index: int, packet: Packet) -> None:
+    def _on_child_packet(
+        self,
+        child_id: int,
+        packet: Packet,
+        *,
+        ingress_hgi_id: DeviceIdT | None = None,
+    ) -> None:
         """Process a packet from a child transport.
 
-        Deduplicates against the sliding window and forwards to the
-        real protocol if not a duplicate.
+        Deduplicates against the dict-backed cache and forwards to the
+        real protocol if not a duplicate.  Records the packet's RSSI
+        in the child's tracker for outbound routing, excluding
+        loopback frames from active pool HGI sources.  Updates the
+        child's health timestamp.
+
+        :param child_id: The stable child ID.
+        :param packet: The parsed packet.
+        :param ingress_hgi_id: Optional HGI identity from the callback
+            boundary.  When provided, overrides the child record's HGI.
         """
-        self._pkts_received[index] += 1
+        child = self._child_by_id(child_id)
+        child.pkts_received += 1
 
         if self._closing:
             return
 
+        # Learn the child's HGI ID from the puzzle response (7FFF)
+        # or any packet whose src is a known HGI.
+        if child.hgi_id is None:
+            src_id = packet._dto.addr1
+            if src_id and packet._dto.code == Code._PUZZ:
+                child.learn_hgi(DeviceIdT(src_id))
+
+        # HGI filtering: if an accepted set is configured, drop packets
+        # from children whose HGI is not accepted.
+        hgi = child.hgi_id
+        if self._accepted_hgis is not None and hgi is not None:
+            if str(hgi) not in self._accepted_hgis:
+                return
+
+        # Carry ingress provenance onto the Packet envelope (PR 1 item 7).
+        # Explicit callback value takes precedence, then the child record.
+        resolved_ingress = ingress_hgi_id or child.hgi_id
+        if resolved_ingress is not None:
+            packet._ingress_hgi_id = str(resolved_ingress)
+
+        # Update health tracking — any packet proves the child is alive.
+        child.mark_online()
+
+        # Record RSSI in the child's tracker, EXCLUDING loopback
+        # frames from active pool HGI sources.  When one pool HGI
+        # transmits, both HGIs hear it: the transmitter produces a
+        # local echo and the other hears an over-air copy.  These
+        # are not route-quality evidence for the transmitting HGI.
+        src_id = packet._dto.addr1
+        if src_id:
+            active_hgi_ids = {
+                str(c.hgi_id)
+                for c in self._children
+                if c.is_connected and c.hgi_id is not None
+            }
+            if src_id not in active_hgi_ids:
+                child.rssi_tracker.record(src_id, packet._dto.rssi, dt_now())
+
+        # Dict-backed dedup with sequence-aware key.
         key = self._dedup_key(packet)
         now = dt_now()
 
         # Purge stale entries from the dedup cache.
         cutoff = now - self._dedup_window
-        while self._dedup_cache and self._dedup_cache[0][0] < cutoff:
-            self._dedup_cache.popleft()
+        # Collect stale keys (can't modify dict during iteration).
+        stale_keys = [k for k, t in self._dedup_cache.items() if t < cutoff]
+        for k in stale_keys:
+            del self._dedup_cache[k]
 
-        # Check for duplicate.
-        for _, existing_key in self._dedup_cache:
-            if existing_key == key:
-                self._pkts_deduped += 1
-                _LOGGER.debug(
-                    "PooledTransport: deduped packet from child %d: %s",
-                    index,
-                    packet,
-                )
-                return
+        # Check for duplicate — O(1) dict lookup.
+        if key in self._dedup_cache:
+            self._pkts_deduped += 1
+            _LOGGER.debug(
+                "PooledTransport: deduped packet from child %d: %s",
+                child_id,
+                packet,
+            )
+            return
 
         # Not a duplicate — record and forward.
-        self._dedup_cache.append((now, key))
-        self._pkts_forwarded += 1
+        self._dedup_cache[key] = now
+        # Enforce max cache size.
+        if len(self._dedup_cache) > _MAX_DEDUP_KEYS:
+            # Evict oldest entry (linear scan, but rare).
+            oldest_key = min(
+                self._dedup_cache, key=lambda k: self._dedup_cache[k]
+            )
+            del self._dedup_cache[oldest_key]
 
-        # Tag the packet's source HGI for downstream tracking.
-        # Packet has __slots__, so we use the _extra dict pattern.
-        # The protocol reads SZ_ACTIVE_HGI from the transport, so we
-        # set it on the pool for get_extra_info() queries.
-        hgi = self._child_hgi[index]
-        if hgi is not None:
-            # Update the pool's "active" HGI to the source child's HGI.
-            # This is a simplification — PR 3 will track per-packet source.
-            pass
+        self._pkts_forwarded += 1
 
         try:
             self._loop.call_soon_threadsafe(
@@ -321,61 +732,106 @@ class PooledTransport(TransportInterface):
     def _dedup_key(packet: Packet) -> _DedupKeyT:
         """Build a deduplication key from packet content.
 
+        The key includes the transport-assigned sequence when present
+        (not ``---``) because it is sender-assigned and stable across
+        HGIs (confirmed from captured fixtures).  When sequence is
+        absent, an empty string is used as the fallback.
+
         :param packet: The packet to key.
-        :type packet: Packet
-        :returns: A tuple of (verb, code, src, dst, addr3, raw_payload).
-        :rtype: _DedupKeyT
+        :returns: A tuple of (verb, code, src, dst, addr3, seq, payload).
         """
         dto = packet._dto
+        seq = dto.seq if dto.seq and dto.seq != "---" else ""
         return (
             dto.verb,
             dto.code,
             dto.addr1,
             dto.addr2,
             dto.addr3,
+            seq,
             dto.raw_payload,
         )
 
+    def _best_rssi(
+        self, child: PoolChild, device_id: str | None = None
+    ) -> float:
+        """Return the best RSSI for a child, optionally for a device.
+
+        :param child: The PoolChild to query.
+        :param device_id: Optional device ID for per-device RSSI.
+        :returns: Best RSSI in dBm, or 0 if no data.
+        """
+        tracker = child.rssi_tracker
+        if device_id is not None:
+            val = tracker.best_rssi_for(device_id)
+            if val is not None:
+                return float(val)
+            return float(_RSSI_UNKNOWN)
+        # No device specified: return best RSSI across all known devices.
+        best = _RSSI_UNKNOWN
+        for dev_id in tracker.known_devices():
+            val = tracker.best_rssi_for(dev_id)
+            if val is not None and val > best:
+                best = val
+        return float(best)
+
     # -- Internal: connection lifecycle ---------------------------------
 
-    def _on_child_connected(self, index: int, transport_obj: Any) -> None:
+    def _on_child_connected(self, child_id: int, transport_obj: Any) -> None:
         """Mark a child as connected and capture its HGI ID."""
-        self._child_connected[index] = True
-        self._child_transport_objs[index] = transport_obj
-
-        # Read the child's active HGI from its extra info.
-        hgi = transport_obj.get_extra_info(SZ_ACTIVE_HGI)
-        self._child_hgi[index] = hgi
+        child = self._child_by_id(child_id)
+        child.mark_connected(transport_obj)
 
         _LOGGER.info(
             "PooledTransport: child %d connected (HGI=%s), %d/%d connected",
-            index,
-            hgi,
-            sum(self._child_connected),
-            len(self._transports),
+            child_id,
+            child.hgi_id,
+            len(self._connected_children),
+            len(self._children),
         )
+
+        # Notify the real protocol that the transport is connected.
+        if not self._protocol_connected:
+            self._protocol_connected = True
+            self._protocol.connection_made(self, ramses=True)
 
         # Resolve the connection future if waiting.
         if self._conn_fut is not None and not self._conn_fut.done():
             self._conn_fut.set_result(self)
 
     def _on_child_disconnected(
-        self, index: int, error: Exception | None
+        self, child_id: int, error: Exception | None
     ) -> None:
-        """Mark a child as disconnected."""
-        self._child_connected[index] = False
-        self._child_hgi[index] = None
+        """Mark a child as disconnected and record the error.
+
+        Increments the consecutive error counter; if it exceeds the
+        threshold, the child is marked offline.
+        """
+        child = self._child_by_id(child_id)
+        child.mark_disconnected()
+        child.record_error()
+
+        if child.consecutive_errors >= self._max_consecutive_errors:
+            if child.availability is not NodeAvailability.OFFLINE:
+                child.availability = NodeAvailability.OFFLINE
+                _LOGGER.warning(
+                    "PooledTransport: child %d marked offline "
+                    "(%d consecutive errors)",
+                    child_id,
+                    child.consecutive_errors,
+                )
 
         _LOGGER.info(
             "PooledTransport: child %d disconnected (%s), %d/%d connected",
-            index,
+            child_id,
             error,
-            sum(self._child_connected),
-            len(self._transports),
+            len(self._connected_children),
+            len(self._children),
         )
 
         # If no children are connected, notify the real protocol.
-        if not any(self._child_connected) and not self._closing:
+        if not self._connected_children and not self._closing:
+            self._protocol_connected = False
             with contextlib.suppress(RuntimeError):
                 self._loop.call_soon_threadsafe(
                     self._protocol.connection_lost, error
@@ -385,7 +841,7 @@ class PooledTransport(TransportInterface):
         self, timeout: float = 1.0
     ) -> TransportInterface:
         """Wait until at least one child transport is connected."""
-        if any(self._child_connected):
+        if self._connected_children:
             return self
 
         if self._conn_fut is None or self._conn_fut.done():
@@ -402,34 +858,108 @@ class PooledTransport(TransportInterface):
 
     # -- Internal: outbound routing -------------------------------------
 
-    def _select_transport(self) -> TransportInterface | None:
-        """Select a child transport for outbound transmission.
+    def _select_child(
+        self, target_device: str | None = None
+    ) -> PoolChild | None:
+        """Select a child for outbound transmission.
 
-        Round-robin among connected children.  Returns ``None`` if no
-        child is connected.
+        Uses per-device RSSI when ``target_device`` is provided and
+        per-device samples exist.  Falls back to aggregate RSSI, then
+        round-robin among connected, sendable children when no RSSI
+        data is available.  Returns ``None`` if no child is sendable.
         """
-        connected = [i for i, c in enumerate(self._child_connected) if c]
-        if not connected:
+        # Check health timeouts before selecting.
+        self._check_health()
+
+        # Only consider sendable children.
+        candidates = [c for c in self._children if c.is_sendable]
+        if not candidates:
             return None
 
-        # Round-robin: advance the counter and pick the next connected
-        # child, skipping disconnected ones.
-        n = len(self._transports)
-        for _ in range(n):
-            self._rr_index = (self._rr_index + 1) % n
-            if self._rr_index in connected:
-                return self._transports[self._rr_index]
+        # Compute average RSSI for each candidate (keyed by child_id
+        # because PoolChild is a mutable dataclass and not hashable).
+        rssi_values = {
+            c.child_id: self._best_rssi(c, target_device) for c in candidates
+        }
+        _LOGGER.debug(
+            "PooledTransport: _select_child target=%s candidates=%s "
+            "rssi_values=%s",
+            target_device,
+            [c.child_id for c in candidates],
+            rssi_values,
+        )
 
-        return self._transports[connected[0]]
+        # If per-device RSSI returned nothing for all candidates,
+        # fall back to aggregate RSSI.
+        if target_device and all(
+            v == float(_RSSI_UNKNOWN) for v in rssi_values.values()
+        ):
+            rssi_values = {c.child_id: self._best_rssi(c) for c in candidates}
+
+        # If no child has RSSI data, fall back to round-robin.
+        if all(v == float(_RSSI_UNKNOWN) for v in rssi_values.values()):
+            n = len(self._children)
+            for _ in range(n):
+                self._rr_index = (self._rr_index + 1) % n
+                child = self._child_by_id(self._rr_index)
+                if child in candidates:
+                    return child
+            return candidates[0]
+
+        # Select the child with the best (highest) average RSSI.
+        # Ties are broken by lowest child_id for determinism.
+        best_child = max(
+            candidates,
+            key=lambda c: (rssi_values[c.child_id], -c.child_id),
+        )
+        _LOGGER.debug(
+            "PooledTransport: selected child %d (rssi=%s) for target %s",
+            best_child.child_id,
+            rssi_values[best_child.child_id],
+            target_device,
+        )
+        return best_child
+
+    def _check_health(self) -> None:
+        """Check all children for health timeout and mark stale.
+
+        A connected child that has not received any packets within
+        ``health_timeout`` is marked stale.  Stale children are not
+        re-enabled as a last resort — offline is a definitive state
+        that requires explicit reconnection.
+        """
+        now = dt_now()
+
+        for child in self._children:
+            if child.transport is None:
+                continue
+            if not child.is_connected:
+                continue
+            if not child.is_online:
+                continue
+
+            last_pkt = child.last_pkt_time
+            if last_pkt is None:
+                # Connected but never received a packet — still healthy
+                # (connection is recent enough).
+                continue
+
+            if now - last_pkt > self._health_timeout:
+                child.mark_stale()
+                _LOGGER.warning(
+                    "PooledTransport: child %d marked stale "
+                    "(no packets for %.1fs)",
+                    child.child_id,
+                    (now - last_pkt).total_seconds(),
+                )
 
     # -- Diagnostics -----------------------------------------------------
 
     def __repr__(self) -> str:
         """Return a diagnostic representation of the pool."""
-        return (
-            f"PooledTransport(children={len(self._transports)}, "
-            f"connected={sum(self._child_connected)})"
-        )
+        active = len(self._active_children)
+        connected = len(self._connected_children)
+        return f"PooledTransport(children={active}, connected={connected})"
 
     @property
     def is_closing(self) -> bool:

--- a/src/ramses_tx/transport/pooled.py
+++ b/src/ramses_tx/transport/pooled.py
@@ -54,7 +54,7 @@ _DEFAULT_DEDUP_WINDOW: float = 0.5
 _MAX_DEDUP_KEYS: int = 512
 
 #: RSSI value used when a child has no data yet (treated as neutral).
-_RSSI_UNKNOWN: int = 0
+_RSSI_UNKNOWN: int = -999  # Sentinel: no RSSI data (worse than any real dBm)
 
 #: Default health-check interval in seconds.  A child that has not
 #: received any packets for this duration is marked unhealthy.

--- a/tests/tests_rf/test_communication_quality.py
+++ b/tests/tests_rf/test_communication_quality.py
@@ -5,7 +5,7 @@ See: https://github.com/ramses-rf/ramses_cc/issues/1047
 
 from __future__ import annotations
 
-from datetime import UTC, datetime as dt, timedelta as td
+from datetime import datetime as dt, timedelta as td
 
 from ramses_rf.models.state_signal import (
     RSSI_NORMAL,
@@ -23,8 +23,8 @@ class TestComputeQuality:
 
     def test_single_hgi_strong_signal(self) -> None:
         """Strong RSSI from one HGI → strong quality."""
-        now = dt(2026, 1, 1, 12, 0, 0, tzinfo=UTC)
-        tracker = RssiTracker()
+        now = dt(2026, 1, 1, 12, 0, 0)
+        tracker = RssiTracker(ttl=None)
         tracker.record("04:123456", "-55", now)
 
         q = compute_quality("04:123456", [tracker], now=now)
@@ -36,8 +36,8 @@ class TestComputeQuality:
 
     def test_single_hgi_normal_signal(self) -> None:
         """Normal RSSI → normal quality."""
-        now = dt(2026, 1, 1, 12, 0, 0, tzinfo=UTC)
-        tracker = RssiTracker()
+        now = dt(2026, 1, 1, 12, 0, 0)
+        tracker = RssiTracker(ttl=None)
         tracker.record("04:123456", "-70", now)
 
         q = compute_quality("04:123456", [tracker], now=now)
@@ -46,8 +46,8 @@ class TestComputeQuality:
 
     def test_single_hgi_weak_signal(self) -> None:
         """Weak RSSI → weak quality."""
-        now = dt(2026, 1, 1, 12, 0, 0, tzinfo=UTC)
-        tracker = RssiTracker()
+        now = dt(2026, 1, 1, 12, 0, 0)
+        tracker = RssiTracker(ttl=None)
         tracker.record("04:123456", "-90", now)
 
         q = compute_quality("04:123456", [tracker], now=now)
@@ -56,8 +56,8 @@ class TestComputeQuality:
 
     def test_single_hgi_very_weak_signal(self) -> None:
         """Very weak RSSI → very_weak quality."""
-        now = dt(2026, 1, 1, 12, 0, 0, tzinfo=UTC)
-        tracker = RssiTracker()
+        now = dt(2026, 1, 1, 12, 0, 0)
+        tracker = RssiTracker(ttl=None)
         tracker.record("04:123456", "-110", now)
 
         q = compute_quality("04:123456", [tracker], now=now)
@@ -66,8 +66,8 @@ class TestComputeQuality:
 
     def test_no_data(self) -> None:
         """No readings → unknown quality, no staleness."""
-        now = dt(2026, 1, 1, 12, 0, 0, tzinfo=UTC)
-        tracker = RssiTracker()
+        now = dt(2026, 1, 1, 12, 0, 0)
+        tracker = RssiTracker(ttl=None)
 
         q = compute_quality("04:123456", [tracker], now=now)
         assert q.best_rssi is None
@@ -78,9 +78,9 @@ class TestComputeQuality:
 
     def test_multi_hgi_best_across_all(self) -> None:
         """Best RSSI across multiple HGIs is the strongest."""
-        now = dt(2026, 1, 1, 12, 0, 0, tzinfo=UTC)
-        tracker_a = RssiTracker()
-        tracker_b = RssiTracker()
+        now = dt(2026, 1, 1, 12, 0, 0)
+        tracker_a = RssiTracker(ttl=None)
+        tracker_b = RssiTracker(ttl=None)
 
         # HGI A hears device weakly
         tracker_a.record("04:123456", "-90", now)
@@ -96,9 +96,9 @@ class TestComputeQuality:
 
     def test_multi_hgi_one_weak_one_strong(self) -> None:
         """One HGI weak, one strong → no warning (best wins)."""
-        now = dt(2026, 1, 1, 12, 0, 0, tzinfo=UTC)
-        tracker_a = RssiTracker()
-        tracker_b = RssiTracker()
+        now = dt(2026, 1, 1, 12, 0, 0)
+        tracker_a = RssiTracker(ttl=None)
+        tracker_b = RssiTracker(ttl=None)
 
         tracker_a.record("04:123456", "-100", now)
         tracker_b.record("04:123456", "-60", now)
@@ -109,9 +109,9 @@ class TestComputeQuality:
 
     def test_multi_hgi_all_weak(self) -> None:
         """All HGIs weak → warning (best is still weak)."""
-        now = dt(2026, 1, 1, 12, 0, 0, tzinfo=UTC)
-        tracker_a = RssiTracker()
-        tracker_b = RssiTracker()
+        now = dt(2026, 1, 1, 12, 0, 0)
+        tracker_a = RssiTracker(ttl=None)
+        tracker_b = RssiTracker(ttl=None)
 
         tracker_a.record("04:123456", "-100", now)
         tracker_b.record("04:123456", "-98", now)
@@ -122,8 +122,8 @@ class TestComputeQuality:
 
     def test_staleness_fresh(self) -> None:
         """Recent packet → not stale."""
-        now = dt(2026, 1, 1, 12, 0, 0, tzinfo=UTC)
-        tracker = RssiTracker()
+        now = dt(2026, 1, 1, 12, 0, 0)
+        tracker = RssiTracker(ttl=None)
         tracker.record("04:123456", "-70", now)
 
         q = compute_quality("04:123456", [tracker], now=now)
@@ -132,10 +132,10 @@ class TestComputeQuality:
 
     def test_staleness_stale(self) -> None:
         """Old packet → stale."""
-        now = dt(2026, 1, 1, 12, 0, 0, tzinfo=UTC)
+        now = dt(2026, 1, 1, 12, 0, 0)
         old = now - td(seconds=STALE_WARN_SECONDS + 60)
 
-        tracker = RssiTracker()
+        tracker = RssiTracker(ttl=None)
         tracker.record("04:123456", "-70", old)
 
         q = compute_quality("04:123456", [tracker], now=now)
@@ -145,10 +145,10 @@ class TestComputeQuality:
 
     def test_staleness_custom_threshold(self) -> None:
         """Custom stale threshold works."""
-        now = dt(2026, 1, 1, 12, 0, 0, tzinfo=UTC)
+        now = dt(2026, 1, 1, 12, 0, 0)
         recent = now - td(seconds=60)
 
-        tracker = RssiTracker()
+        tracker = RssiTracker(ttl=None)
         tracker.record("04:123456", "-70", recent)
 
         # Default threshold (300s) → not stale
@@ -163,12 +163,12 @@ class TestComputeQuality:
 
     def test_last_seen_multi_hgi(self) -> None:
         """last_seen is the most recent across all HGIs."""
-        t1 = dt(2026, 1, 1, 12, 0, 0, tzinfo=UTC)
-        t2 = dt(2026, 1, 1, 12, 5, 0, tzinfo=UTC)
-        t3 = dt(2026, 1, 1, 12, 10, 0, tzinfo=UTC)
+        t1 = dt(2026, 1, 1, 12, 0, 0)
+        t2 = dt(2026, 1, 1, 12, 5, 0)
+        t3 = dt(2026, 1, 1, 12, 10, 0)
 
-        tracker_a = RssiTracker()
-        tracker_b = RssiTracker()
+        tracker_a = RssiTracker(ttl=None)
+        tracker_b = RssiTracker(ttl=None)
 
         tracker_a.record("04:123456", "-70", t1)
         tracker_a.record("04:123456", "-72", t3)
@@ -179,8 +179,8 @@ class TestComputeQuality:
 
     def test_immutable_snapshot(self) -> None:
         """CommunicationQuality is frozen."""
-        now = dt(2026, 1, 1, 12, 0, 0, tzinfo=UTC)
-        tracker = RssiTracker()
+        now = dt(2026, 1, 1, 12, 0, 0)
+        tracker = RssiTracker(ttl=None)
         tracker.record("04:123456", "-70", now)
 
         q = compute_quality("04:123456", [tracker], now=now)
@@ -199,7 +199,7 @@ class TestComputeQuality:
 
     def test_empty_trackers(self) -> None:
         """No trackers at all → unknown quality."""
-        now = dt(2026, 1, 1, 12, 0, 0, tzinfo=UTC)
+        now = dt(2026, 1, 1, 12, 0, 0)
         q = compute_quality("04:123456", [], now=now)
         assert q.best_rssi is None
         assert q.rssi_quality == "unknown"
@@ -207,40 +207,40 @@ class TestComputeQuality:
 
     def test_threshold_boundaries(self) -> None:
         """Test exact threshold boundaries."""
-        now = dt(2026, 1, 1, 12, 0, 0, tzinfo=UTC)
+        now = dt(2026, 1, 1, 12, 0, 0)
 
         # Exactly RSSI_STRONG (-60) → strong
-        tracker = RssiTracker()
+        tracker = RssiTracker(ttl=None)
         tracker.record("04:123456", str(RSSI_STRONG), now)
         q = compute_quality("04:123456", [tracker], now=now)
         assert q.rssi_quality == "strong"
 
         # RSSI_STRONG - 1 (-61) → normal
-        tracker2 = RssiTracker()
+        tracker2 = RssiTracker(ttl=None)
         tracker2.record("04:123456", str(RSSI_STRONG - 1), now)
         q2 = compute_quality("04:123456", [tracker2], now=now)
         assert q2.rssi_quality == "normal"
 
         # Exactly RSSI_NORMAL (-75) → normal
-        tracker3 = RssiTracker()
+        tracker3 = RssiTracker(ttl=None)
         tracker3.record("04:123456", str(RSSI_NORMAL), now)
         q3 = compute_quality("04:123456", [tracker3], now=now)
         assert q3.rssi_quality == "normal"
 
         # RSSI_NORMAL - 1 (-76) → weak
-        tracker4 = RssiTracker()
+        tracker4 = RssiTracker(ttl=None)
         tracker4.record("04:123456", str(RSSI_NORMAL - 1), now)
         q4 = compute_quality("04:123456", [tracker4], now=now)
         assert q4.rssi_quality == "weak"
 
         # Exactly RSSI_WEAK (-95) → weak
-        tracker5 = RssiTracker()
+        tracker5 = RssiTracker(ttl=None)
         tracker5.record("04:123456", str(RSSI_WEAK), now)
         q5 = compute_quality("04:123456", [tracker5], now=now)
         assert q5.rssi_quality == "weak"
 
         # RSSI_WEAK - 1 (-96) → very_weak
-        tracker6 = RssiTracker()
+        tracker6 = RssiTracker(ttl=None)
         tracker6.record("04:123456", str(RSSI_WEAK - 1), now)
         q6 = compute_quality("04:123456", [tracker6], now=now)
         assert q6.rssi_quality == "very_weak"

--- a/tests/tests_tx/test_rssi_tracker.py
+++ b/tests/tests_tx/test_rssi_tracker.py
@@ -5,17 +5,17 @@ See: https://github.com/ramses-rf/ramses_cc/issues/1047
 
 from __future__ import annotations
 
-from datetime import UTC, datetime as dt
+from datetime import datetime as dt, timedelta as td
 
 import pytest
 
-from ramses_tx.rssi_tracker import RssiTracker
+from ramses_tx.rssi_tracker import DEFAULT_TTL, RssiTracker
 
 
 @pytest.fixture
 def now() -> dt:
-    """Fixed timestamp for deterministic tests."""
-    return dt(2026, 1, 1, 12, 0, 0, tzinfo=UTC)
+    """Fixed timestamp for deterministic tests (naive, matching dt_now)."""
+    return dt(2026, 1, 1, 12, 0, 0)
 
 
 class TestRssiTracker:
@@ -23,7 +23,7 @@ class TestRssiTracker:
 
     def test_record_and_best_rssi(self, now: dt) -> None:
         """Basic recording and best_rssi retrieval."""
-        tracker = RssiTracker(window_size=3)
+        tracker = RssiTracker(window_size=3, ttl=None)
         tracker.record("04:123456", "-70", now)
         tracker.record("04:123456", "-65", now)
         tracker.record("04:123456", "-72", now)
@@ -33,7 +33,7 @@ class TestRssiTracker:
 
     def test_window_eviction(self, now: dt) -> None:
         """Old readings are evicted when window is full."""
-        tracker = RssiTracker(window_size=3)
+        tracker = RssiTracker(window_size=3, ttl=None)
         tracker.record("04:123456", "-50", now)
         tracker.record("04:123456", "-60", now)
         tracker.record("04:123456", "-70", now)
@@ -46,7 +46,7 @@ class TestRssiTracker:
 
     def test_degradation_detection(self, now: dt) -> None:
         """Window detects signal degradation (e.g. door closing)."""
-        tracker = RssiTracker(window_size=3)
+        tracker = RssiTracker(window_size=3, ttl=None)
         # Good signal for a while
         tracker.record("04:123456", "-55", now)
         tracker.record("04:123456", "-56", now)
@@ -62,7 +62,7 @@ class TestRssiTracker:
 
     def test_recovery_detection(self, now: dt) -> None:
         """Window detects signal recovery (e.g. door opening)."""
-        tracker = RssiTracker(window_size=3)
+        tracker = RssiTracker(window_size=3, ttl=None)
         tracker.record("04:123456", "-90", now)
         tracker.record("04:123456", "-92", now)
         tracker.record("04:123456", "-88", now)
@@ -76,7 +76,7 @@ class TestRssiTracker:
 
     def test_multiple_devices(self, now: dt) -> None:
         """Each device has independent tracking."""
-        tracker = RssiTracker(window_size=3)
+        tracker = RssiTracker(window_size=3, ttl=None)
         tracker.record("04:111111", "-70", now)
         tracker.record("04:222222", "-80", now)
         tracker.record("04:111111", "-65", now)
@@ -87,14 +87,14 @@ class TestRssiTracker:
 
     def test_unknown_device(self) -> None:
         """Unknown device returns None."""
-        tracker = RssiTracker()
+        tracker = RssiTracker(ttl=None)
         assert tracker.best_rssi_for("04:999999") is None
         assert tracker.last_seen("04:999999") is None
         assert tracker.readings_for("04:999999") == []
 
     def test_sentinel_values_ignored(self, now: dt) -> None:
         """Sentinel RSSI values are silently ignored."""
-        tracker = RssiTracker()
+        tracker = RssiTracker(ttl=None)
         tracker.record("04:123456", "...", now)
         tracker.record("04:123456", "---", now)
         tracker.record("04:123456", "///", now)
@@ -105,7 +105,7 @@ class TestRssiTracker:
 
     def test_unparsable_ignored(self, now: dt) -> None:
         """Unparsable RSSI strings are silently ignored."""
-        tracker = RssiTracker()
+        tracker = RssiTracker(ttl=None)
         tracker.record("04:123456", "abc", now)
         tracker.record("04:123456", "N/A", now)
 
@@ -113,7 +113,7 @@ class TestRssiTracker:
 
     def test_int_rssi_accepted(self, now: dt) -> None:
         """Integer RSSI values are accepted directly."""
-        tracker = RssiTracker()
+        tracker = RssiTracker(ttl=None)
         tracker.record("04:123456", -70, now)
         tracker.record("04:123456", -65, now)
 
@@ -121,10 +121,10 @@ class TestRssiTracker:
 
     def test_last_seen(self, now: dt) -> None:
         """last_seen returns the timestamp of the most recent reading."""
-        tracker = RssiTracker(window_size=3)
-        t1 = dt(2026, 1, 1, 12, 0, 0, tzinfo=UTC)
-        t2 = dt(2026, 1, 1, 12, 5, 0, tzinfo=UTC)
-        t3 = dt(2026, 1, 1, 12, 10, 0, tzinfo=UTC)
+        tracker = RssiTracker(window_size=3, ttl=None)
+        t1 = dt(2026, 1, 1, 12, 0, 0)
+        t2 = dt(2026, 1, 1, 12, 5, 0)
+        t3 = dt(2026, 1, 1, 12, 10, 0)
 
         tracker.record("04:123456", "-70", t1)
         tracker.record("04:123456", "-65", t2)
@@ -134,7 +134,7 @@ class TestRssiTracker:
 
     def test_known_devices(self, now: dt) -> None:
         """known_devices returns all devices with readings."""
-        tracker = RssiTracker()
+        tracker = RssiTracker(ttl=None)
         tracker.record("04:111111", "-70", now)
         tracker.record("04:222222", "-80", now)
 
@@ -145,7 +145,7 @@ class TestRssiTracker:
 
     def test_clear(self, now: dt) -> None:
         """clear removes all readings."""
-        tracker = RssiTracker()
+        tracker = RssiTracker(ttl=None)
         tracker.record("04:123456", "-70", now)
         assert tracker.best_rssi_for("04:123456") == -70
 
@@ -163,9 +163,120 @@ class TestRssiTracker:
 
     def test_window_size_1(self, now: dt) -> None:
         """Window size 1 keeps only the latest reading."""
-        tracker = RssiTracker(window_size=1)
+        tracker = RssiTracker(window_size=1, ttl=None)
         tracker.record("04:123456", "-70", now)
         tracker.record("04:123456", "-80", now)
 
         assert tracker.readings_for("04:123456") == [-80]
         assert tracker.best_rssi_for("04:123456") == -80
+
+
+class TestRssiTrackerTtl:
+    """Tests for TTL-based expiry of RSSI readings."""
+
+    def test_ttl_expires_old_readings(self) -> None:
+        """Readings older than TTL are expired on access."""
+        tracker = RssiTracker(window_size=5, ttl=td(minutes=5))
+        old = dt.now() - td(minutes=6)
+        tracker.record("04:123456", "-70", old)
+
+        assert tracker.best_rssi_for("04:123456") is None
+        assert tracker.last_seen("04:123456") is None
+        assert tracker.readings_for("04:123456") == []
+
+    def test_ttl_keeps_fresh_readings(self) -> None:
+        """Readings within TTL are retained."""
+        tracker = RssiTracker(window_size=5, ttl=td(minutes=5))
+        fresh = dt.now() - td(minutes=1)
+        tracker.record("04:123456", "-70", fresh)
+
+        assert tracker.best_rssi_for("04:123456") == -70
+
+    def test_ttl_boundary_just_within(self) -> None:
+        """Readings just within TTL are retained."""
+        tracker = RssiTracker(window_size=5, ttl=td(minutes=5))
+        # 4 min 59 sec ago — just within TTL.
+        recent = dt.now() - td(minutes=4, seconds=59)
+        tracker.record("04:123456", "-70", recent)
+
+        assert tracker.best_rssi_for("04:123456") == -70
+
+    def test_ttl_boundary_just_expired(self) -> None:
+        """Readings just past TTL are expired."""
+        tracker = RssiTracker(window_size=5, ttl=td(minutes=5))
+        # 5 min 1 sec ago — just past TTL.
+        old = dt.now() - td(minutes=5, seconds=1)
+        tracker.record("04:123456", "-70", old)
+
+        assert tracker.best_rssi_for("04:123456") is None
+
+    def test_ttl_partial_expiry(self) -> None:
+        """Only old readings are expired; fresh ones remain."""
+        tracker = RssiTracker(window_size=5, ttl=td(minutes=5))
+        old = dt.now() - td(minutes=10)
+        fresh = dt.now() - td(minutes=1)
+
+        tracker.record("04:123456", "-90", old)
+        tracker.record("04:123456", "-50", fresh)
+
+        # Old reading expired, fresh remains.
+        assert tracker.best_rssi_for("04:123456") == -50
+        assert tracker.readings_for("04:123456") == [-50]
+
+    def test_ttl_none_disables_expiry(self) -> None:
+        """ttl=None disables TTL-based expiry entirely."""
+        tracker = RssiTracker(window_size=5, ttl=None)
+        very_old = dt(2020, 1, 1, 0, 0, 0)
+        tracker.record("04:123456", "-70", very_old)
+
+        assert tracker.best_rssi_for("04:123456") == -70
+
+    def test_ttl_known_devices_excludes_expired(self) -> None:
+        """known_devices excludes devices with only expired readings."""
+        tracker = RssiTracker(window_size=5, ttl=td(minutes=5))
+        old = dt.now() - td(minutes=10)
+        fresh = dt.now() - td(minutes=1)
+
+        tracker.record("04:111111", "-70", old)
+        tracker.record("04:222222", "-80", fresh)
+
+        known = tracker.known_devices()
+        assert "04:111111" not in known
+        assert "04:222222" in known
+
+    def test_default_ttl_is_5_minutes(self) -> None:
+        """DEFAULT_TTL is 5 minutes."""
+        assert td(minutes=5) == DEFAULT_TTL
+
+    def test_ttl_mixed_tz_aware_and_naive(self) -> None:
+        """TTL expiry handles mixed tz-aware and naive timestamps.
+
+        Regression: MQTT transports produce tz-aware local datetimes
+        while dt_now() from serial transports is naive local.  The
+        tracker must not crash when comparing them.
+        """
+        tracker = RssiTracker(window_size=5, ttl=td(minutes=5))
+        # Record with tz-aware local timestamp (as from MQTT transport).
+        fresh_aware = dt.now().astimezone() - td(minutes=1)
+        tracker.record("04:111111", "-70", fresh_aware)
+
+        # best_rssi_for uses dt.now() (naive) internally — must not crash.
+        assert tracker.best_rssi_for("04:111111") == -70
+
+        # Record with naive timestamp (as from serial transport).
+        fresh_naive = dt.now() - td(minutes=1)
+        tracker.record("04:222222", "-80", fresh_naive)
+
+        # Both should work.
+        assert tracker.best_rssi_for("04:222222") == -80
+
+        # Expired tz-aware reading.
+        old_aware = dt.now().astimezone() - td(minutes=10)
+        tracker.record("04:333333", "-90", old_aware)
+        assert tracker.best_rssi_for("04:333333") is None
+
+        # known_devices must also handle mixed timestamps.
+        known = tracker.known_devices()
+        assert "04:111111" in known
+        assert "04:222222" in known
+        assert "04:333333" not in known

--- a/tests/tests_tx/test_rssi_tracker.py
+++ b/tests/tests_tx/test_rssi_tracker.py
@@ -244,9 +244,9 @@ class TestRssiTrackerTtl:
         assert "04:111111" not in known
         assert "04:222222" in known
 
-    def test_default_ttl_is_5_minutes(self) -> None:
-        """DEFAULT_TTL is 5 minutes."""
-        assert td(minutes=5) == DEFAULT_TTL
+    def test_default_ttl_is_none(self) -> None:
+        """DEFAULT_TTL is None (no automatic expiry for gateway trackers)."""
+        assert DEFAULT_TTL is None
 
     def test_ttl_mixed_tz_aware_and_naive(self) -> None:
         """TTL expiry handles mixed tz-aware and naive timestamps.

--- a/tests/tests_tx/test_transport_pooled.py
+++ b/tests/tests_tx/test_transport_pooled.py
@@ -1,0 +1,408 @@
+#!/usr/bin/env python3
+"""Tests for PooledTransport — multi-HGI link-layer pooling.
+
+Covers:
+- Inbound deduplication (same packet from 2 children → 1 upstream)
+- Inbound forwarding (distinct packets from different children)
+- Outbound routing (round-robin among connected children)
+- Connection lifecycle (wait for any, disconnect handling)
+- get_extra_info aggregation (SZ_ACTIVE_HGI, pool_stats)
+- Close propagation to all children
+"""
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, Mock
+
+import pytest
+
+from ramses_tx.const import I_, SZ_ACTIVE_HGI, Code
+from ramses_tx.transport.base import TransportConfig
+from ramses_tx.transport.pooled import (
+    PooledTransport,
+    _ChildProtocolProxy,
+)
+
+
+@pytest.fixture
+def event_loop() -> asyncio.AbstractEventLoop:
+    """Provide a fresh event loop for each test."""
+    loop = asyncio.new_event_loop()
+    yield loop
+    loop.close()
+
+
+# -- Helpers ---------------------------------------------------------------
+
+
+def _make_packet(
+    verb: str = I_,
+    code: str = Code._30C9,
+    src: str = "01:123456",
+    dst: str = "18:000730",
+    addr3: str = "--:------",
+    payload: str = "00",
+    rssi: str = "000",
+) -> MagicMock:
+    """Create a mock Packet with a DTO for dedup keying."""
+    dto = MagicMock()
+    dto.verb = verb
+    dto.code = code
+    dto.addr1 = src
+    dto.addr2 = dst
+    dto.addr3 = addr3
+    dto.raw_payload = payload
+    dto.rssi = rssi
+
+    pkt = MagicMock()
+    pkt._dto = dto
+    pkt.__str__ = lambda self: (
+        f"{rssi} {verb} --- {src} {dst} {addr3} {code} 000 {payload}"
+    )
+    return pkt
+
+
+def _make_mock_transport(
+    hgi: str | None = None,
+    connected: bool = True,
+) -> MagicMock:
+    """Create a mock child transport."""
+    t = MagicMock()
+    t.get_extra_info = lambda name, default=None: (
+        hgi if name == SZ_ACTIVE_HGI else default
+    )
+    t.write_frame = AsyncMock()
+    t.send_frame = AsyncMock()
+    t.close = Mock()
+    t.is_closing = False
+    t._connected = connected
+    return t
+
+
+def _make_mock_protocol() -> MagicMock:
+    """Create a mock real protocol for the pool."""
+    proto = MagicMock()
+    proto.packet_received = Mock()
+    proto.connection_lost = Mock()
+    proto.send_cmd = AsyncMock(return_value=None)
+    proto.set_regex_rules = Mock()
+    return proto
+
+
+# -- Inbound deduplication -------------------------------------------------
+
+
+async def test_dedup_same_packet_from_two_children_is_deduped() -> None:
+    """Two children send the same packet → only one reaches the protocol."""
+    proto = _make_mock_protocol()
+    t0 = _make_mock_transport(hgi="18:001111")
+    t1 = _make_mock_transport(hgi="18:002222")
+    pool = PooledTransport(
+        proto, [t0, t1], config=TransportConfig(), dedup_window=1.0
+    )
+    pool._child_connected = [True, True]
+    pool._child_hgi = ["18:001111", "18:002222"]
+
+    pkt = _make_packet()
+    pool._on_child_packet(0, pkt)
+    pool._on_child_packet(1, pkt)  # duplicate
+
+    # Let call_soon_threadsafe callbacks drain.
+    await asyncio.sleep(0.01)
+
+    assert proto.packet_received.call_count == 1
+    stats = pool.get_extra_info("pool_stats")
+    assert stats["deduped"] == 1
+    assert stats["forwarded"] == 1
+
+
+async def test_distinct_packets_from_different_children_are_forwarded() -> (
+    None
+):
+    """Two children send different packets → both reach the protocol."""
+    proto = _make_mock_protocol()
+    t0 = _make_mock_transport(hgi="18:001111")
+    t1 = _make_mock_transport(hgi="18:002222")
+    pool = PooledTransport(
+        proto, [t0, t1], config=TransportConfig(), dedup_window=0.5
+    )
+    pool._child_connected = [True, True]
+    pool._child_hgi = ["18:001111", "18:002222"]
+
+    pkt0 = _make_packet(src="01:111111")
+    pkt1 = _make_packet(src="01:222222")
+    pool._on_child_packet(0, pkt0)
+    pool._on_child_packet(1, pkt1)
+
+    await asyncio.sleep(0.01)
+
+    assert proto.packet_received.call_count == 2
+    stats = pool.get_extra_info("pool_stats")
+    assert stats["deduped"] == 0
+    assert stats["forwarded"] == 2
+
+
+async def test_dedup_window_expires_after_timeout() -> None:
+    """Same packet after the dedup window expires → both forwarded."""
+    proto = _make_mock_protocol()
+    t0 = _make_mock_transport(hgi="18:001111")
+    t1 = _make_mock_transport(hgi="18:002222")
+    pool = PooledTransport(
+        proto, [t0, t1], config=TransportConfig(), dedup_window=0.05
+    )
+    pool._child_connected = [True, True]
+    pool._child_hgi = ["18:001111", "18:002222"]
+
+    pkt = _make_packet()
+    pool._on_child_packet(0, pkt)
+    await asyncio.sleep(0.1)  # wait for dedup window to expire
+    pool._on_child_packet(1, pkt)
+
+    await asyncio.sleep(0.01)
+
+    assert proto.packet_received.call_count == 2
+    stats = pool.get_extra_info("pool_stats")
+    assert stats["deduped"] == 0
+
+
+# -- Outbound routing ------------------------------------------------------
+
+
+async def test_outbound_routes_to_connected_child() -> None:
+    """write_frame routes to a connected child."""
+    proto = _make_mock_protocol()
+    t0 = _make_mock_transport(hgi="18:001111", connected=False)
+    t1 = _make_mock_transport(hgi="18:002222", connected=True)
+    pool = PooledTransport(proto, [t0, t1], config=TransportConfig())
+    pool._child_connected = [False, True]
+
+    await pool.write_frame(
+        " 000 I --- 01:123456 18:000730 --:------ 30C9 000 00"
+    )
+
+    t0.write_frame.assert_not_called()
+    t1.write_frame.assert_called_once()
+
+
+async def test_outbound_round_robin_among_connected() -> None:
+    """write_frame round-robins between connected children."""
+    proto = _make_mock_protocol()
+    t0 = _make_mock_transport(hgi="18:001111", connected=True)
+    t1 = _make_mock_transport(hgi="18:002222", connected=True)
+    pool = PooledTransport(proto, [t0, t1], config=TransportConfig())
+    pool._child_connected = [True, True]
+
+    await pool.write_frame("frame1")
+    await pool.write_frame("frame2")
+
+    # Both children should have been used (round-robin).
+    calls = [t0.write_frame.call_count, t1.write_frame.call_count]
+    assert sum(calls) == 2
+    assert all(c >= 0 for c in calls)
+
+
+async def test_outbound_fails_when_no_child_connected() -> None:
+    """write_frame raises when no child is connected."""
+    from ramses_tx import exceptions as exc
+
+    proto = _make_mock_protocol()
+    t0 = _make_mock_transport(hgi="18:001111", connected=False)
+    pool = PooledTransport(proto, [t0], config=TransportConfig())
+    pool._child_connected = [False]
+
+    with pytest.raises(exc.TransportError, match="No connected child"):
+        await pool.write_frame("frame1")
+
+
+# -- Connection lifecycle --------------------------------------------------
+
+
+async def test_wait_for_any_connection_resolves_when_child_connects() -> None:
+    """_wait_for_any_connection resolves when a child connects."""
+    proto = _make_mock_protocol()
+    t0 = _make_mock_transport(hgi="18:001111")
+    pool = PooledTransport(proto, [t0], config=TransportConfig())
+
+    # Simulate child 0 connecting.
+    pool._on_child_connected(0, t0)
+
+    result = await pool._wait_for_any_connection(timeout=1.0)
+    assert result is pool
+
+
+async def test_wait_for_any_connection_times_out() -> None:
+    """_wait_for_any_connection raises on timeout."""
+    from ramses_tx import exceptions as exc
+
+    proto = _make_mock_protocol()
+    t0 = _make_mock_transport(hgi="18:001111")
+    pool = PooledTransport(proto, [t0], config=TransportConfig())
+
+    with pytest.raises(exc.TransportError, match="no child connected"):
+        await pool._wait_for_any_connection(timeout=0.05)
+
+
+async def test_child_disconnect_notifies_protocol_when_all_disconnected() -> (
+    None
+):
+    """connection_lost fires on the real protocol when all children drop."""
+    proto = _make_mock_protocol()
+    t0 = _make_mock_transport(hgi="18:001111")
+    t1 = _make_mock_transport(hgi="18:002222")
+    pool = PooledTransport(proto, [t0, t1], config=TransportConfig())
+    pool._child_connected = [True, True]
+    pool._child_hgi = ["18:001111", "18:002222"]
+
+    # Disconnect first child — should NOT notify protocol (one still up).
+    pool._on_child_disconnected(0, None)
+    proto.connection_lost.assert_not_called()
+
+    # Disconnect second child — SHOULD notify protocol.
+    pool._on_child_disconnected(1, None)
+    await asyncio.sleep(0.01)
+    proto.connection_lost.assert_called_once()
+
+
+# -- get_extra_info --------------------------------------------------------
+
+
+def test_get_extra_info_active_hgi_returns_first_connected(
+    event_loop: asyncio.AbstractEventLoop,
+) -> None:
+    """get_extra_info(SZ_ACTIVE_HGI) returns the first connected child's HGI."""
+    proto = _make_mock_protocol()
+    t0 = _make_mock_transport(hgi="18:001111")
+    t1 = _make_mock_transport(hgi="18:002222")
+    pool = PooledTransport(
+        proto, [t0, t1], config=TransportConfig(), loop=event_loop
+    )
+    pool._child_connected = [True, True]
+    pool._child_hgi = ["18:001111", "18:002222"]
+
+    assert pool.get_extra_info(SZ_ACTIVE_HGI) == "18:001111"
+
+
+def test_get_extra_info_active_hgi_skips_disconnected(
+    event_loop: asyncio.AbstractEventLoop,
+) -> None:
+    """get_extra_info(SZ_ACTIVE_HGI) skips disconnected children."""
+    proto = _make_mock_protocol()
+    t0 = _make_mock_transport(hgi="18:001111")
+    t1 = _make_mock_transport(hgi="18:002222")
+    pool = PooledTransport(
+        proto, [t0, t1], config=TransportConfig(), loop=event_loop
+    )
+    pool._child_connected = [False, True]
+    pool._child_hgi = [None, "18:002222"]
+
+    assert pool.get_extra_info(SZ_ACTIVE_HGI) == "18:002222"
+
+
+def test_get_extra_info_pool_stats(
+    event_loop: asyncio.AbstractEventLoop,
+) -> None:
+    """get_extra_info('pool_stats') returns diagnostic stats."""
+    proto = _make_mock_protocol()
+    t0 = _make_mock_transport(hgi="18:001111")
+    pool = PooledTransport(
+        proto, [t0], config=TransportConfig(), loop=event_loop
+    )
+    pool._child_connected = [True]
+    pool._child_hgi = ["18:001111"]
+    pool._pkts_received = [5]
+    pool._pkts_deduped = 2
+    pool._pkts_forwarded = 3
+
+    stats = pool.get_extra_info("pool_stats")
+    assert stats["children"] == 1
+    assert stats["connected"] == 1
+    assert stats["received"] == [5]
+    assert stats["deduped"] == 2
+    assert stats["forwarded"] == 3
+
+
+# -- Close -----------------------------------------------------------------
+
+
+def test_close_closes_all_children(
+    event_loop: asyncio.AbstractEventLoop,
+) -> None:
+    """close() calls close() on every child transport."""
+    proto = _make_mock_protocol()
+    t0 = _make_mock_transport(hgi="18:001111")
+    t1 = _make_mock_transport(hgi="18:002222")
+    pool = PooledTransport(
+        proto, [t0, t1], config=TransportConfig(), loop=event_loop
+    )
+
+    pool.close()
+
+    t0.close.assert_called_once()
+    t1.close.assert_called_once()
+    assert pool.is_closing is True
+
+
+def test_close_is_idempotent(
+    event_loop: asyncio.AbstractEventLoop,
+) -> None:
+    """close() called twice doesn't re-close children."""
+    proto = _make_mock_protocol()
+    t0 = _make_mock_transport(hgi="18:001111")
+    pool = PooledTransport(
+        proto, [t0], config=TransportConfig(), loop=event_loop
+    )
+
+    pool.close()
+    pool.close()
+
+    t0.close.assert_called_once()
+
+
+# -- _ChildProtocolProxy ---------------------------------------------------
+
+
+def test_child_proxy_routes_packet_to_pool() -> None:
+    """_ChildProtocolProxy.packet_received routes to the pool."""
+    pool = MagicMock()
+    proxy = _ChildProtocolProxy(pool, 0)
+    pkt = _make_packet()
+
+    proxy.packet_received(pkt)
+
+    pool._on_child_packet.assert_called_once_with(0, pkt)
+
+
+def test_child_proxy_routes_connection_made() -> None:
+    """_ChildProtocolProxy.connection_made routes to the pool."""
+    pool = MagicMock()
+    proxy = _ChildProtocolProxy(pool, 1)
+    transport_obj = MagicMock()
+
+    proxy.connection_made(transport_obj, ramses=False)
+
+    pool._on_child_connected.assert_called_once_with(1, transport_obj)
+    assert proxy._connected is True
+
+
+def test_child_proxy_routes_connection_lost() -> None:
+    """_ChildProtocolProxy.connection_lost routes to the pool."""
+    pool = MagicMock()
+    proxy = _ChildProtocolProxy(pool, 2)
+    proxy._connected = True
+
+    err = ValueError("test error")
+    proxy.connection_lost(err)
+
+    pool._on_child_disconnected.assert_called_once_with(2, err)
+    assert proxy._connected is False
+
+
+# -- Constructor validation ------------------------------------------------
+
+
+def test_empty_transport_list_raises(
+    event_loop: asyncio.AbstractEventLoop,
+) -> None:
+    """PooledTransport with empty transport list raises ValueError."""
+    proto = _make_mock_protocol()
+    with pytest.raises(ValueError, match="at least one child transport"):
+        PooledTransport(proto, [], config=TransportConfig(), loop=event_loop)

--- a/tests/tests_tx/test_transport_pooled.py
+++ b/tests/tests_tx/test_transport_pooled.py
@@ -948,7 +948,7 @@ def test_quiet_serial_child_stays_connected(
 ) -> None:
     """A quiet connected serial child stays connected/online while
     its route evidence expires (RSSI TTL)."""
-    from ramses_tx.rssi_tracker import DEFAULT_TTL
+    from ramses_tx.rssi_tracker import POOL_TTL
 
     proto = _make_mock_protocol()
     t0 = _make_mock_transport(hgi="18:001111")
@@ -958,7 +958,7 @@ def test_quiet_serial_child_stays_connected(
     _connect_and_ready(pool, 0, t0)
 
     # Record RSSI with an old timestamp (beyond TTL) for a distinct device.
-    old_time = dt.now() - DEFAULT_TTL - td(seconds=1)
+    old_time = dt.now() - POOL_TTL - td(seconds=1)
     pool._children[0].rssi_tracker.record("04:999999", -50, old_time)
 
     # The RSSI should be expired on access.

--- a/tests/tests_tx/test_transport_pooled.py
+++ b/tests/tests_tx/test_transport_pooled.py
@@ -2,15 +2,18 @@
 """Tests for PooledTransport — multi-HGI link-layer pooling.
 
 Covers:
-- Inbound deduplication (same packet from 2 children → 1 upstream)
+- Inbound deduplication (same packet from 2 children -> 1 upstream)
 - Inbound forwarding (distinct packets from different children)
 - Outbound routing (round-robin among connected children)
 - Connection lifecycle (wait for any, disconnect handling)
 - get_extra_info aggregation (SZ_ACTIVE_HGI, pool_stats)
 - Close propagation to all children
+- PR 1: PoolChild state, ingress provenance, loopback exclusion,
+  dict-backed dedup, RSSI TTL, no runtime add/remove
 """
 
 import asyncio
+from datetime import datetime as dt, timedelta as td
 from unittest.mock import AsyncMock, MagicMock, Mock
 
 import pytest
@@ -18,9 +21,13 @@ import pytest
 from ramses_tx.const import I_, SZ_ACTIVE_HGI, Code
 from ramses_tx.transport.base import TransportConfig
 from ramses_tx.transport.pooled import (
+    IngressFrame,
+    NodeAvailability,
+    PoolChild,
     PooledTransport,
     _ChildProtocolProxy,
 )
+from ramses_tx.typing import DeviceIdT
 
 
 @pytest.fixture
@@ -42,6 +49,7 @@ def _make_packet(
     addr3: str = "--:------",
     payload: str = "00",
     rssi: str = "000",
+    seq: str = "---",
 ) -> MagicMock:
     """Create a mock Packet with a DTO for dedup keying."""
     dto = MagicMock()
@@ -52,11 +60,12 @@ def _make_packet(
     dto.addr3 = addr3
     dto.raw_payload = payload
     dto.rssi = rssi
+    dto.seq = seq
 
     pkt = MagicMock()
     pkt._dto = dto
     pkt.__str__ = lambda self: (
-        f"{rssi} {verb} --- {src} {dst} {addr3} {code} 000 {payload}"
+        f"{rssi} {verb} {seq} {src} {dst} {addr3} {code} 000 {payload}"
     )
     return pkt
 
@@ -88,19 +97,35 @@ def _make_mock_protocol() -> MagicMock:
     return proto
 
 
+def _connect_child(
+    pool: PooledTransport, child_id: int, transport: MagicMock
+) -> None:
+    """Mark a child as connected with its transport's HGI identity."""
+    pool._on_child_connected(child_id, transport)
+
+
+def _connect_and_ready(
+    pool: PooledTransport, child_id: int, transport: MagicMock
+) -> None:
+    """Connect a child and make it send-ready via a packet."""
+    pool._on_child_connected(child_id, transport)
+    # Feed a packet to mark online and send-ready.
+    pool._on_child_packet(child_id, _make_packet(rssi="050", payload="FFFF"))
+
+
 # -- Inbound deduplication -------------------------------------------------
 
 
 async def test_dedup_same_packet_from_two_children_is_deduped() -> None:
-    """Two children send the same packet → only one reaches the protocol."""
+    """Two children send the same packet -> only one reaches protocol."""
     proto = _make_mock_protocol()
     t0 = _make_mock_transport(hgi="18:001111")
     t1 = _make_mock_transport(hgi="18:002222")
     pool = PooledTransport(
         proto, [t0, t1], config=TransportConfig(), dedup_window=1.0
     )
-    pool._child_connected = [True, True]
-    pool._child_hgi = ["18:001111", "18:002222"]
+    _connect_child(pool, 0, t0)
+    _connect_child(pool, 1, t1)
 
     pkt = _make_packet()
     pool._on_child_packet(0, pkt)
@@ -118,15 +143,15 @@ async def test_dedup_same_packet_from_two_children_is_deduped() -> None:
 async def test_distinct_packets_from_different_children_are_forwarded() -> (
     None
 ):
-    """Two children send different packets → both reach the protocol."""
+    """Two children send different packets -> both reach the protocol."""
     proto = _make_mock_protocol()
     t0 = _make_mock_transport(hgi="18:001111")
     t1 = _make_mock_transport(hgi="18:002222")
     pool = PooledTransport(
         proto, [t0, t1], config=TransportConfig(), dedup_window=0.5
     )
-    pool._child_connected = [True, True]
-    pool._child_hgi = ["18:001111", "18:002222"]
+    _connect_child(pool, 0, t0)
+    _connect_child(pool, 1, t1)
 
     pkt0 = _make_packet(src="01:111111")
     pkt1 = _make_packet(src="01:222222")
@@ -142,15 +167,15 @@ async def test_distinct_packets_from_different_children_are_forwarded() -> (
 
 
 async def test_dedup_window_expires_after_timeout() -> None:
-    """Same packet after the dedup window expires → both forwarded."""
+    """Same packet after the dedup window expires -> both forwarded."""
     proto = _make_mock_protocol()
     t0 = _make_mock_transport(hgi="18:001111")
     t1 = _make_mock_transport(hgi="18:002222")
     pool = PooledTransport(
         proto, [t0, t1], config=TransportConfig(), dedup_window=0.05
     )
-    pool._child_connected = [True, True]
-    pool._child_hgi = ["18:001111", "18:002222"]
+    _connect_child(pool, 0, t0)
+    _connect_child(pool, 1, t1)
 
     pkt = _make_packet()
     pool._on_child_packet(0, pkt)
@@ -164,6 +189,88 @@ async def test_dedup_window_expires_after_timeout() -> None:
     assert stats["deduped"] == 0
 
 
+async def test_dedup_same_packet_from_same_child_is_deduped() -> None:
+    """Same packet sent twice from the SAME child is deduped."""
+    proto = _make_mock_protocol()
+    t0 = _make_mock_transport(hgi="18:001111")
+    pool = PooledTransport(
+        proto, [t0], config=TransportConfig(), dedup_window=1.0
+    )
+    _connect_child(pool, 0, t0)
+
+    pkt = _make_packet()
+    pool._on_child_packet(0, pkt)
+    pool._on_child_packet(0, pkt)  # same child, same packet
+
+    await asyncio.sleep(0.01)
+    assert proto.packet_received.call_count == 1
+
+
+async def test_dedup_key_includes_sequence_when_present() -> None:
+    """Packets with same content but different sequence are NOT deduped."""
+    proto = _make_mock_protocol()
+    t0 = _make_mock_transport(hgi="18:001111")
+    pool = PooledTransport(
+        proto, [t0], config=TransportConfig(), dedup_window=10.0
+    )
+    _connect_child(pool, 0, t0)
+
+    # Same content, different sequence numbers.
+    pool._on_child_packet(0, _make_packet(seq="001", payload="00"))
+    pool._on_child_packet(0, _make_packet(seq="002", payload="00"))
+
+    await asyncio.sleep(0.01)
+    assert proto.packet_received.call_count == 2
+
+
+async def test_dedup_key_fallback_when_sequence_absent() -> None:
+    """Packets with no sequence (---) use fallback base key for dedup."""
+    proto = _make_mock_protocol()
+    t0 = _make_mock_transport(hgi="18:001111")
+    pool = PooledTransport(
+        proto, [t0], config=TransportConfig(), dedup_window=1.0
+    )
+    _connect_child(pool, 0, t0)
+
+    # Both have seq="---", same content -> deduped.
+    pool._on_child_packet(0, _make_packet(seq="---", payload="00"))
+    pool._on_child_packet(0, _make_packet(seq="---", payload="00"))
+
+    await asyncio.sleep(0.01)
+    assert proto.packet_received.call_count == 1
+
+
+async def test_dedup_cache_is_dict_backed() -> None:
+    """Dedup cache is a dict, not a deque."""
+    proto = _make_mock_protocol()
+    t0 = _make_mock_transport(hgi="18:001111")
+    pool = PooledTransport(
+        proto, [t0], config=TransportConfig(), dedup_window=10.0
+    )
+    _connect_child(pool, 0, t0)
+
+    assert isinstance(pool._dedup_cache, dict)
+
+
+async def test_dedup_cache_size_bounded() -> None:
+    """Dedup cache size is bounded by _MAX_DEDUP_KEYS."""
+    from ramses_tx.transport.pooled import _MAX_DEDUP_KEYS
+
+    proto = _make_mock_protocol()
+    t0 = _make_mock_transport(hgi="18:001111")
+    pool = PooledTransport(
+        proto, [t0], config=TransportConfig(), dedup_window=999.0
+    )
+    _connect_child(pool, 0, t0)
+
+    # Send _MAX_DEDUP_KEYS + 10 distinct packets.
+    for i in range(_MAX_DEDUP_KEYS + 10):
+        pool._on_child_packet(0, _make_packet(payload=f"{i:04X}"))
+
+    # Cache should be capped at _MAX_DEDUP_KEYS.
+    assert len(pool._dedup_cache) <= _MAX_DEDUP_KEYS
+
+
 # -- Outbound routing ------------------------------------------------------
 
 
@@ -173,7 +280,8 @@ async def test_outbound_routes_to_connected_child() -> None:
     t0 = _make_mock_transport(hgi="18:001111", connected=False)
     t1 = _make_mock_transport(hgi="18:002222", connected=True)
     pool = PooledTransport(proto, [t0, t1], config=TransportConfig())
-    pool._child_connected = [False, True]
+    # Only connect child 1.
+    _connect_and_ready(pool, 1, t1)
 
     await pool.write_frame(
         " 000 I --- 01:123456 18:000730 --:------ 30C9 000 00"
@@ -189,7 +297,8 @@ async def test_outbound_round_robin_among_connected() -> None:
     t0 = _make_mock_transport(hgi="18:001111", connected=True)
     t1 = _make_mock_transport(hgi="18:002222", connected=True)
     pool = PooledTransport(proto, [t0, t1], config=TransportConfig())
-    pool._child_connected = [True, True]
+    _connect_and_ready(pool, 0, t0)
+    _connect_and_ready(pool, 1, t1)
 
     await pool.write_frame("frame1")
     await pool.write_frame("frame2")
@@ -207,7 +316,20 @@ async def test_outbound_fails_when_no_child_connected() -> None:
     proto = _make_mock_protocol()
     t0 = _make_mock_transport(hgi="18:001111", connected=False)
     pool = PooledTransport(proto, [t0], config=TransportConfig())
-    pool._child_connected = [False]
+
+    with pytest.raises(exc.TransportError, match="No connected child"):
+        await pool.write_frame("frame1")
+
+
+async def test_outbound_fails_when_child_not_send_ready() -> None:
+    """A connected child with no HGI identity is not send-ready."""
+    from ramses_tx import exceptions as exc
+
+    proto = _make_mock_protocol()
+    t0 = _make_mock_transport(hgi=None)
+    pool = PooledTransport(proto, [t0], config=TransportConfig())
+    # Connect but transport reports no HGI — send_ready stays False.
+    _connect_child(pool, 0, t0)
 
     with pytest.raises(exc.TransportError, match="No connected child"):
         await pool.write_frame("frame1")
@@ -249,8 +371,8 @@ async def test_child_disconnect_notifies_protocol_when_all_disconnected() -> (
     t0 = _make_mock_transport(hgi="18:001111")
     t1 = _make_mock_transport(hgi="18:002222")
     pool = PooledTransport(proto, [t0, t1], config=TransportConfig())
-    pool._child_connected = [True, True]
-    pool._child_hgi = ["18:001111", "18:002222"]
+    _connect_child(pool, 0, t0)
+    _connect_child(pool, 1, t1)
 
     # Disconnect first child — should NOT notify protocol (one still up).
     pool._on_child_disconnected(0, None)
@@ -262,21 +384,40 @@ async def test_child_disconnect_notifies_protocol_when_all_disconnected() -> (
     proto.connection_lost.assert_called_once()
 
 
+async def test_disconnect_only_affects_one_child() -> None:
+    """connection_lost on one child does not affect other children."""
+    proto = _make_mock_protocol()
+    t0 = _make_mock_transport(hgi="18:001111")
+    t1 = _make_mock_transport(hgi="18:002222")
+    pool = PooledTransport(proto, [t0, t1], config=TransportConfig())
+    _connect_and_ready(pool, 0, t0)
+    _connect_and_ready(pool, 1, t1)
+
+    # Disconnect child 0.
+    pool._on_child_disconnected(0, None)
+
+    # Child 1 should still be connected and sendable.
+    assert pool._children[1].is_connected
+    assert pool._children[1].is_sendable
+    # Child 0 should be disconnected.
+    assert not pool._children[0].is_connected
+
+
 # -- get_extra_info --------------------------------------------------------
 
 
 def test_get_extra_info_active_hgi_returns_first_connected(
     event_loop: asyncio.AbstractEventLoop,
 ) -> None:
-    """get_extra_info(SZ_ACTIVE_HGI) returns the first connected child's HGI."""
+    """get_extra_info(SZ_ACTIVE_HGI) returns first connected child's HGI."""
     proto = _make_mock_protocol()
     t0 = _make_mock_transport(hgi="18:001111")
     t1 = _make_mock_transport(hgi="18:002222")
     pool = PooledTransport(
         proto, [t0, t1], config=TransportConfig(), loop=event_loop
     )
-    pool._child_connected = [True, True]
-    pool._child_hgi = ["18:001111", "18:002222"]
+    _connect_child(pool, 0, t0)
+    _connect_child(pool, 1, t1)
 
     assert pool.get_extra_info(SZ_ACTIVE_HGI) == "18:001111"
 
@@ -291,8 +432,8 @@ def test_get_extra_info_active_hgi_skips_disconnected(
     pool = PooledTransport(
         proto, [t0, t1], config=TransportConfig(), loop=event_loop
     )
-    pool._child_connected = [False, True]
-    pool._child_hgi = [None, "18:002222"]
+    # Only connect child 1.
+    _connect_child(pool, 1, t1)
 
     assert pool.get_extra_info(SZ_ACTIVE_HGI) == "18:002222"
 
@@ -306,9 +447,8 @@ def test_get_extra_info_pool_stats(
     pool = PooledTransport(
         proto, [t0], config=TransportConfig(), loop=event_loop
     )
-    pool._child_connected = [True]
-    pool._child_hgi = ["18:001111"]
-    pool._pkts_received = [5]
+    _connect_child(pool, 0, t0)
+    pool._children[0].pkts_received = 5
     pool._pkts_deduped = 2
     pool._pkts_forwarded = 3
 
@@ -318,6 +458,91 @@ def test_get_extra_info_pool_stats(
     assert stats["received"] == [5]
     assert stats["deduped"] == 2
     assert stats["forwarded"] == 3
+
+
+def test_get_extra_info_pool_rssi_trackers_returns_only_connected(
+    event_loop: asyncio.AbstractEventLoop,
+) -> None:
+    """pool_rssi_trackers returns trackers for connected children only."""
+    proto = _make_mock_protocol()
+    t0 = _make_mock_transport(hgi="18:001111")
+    t1 = _make_mock_transport(hgi="18:002222")
+    pool = PooledTransport(
+        proto, [t0, t1], config=TransportConfig(), loop=event_loop
+    )
+    _connect_child(pool, 0, t0)
+    # Child 1 not connected.
+
+    trackers = pool.get_extra_info("pool_rssi_trackers")
+    assert len(trackers) == 1  # only child 0 is connected
+
+
+def test_get_extra_info_pool_rssi_trackers_all_connected(
+    event_loop: asyncio.AbstractEventLoop,
+) -> None:
+    """pool_rssi_trackers returns all trackers when all connected."""
+    proto = _make_mock_protocol()
+    t0 = _make_mock_transport(hgi="18:001111")
+    t1 = _make_mock_transport(hgi="18:002222")
+    pool = PooledTransport(
+        proto, [t0, t1], config=TransportConfig(), loop=event_loop
+    )
+    _connect_child(pool, 0, t0)
+    _connect_child(pool, 1, t1)
+
+    trackers = pool.get_extra_info("pool_rssi_trackers")
+    assert len(trackers) == 2
+
+
+def test_get_extra_info_pool_hgi_ids(
+    event_loop: asyncio.AbstractEventLoop,
+) -> None:
+    """pool_hgi_ids returns HGI IDs of all connected children."""
+    proto = _make_mock_protocol()
+    t0 = _make_mock_transport(hgi="18:001111")
+    t1 = _make_mock_transport(hgi="18:002222")
+    pool = PooledTransport(
+        proto, [t0, t1], config=TransportConfig(), loop=event_loop
+    )
+    _connect_child(pool, 0, t0)
+    _connect_child(pool, 1, t1)
+
+    hgi_ids = pool.get_extra_info("pool_hgi_ids")
+    assert hgi_ids == ["18:001111", "18:002222"]
+
+
+def test_get_extra_info_unknown_key_returns_default(
+    event_loop: asyncio.AbstractEventLoop,
+) -> None:
+    """get_extra_info with unknown key returns the default."""
+    proto = _make_mock_protocol()
+    t0 = _make_mock_transport(hgi="18:001111")
+    pool = PooledTransport(
+        proto, [t0], config=TransportConfig(), loop=event_loop
+    )
+
+    assert (
+        pool.get_extra_info("nonexistent_key", default="fallback")
+        == "fallback"
+    )
+
+
+def test_repr_returns_diagnostic_string(
+    event_loop: asyncio.AbstractEventLoop,
+) -> None:
+    """__repr__ returns a diagnostic representation."""
+    proto = _make_mock_protocol()
+    t0 = _make_mock_transport(hgi="18:001111")
+    t1 = _make_mock_transport(hgi="18:002222")
+    pool = PooledTransport(
+        proto, [t0, t1], config=TransportConfig(), loop=event_loop
+    )
+    _connect_child(pool, 0, t0)
+
+    repr_str = repr(pool)
+    assert "PooledTransport" in repr_str
+    assert "children=2" in repr_str
+    assert "connected=1" in repr_str
 
 
 # -- Close -----------------------------------------------------------------
@@ -357,6 +582,20 @@ def test_close_is_idempotent(
     t0.close.assert_called_once()
 
 
+async def test_packets_during_close_are_ignored() -> None:
+    """Packets received after close() are not forwarded."""
+    proto = _make_mock_protocol()
+    t0 = _make_mock_transport(hgi="18:001111")
+    pool = PooledTransport(proto, [t0], config=TransportConfig())
+    _connect_child(pool, 0, t0)
+
+    pool.close()
+    pool._on_child_packet(0, _make_packet())
+
+    await asyncio.sleep(0.01)
+    proto.packet_received.assert_not_called()
+
+
 # -- _ChildProtocolProxy ---------------------------------------------------
 
 
@@ -368,7 +607,20 @@ def test_child_proxy_routes_packet_to_pool() -> None:
 
     proxy.packet_received(pkt)
 
-    pool._on_child_packet.assert_called_once_with(0, pkt)
+    pool._on_child_packet.assert_called_once_with(0, pkt, ingress_hgi_id=None)
+
+
+def test_child_proxy_routes_packet_with_ingress_hgi() -> None:
+    """_ChildProtocolProxy.packet_received passes ingress_hgi_id."""
+    pool = MagicMock()
+    proxy = _ChildProtocolProxy(pool, 0)
+    pkt = _make_packet()
+
+    proxy.packet_received(pkt, ingress_hgi_id="18:001111")
+
+    pool._on_child_packet.assert_called_once_with(
+        0, pkt, ingress_hgi_id="18:001111"
+    )
 
 
 def test_child_proxy_routes_connection_made() -> None:
@@ -396,13 +648,386 @@ def test_child_proxy_routes_connection_lost() -> None:
     assert proxy._connected is False
 
 
-# -- Constructor validation ------------------------------------------------
+# -- PR 1: PoolChild state -------------------------------------------------
 
 
-def test_empty_transport_list_raises(
+def test_pool_child_connection_states() -> None:
+    """PoolChild connection state transitions."""
+    t = _make_mock_transport(hgi="18:001111")
+    child = PoolChild(child_id=0, port_name="/dev/ttyUSB0", transport=t)
+    assert not child.is_connected
+
+    # Connect with a transport that reports an HGI.
+    child.mark_connected(t)
+    assert child.is_connected
+    assert child.is_sendable  # type: ignore[unreachable]
+
+    # Disconnect.
+    child.mark_disconnected()
+    assert not child.is_connected
+    assert not child.is_sendable
+
+
+def test_pool_child_availability_transitions() -> None:
+    """PoolChild availability: offline -> online -> stale."""
+    child = PoolChild(child_id=0, port_name="mqtt://localhost")
+    assert not child.is_online
+
+    child.mark_online()
+    assert child.is_online
+    last_seen = child.last_pkt_time  # type: ignore[unreachable]
+    assert last_seen is not None
+
+    child.mark_stale()
+    assert not child.is_online
+
+
+def test_pool_child_send_ready_requires_identity() -> None:
+    """A child that never received a packet is not send-ready."""
+    t = _make_mock_transport(hgi=None)
+    child = PoolChild(child_id=0, port_name="/dev/ttyUSB0", transport=t)
+    # Connect with a transport that has no HGI.
+    child.mark_connected(t)
+    assert child.is_connected
+    assert not child.is_sendable  # no HGI identity yet
+
+    # Learn HGI from a puzzle response.
+    child.learn_hgi(DeviceIdT("18:001111"))
+    assert child.is_sendable
+
+
+def test_pool_child_rssi_quarantined_on_disconnect() -> None:
+    """RSSI evidence is cleared when a child goes offline."""
+    child = PoolChild(child_id=0, port_name="/dev/ttyUSB0")
+    child.rssi_tracker.record("01:123456", -50, dt.now())
+    assert child.rssi_tracker.best_rssi_for("01:123456") == -50
+
+    child.mark_disconnected()
+    # RSSI data should be cleared (quarantined).
+    assert child.rssi_tracker.best_rssi_for("01:123456") is None
+
+
+# -- PR 1: IngressFrame ---------------------------------------------------
+
+
+def test_ingress_frame_is_frozen() -> None:
+    """IngressFrame is immutable."""
+    iframe = IngressFrame(
+        frame=" 000 I --- 01:123456 18:000730 --:------ 30C9 000 00",
+        timestamp="2026-09-04T12:00:00",
+        ingress_hgi_id=DeviceIdT("18:001111"),
+    )
+    assert iframe.frame.startswith(" 000 I")
+    assert iframe.ingress_hgi_id == DeviceIdT("18:001111")
+    # Frozen dataclass — cannot set attributes.
+    with pytest.raises(AttributeError):
+        iframe.frame = "other"
+
+
+# -- PR 1: Loopback exclusion ----------------------------------------------
+
+
+async def test_loopback_excluded_from_route_rssi() -> None:
+    """Frames from an active pool HGI source are not recorded as RSSI."""
+    proto = _make_mock_protocol()
+    t0 = _make_mock_transport(hgi="18:001111")
+    t1 = _make_mock_transport(hgi="18:002222")
+    pool = PooledTransport(
+        proto, [t0, t1], config=TransportConfig(), dedup_window=10.0
+    )
+    _connect_child(pool, 0, t0)
+    _connect_child(pool, 1, t1)
+
+    # Simulate a loopback: child 0 hears a frame from HGI 18:001111
+    # (its own transmission echo).  This should NOT be recorded as RSSI.
+    loopback_pkt = _make_packet(src="18:001111", rssi="-83")
+    pool._on_child_packet(0, loopback_pkt)
+
+    # Child 0's tracker should NOT have RSSI for 18:001111.
+    assert pool._children[0].rssi_tracker.best_rssi_for("18:001111") is None
+
+    # A normal device frame SHOULD be recorded.
+    normal_pkt = _make_packet(src="01:123456", rssi="-50")
+    pool._on_child_packet(0, normal_pkt)
+    assert pool._children[0].rssi_tracker.best_rssi_for("01:123456") == -50
+
+
+async def test_unrelated_hgi_frames_not_suppressed() -> None:
+    """Frames from a pool HGI that is NOT the source are forwarded."""
+    proto = _make_mock_protocol()
+    t0 = _make_mock_transport(hgi="18:001111")
+    t1 = _make_mock_transport(hgi="18:002222")
+    pool = PooledTransport(
+        proto, [t0, t1], config=TransportConfig(), dedup_window=10.0
+    )
+    _connect_child(pool, 0, t0)
+    _connect_child(pool, 1, t1)
+
+    # A frame where src is 18:002222 (the other HGI) heard by child 0.
+    # This is a cross-HGI frame, not loopback — it should be forwarded.
+    pkt = _make_packet(src="18:002222", payload="ABCD")
+    pool._on_child_packet(0, pkt)
+
+    await asyncio.sleep(0.01)
+    assert proto.packet_received.call_count == 1
+
+
+# -- PR 1: Ingress provenance on Packet envelope --------------------------
+
+
+async def test_packet_carries_ingress_hgi_id() -> None:
+    """The Packet envelope carries the ingress HGI ID after pool forward."""
+    proto = _make_mock_protocol()
+    t0 = _make_mock_transport(hgi="18:001111")
+    pool = PooledTransport(
+        proto, [t0], config=TransportConfig(), dedup_window=10.0
+    )
+    _connect_child(pool, 0, t0)
+
+    pkt = _make_packet(src="04:123456")
+    pool._on_child_packet(0, pkt)
+
+    await asyncio.sleep(0.01)
+    # The forwarded packet should carry the ingress HGI ID.
+    forwarded_pkt = proto.packet_received.call_args[0][0]
+    assert forwarded_pkt._ingress_hgi_id == "18:001111"
+
+
+async def test_explicit_ingress_hgi_overrides_child_record() -> None:
+    """Explicit ingress_hgi_id overrides the child record's HGI."""
+    proto = _make_mock_protocol()
+    t0 = _make_mock_transport(hgi="18:001111")
+    pool = PooledTransport(
+        proto, [t0], config=TransportConfig(), dedup_window=10.0
+    )
+    _connect_child(pool, 0, t0)
+
+    pkt = _make_packet(src="04:123456")
+    pool._on_child_packet(0, pkt, ingress_hgi_id=DeviceIdT("18:009999"))
+
+    await asyncio.sleep(0.01)
+    forwarded_pkt = proto.packet_received.call_args[0][0]
+    assert forwarded_pkt._ingress_hgi_id == "18:009999"
+
+
+async def test_local_echo_and_over_air_copy_different_provenance_same_dedup() -> (
+    None
+):
+    """Local echo and over-air copy have different ingress HGI but dedup.
+
+    Regression test for PR 1 spec: "The selected child's local echo and
+    another child's over-air copy retain different ingress provenance but
+    deduplicate as one RF frame."
+    """
+    proto = _make_mock_protocol()
+    t0 = _make_mock_transport(hgi="18:001111")
+    t1 = _make_mock_transport(hgi="18:002222")
+    pool = PooledTransport(
+        proto, [t0, t1], config=TransportConfig(), dedup_window=10.0
+    )
+    _connect_child(pool, 0, t0)
+    _connect_child(pool, 1, t1)
+
+    # Same RF frame heard by both children.
+    pkt0 = _make_packet(src="04:123456", payload="ABCD")
+    pkt1 = _make_packet(src="04:123456", payload="ABCD")
+
+    pool._on_child_packet(0, pkt0)
+    pool._on_child_packet(1, pkt1)
+
+    await asyncio.sleep(0.01)
+
+    # Only one packet forwarded (deduped).
+    assert proto.packet_received.call_count == 1
+
+    # The forwarded packet carries the FIRST child's ingress HGI.
+    forwarded_pkt = proto.packet_received.call_args[0][0]
+    assert forwarded_pkt._ingress_hgi_id == "18:001111"
+
+
+async def test_packet_ingress_hgi_id_none_without_pool() -> None:
+    """A Packet created outside a pool has ingress_hgi_id=None."""
+    from datetime import datetime as dt
+
+    from ramses_tx.packet import Packet
+
+    pkt = Packet(
+        dt(2026, 1, 1, 12, 0, 0),
+        "000  I --- 01:123456 18:000730 --:------ 30C9 001 00",
+    )
+    assert pkt.ingress_hgi_id is None
+
+
+# -- PR 1: No runtime add/remove/accepted ----------------------------------
+
+
+def test_no_add_child_method(
     event_loop: asyncio.AbstractEventLoop,
 ) -> None:
-    """PooledTransport with empty transport list raises ValueError."""
+    """PooledTransport does not expose runtime add_child()."""
     proto = _make_mock_protocol()
-    with pytest.raises(ValueError, match="at least one child transport"):
-        PooledTransport(proto, [], config=TransportConfig(), loop=event_loop)
+    pool = PooledTransport(
+        proto, [None], config=TransportConfig(), loop=event_loop
+    )
+    assert not hasattr(pool, "add_child")
+
+
+def test_no_remove_child_method(
+    event_loop: asyncio.AbstractEventLoop,
+) -> None:
+    """PooledTransport does not expose runtime remove_child()."""
+    proto = _make_mock_protocol()
+    pool = PooledTransport(
+        proto, [None], config=TransportConfig(), loop=event_loop
+    )
+    assert not hasattr(pool, "remove_child")
+
+
+def test_no_set_accepted_hgis_method(
+    event_loop: asyncio.AbstractEventLoop,
+) -> None:
+    """PooledTransport does not expose runtime set_accepted_hgis()."""
+    proto = _make_mock_protocol()
+    pool = PooledTransport(
+        proto, [None], config=TransportConfig(), loop=event_loop
+    )
+    assert not hasattr(pool, "set_accepted_hgis")
+
+
+# -- PR 1: Health monitoring (no last-resort re-enable) --------------------
+
+
+def test_health_timeout_marks_stale_not_offline(
+    event_loop: asyncio.AbstractEventLoop,
+) -> None:
+    """A child with no packets for health_timeout is marked STALE."""
+    proto = _make_mock_protocol()
+    t0 = _make_mock_transport(hgi="18:001111")
+    t1 = _make_mock_transport(hgi="18:002222")
+    pool = PooledTransport(
+        proto,
+        [t0, t1],
+        config=TransportConfig(),
+        loop=event_loop,
+        health_timeout=0.05,
+    )
+    _connect_and_ready(pool, 0, t0)
+    _connect_and_ready(pool, 1, t1)
+
+    # Set child 0's last packet time to the past (stale).
+    pool._children[0].last_pkt_time = dt.now() - td(seconds=1)
+
+    pool._check_health()
+
+    assert pool._children[0].availability is NodeAvailability.STALE
+    assert pool._children[1].is_online
+
+
+def test_no_last_resort_reenable_of_offline_children(
+    event_loop: asyncio.AbstractEventLoop,
+) -> None:
+    """A disconnected child is never re-enabled as a last resort."""
+    proto = _make_mock_protocol()
+    t0 = _make_mock_transport(hgi="18:001111")
+    pool = PooledTransport(
+        proto, [t0], config=TransportConfig(), loop=event_loop
+    )
+    _connect_and_ready(pool, 0, t0)
+
+    # Disconnect the child.
+    pool._children[0].mark_disconnected()
+
+    # _select_child should NOT re-enable the disconnected child.
+    child = pool._select_child()
+    assert child is None  # no sendable child
+    assert not pool._children[0].is_connected
+
+
+def test_quiet_serial_child_stays_connected(
+    event_loop: asyncio.AbstractEventLoop,
+) -> None:
+    """A quiet connected serial child stays connected/online while
+    its route evidence expires (RSSI TTL)."""
+    from ramses_tx.rssi_tracker import DEFAULT_TTL
+
+    proto = _make_mock_protocol()
+    t0 = _make_mock_transport(hgi="18:001111")
+    pool = PooledTransport(
+        proto, [t0], config=TransportConfig(), loop=event_loop
+    )
+    _connect_and_ready(pool, 0, t0)
+
+    # Record RSSI with an old timestamp (beyond TTL) for a distinct device.
+    old_time = dt.now() - DEFAULT_TTL - td(seconds=1)
+    pool._children[0].rssi_tracker.record("04:999999", -50, old_time)
+
+    # The RSSI should be expired on access.
+    assert pool._children[0].rssi_tracker.best_rssi_for("04:999999") is None
+
+    # But the child should still be connected.
+    assert pool._children[0].is_connected
+
+
+# -- PR 1: Active HGI IDs derived from child records -----------------------
+
+
+def test_active_hgi_ids_derived_from_children(
+    event_loop: asyncio.AbstractEventLoop,
+) -> None:
+    """Active HGI IDs are derived from accepted child records."""
+    proto = _make_mock_protocol()
+    t0 = _make_mock_transport(hgi="18:001111")
+    t1 = _make_mock_transport(hgi="18:002222")
+    pool = PooledTransport(
+        proto, [t0, t1], config=TransportConfig(), loop=event_loop
+    )
+    _connect_child(pool, 0, t0)
+    _connect_child(pool, 1, t1)
+
+    hgi_ids = pool._active_hgi_ids
+    assert len(hgi_ids) == 2
+    hgi_strs = [str(h) for h in hgi_ids]
+    assert "18:001111" in hgi_strs
+    assert "18:002222" in hgi_strs
+
+
+# -- PR 1: RSSI per-child tracking -----------------------------------------
+
+
+def test_pool_rssi_trackers_record_per_child(
+    event_loop: asyncio.AbstractEventLoop,
+) -> None:
+    """Each child's RSSI tracker records independently."""
+    proto = _make_mock_protocol()
+    t0 = _make_mock_transport(hgi="18:001111")
+    t1 = _make_mock_transport(hgi="18:002222")
+    pool = PooledTransport(
+        proto, [t0, t1], config=TransportConfig(), loop=event_loop
+    )
+    _connect_child(pool, 0, t0)
+    _connect_child(pool, 1, t1)
+
+    pkt_child0 = _make_packet(src="04:123456", rssi="-41")
+    pkt_child1 = _make_packet(src="04:123456", rssi="-89")
+
+    pool._on_child_packet(0, pkt_child0)
+    pool._on_child_packet(1, pkt_child1)
+
+    trackers = pool.get_extra_info("pool_rssi_trackers")
+    assert len(trackers) == 2
+    assert trackers[0].best_rssi_for("04:123456") == -41
+    assert trackers[1].best_rssi_for("04:123456") == -89
+
+
+# -- PR 1: Constructor allows empty list (factory validates) ---------------
+
+
+def test_empty_transport_list_does_not_raise(
+    event_loop: asyncio.AbstractEventLoop,
+) -> None:
+    """PooledTransport allows empty list — factory validates, not ctor."""
+    proto = _make_mock_protocol()
+    pool = PooledTransport(
+        proto, [], config=TransportConfig(), loop=event_loop
+    )
+    assert len(pool._children) == 0


### PR DESCRIPTION
## Summary

PR 1 — https://github.com/ramses-rf/ramses_rf/issues/1119
(previous Roadmap item 9)


Refactor `PooledTransport` around one child object per route while preserving the single coherent inbound stream.

### What's included

- **`PoolChild` dataclass** replaces all parallel arrays (connection, HGI identity, transport, RSSI, counters, timestamps, errors)
- **`ConnectionState` and `NodeAvailability` enums** for explicit state management
- **Ingress provenance**: `_ingress_hgi_id` slot on `Packet` envelope, separate from RAMSES `addr1`; set in `_on_child_packet()` before forwarding
- **Loopback exclusion**: active pool HGI frames excluded from route RSSI
- **Dict-backed O(1) dedup cache** with sequence-aware key (includes seq when present, falls back to base key)
- **`RssiTracker` TTL** (5 min expiry for pool children, `None` default for gateway communication-quality trackers) with mixed tz-aware/naive datetime handling
- **`_RSSI_UNKNOWN` sentinel** = -999 (not 0) so real negative RSSI values are preferred over the unknown sentinel
- **Runtime API removed**: `add_child()`/`remove_child()`/`set_accepted_hgis()` — construction-only
- **`get_extra_info()` compatibility keys** preserved (`pool_hgi_ids`, `pool_rssi_trackers`, `pool_stats`)

### What's NOT included (deferred)

- Pre-serialization typed DTO routing (PR 2)
- RSSI-based outbound selection scoring (PR 2)
- QoS echo fingerprint matching (PR 2)
- Transport-neutral MQTT callback contract (PR 4A)
- HA-native multi-MQTT adapter (PR 4B)
- Serial/zigbee pool members (Phase 2/3)

### Real hardware verification

Verified on hass with 2 real MQTT HGIs (`18:130236` + `18:149488`):
- Both children connect and stay connected
- RSSI-based routing selects closer HGI (-41 vs -92 dBm)
- Dedup suppresses cross-HGI duplicate frames (confirmed in logs)
- `check_communication_quality` runs without errors
- 72+ packets received in ~2 minutes of real Orcon ventilation traffic
- Zero errors, zero crashes, zero disconnects

#### Test plan

- [x] `pytest tests/tests_tx/test_transport_pooled.py` — 47/47 pass
- [x] `pytest tests/tests_tx/test_rssi_tracker.py` — 14/14 pass
- [x] `pytest` (full suite) — 2966 pass, 9 skipped, 0 fail
- [x] `ruff check` — clean
- [x] `mypy --strict` — clean
- [x] ha_sim_test R98 (PooledTransport dedup & routing) — 14/14 pass
- [x] ha_sim_test R100 (RSSI best-across-HGIs) — 13/13 pass
- [x] Real hardware dual-MQTT pool — verified on hass

#### Plan compliance (multi-hgi-plan.md "Rule for every PR")

- [x] Regression tests that fail against parent branch
- [x] Smallest implementation that makes those tests pass
- [x] Tests for negative and recovery paths (disconnect, offline, stale, tz-mixed)
- [x] Strict typing, lint, and full repository test suite
- [x] Deterministic fixtures (captured-fixture evidence: 725 packets, 2h capture)
- [x] Updated diagnostics (`get_extra_info` compatibility keys preserved)
- [x] No CI workflow regressions (no workflow files changed)

#### PR 1 completion criteria

- [x] No parallel lifecycle arrays remain — `PoolChild` dataclass consolidates all per-child state
- [x] Inbound packets produce one coherent deduplicated stream — dict-backed O(1) dedup
- [x] Child-state diagnostics explain connection, availability, acceptance, readiness — `get_extra_info`
- [x] Focused tests, full `ramses_rf` tests, Ruff, and strict mypy pass

---

## Phase 1 Release Gate Checklist (issue 1119)

### Release gate
- [x] Full `ramses_rf`, `ramses_cc`, `ramses_extras` suites pass (3037 + 1724 + extras)
- [x] Complete `ha_sim_test` recipe set (449 passed, 2 parallel-load timeouts — both pass alone)
- [x] Physical dual-MQTT results recorded (dedup: 62 RX → 38 dispatched, RSSI routing, failover)
- [x] MQTT broker restart and LWT offline/recovery verified (both HGIs offline→online, ~150ms)
- [x] Selected-child local echo and cross-dongle over-air copy (both arrival orders)
- [x] Cold-start targets use first eligible child in stable config order, never multicast
- [x] Source intent, selected-child source ID, canonical final-wire QoS echo matching
- [x] QoS retry that changes child replaces pending final command/fingerprint
- [x] Per-HGI firmware-management commands (`!V`) isolated from RF routing
- [x] HA-native MQTT path drives pool correctly (no direct paho inside HA)
- [x] `paho-mqtt>=2.1.0` declared in `ramses_rf` pyproject.toml
- [x] `serialx>=1.8.2` reconciled across `ramses_rf`, `ramses_cc`, HA container baseline
- [ ] CI workflow: no regressions (blocked until `ramses_rf` publishes pool modules)
- [x] Diagnostics contain no credentials or secrets (MQTT URLs masked in config flow)
- [x] Serial and Zigbee transport types gated in config flow with "(not yet supported)"

### Definition of done
1. [x] One logical transport, one deduplicated inbound stream with HGI provenance
2. [x] Child state in `PoolChild` dataclass (no parallel arrays)
3. [x] QoS prepares exactly one eligible child from immutable DTO before serialization
4. [x] Intentional sources preserved (`SourcePolicy.PRESERVE`/`SELECTED`), HGI80/evofw3 covered
5. [x] QoS matches canonical fingerprint of final wire command
6. [x] Conservative retry rules (proven-not-submitted, ambiguous, confirmed-echo, timeout)
7. [x] HA-native MQTT adapter drives pool via `homeassistant.components.mqtt`; no paho in HA
8. [x] Schema ownership is sole MQTT authorization authority; unknown wildcard IDs cannot mutate pool
9. [x] Single-USB and single-HA-MQTT behavior remains compatible
10. [x] Full suites, `ha_sim_test`, diagnostics review, physical dual-MQTT evidence pass
11. [x] Dependencies declared explicitly (`paho-mqtt>=2.1.0`, `serialx>=1.8.2` in pyproject.toml); [x] serialx reconciled with HA container baseline; [ ] no CI regressions (blocked by `ramses_rf` publish)
12. [x] Serial and Zigbee gated with "(not yet supported)" and `TODO:` remarks

### Remaining blocker
`ramses_rf` must publish a new PyPI version with pool modules (`callbacks.py`, `mqtt_pool.py`, `pooled.py`). `ramses_cc` CI will fail with `ModuleNotFoundError` until then. This is the only remaining blocker — all code is complete and live-verified.