### PR TITLE
Support Orcon HRC-350 ventilation demand control

### DIFF
--- a/src/ramses_rf/commands/builders/__init__.py
+++ b/src/ramses_rf/commands/builders/__init__.py
@@ -22,6 +22,7 @@ BUILDERS: dict[Action, Callable[[Command], CommandDTO]] = {
     Action.SET_DHW_MODE: dhw.build_set_dhw_mode,
     # HVAC Commands
     Action.PUT_CO2_LEVEL: hvac.build_put_co2_level,
+    Action.PUT_VENTILATION_DEMAND: hvac.build_put_ventilation_demand,
     Action.PUT_INDOOR_HUMIDITY: hvac.build_put_indoor_humidity,
     Action.SET_FAN_MODE: hvac.build_set_fan_mode,
     Action.SET_BYPASS_POSITION: hvac.build_set_bypass_position,

--- a/src/ramses_rf/commands/builders/hvac.py
+++ b/src/ramses_rf/commands/builders/hvac.py
@@ -146,6 +146,49 @@ def build_put_co2_level(intent: Command) -> CommandDTO:
     )
 
 
+def build_put_ventilation_demand(intent: Command) -> CommandDTO:
+    """Translate a transient ventilation demand into an Orcon 31E0 DTO.
+
+    Orcon HRC-350 CO2 controllers send two four-byte demand domains in one
+    message.  The first carries a standard RAMSES high-resolution percentage
+    (0-200) and the second is inactive::
+
+        00 00 DD 00 01 00 00 00
+
+    HRC-400 community implementations have been observed using the second
+    domain with a literal 0-100 byte.  Keep this HRC-350 encoding explicitly
+    vendor/model-specific until a capability discriminator is available.
+
+    :param intent: The command intent containing the demand and scheme.
+    :type intent: Command
+    :returns: The encoded Orcon demand command.
+    :rtype: CommandDTO
+    :raises ValueError: If the demand or scheme is unsupported.
+    """
+    demand = float(intent.get("ventilation_demand"))
+    if not 0.0 <= demand <= 1.0:
+        raise ValueError("ventilation_demand must be between 0.0 and 1.0")
+
+    scheme = intent.get("scheme")
+    if scheme != "orcon":
+        raise ValueError(
+            "put_ventilation_demand is currently supported only for Orcon"
+        )
+
+    demand_raw = round(demand * 200)
+    addr1, addr2, addr3 = resolve_addrs(intent.src, intent.dst)
+    return CommandDTO(
+        verb=I_,
+        addr1=addr1,
+        addr2=addr2,
+        addr3=addr3,
+        code=Code._31E0,
+        payload=f"0000{demand_raw:02X}0001000000",
+        priority=Priority.DEFAULT,
+        num_repeats=DEFAULT_NUM_REPEATS,
+    )
+
+
 def build_put_indoor_humidity(intent: Command) -> CommandDTO:
     """Translate a PUT_INDOOR_HUMIDITY intent into a CommandDTO.
 

--- a/src/ramses_rf/commands/builders/hvac.py
+++ b/src/ramses_rf/commands/builders/hvac.py
@@ -13,7 +13,7 @@ from ramses_rf.models.hvac_schemas import (
     _2411_PARAMS_SCHEMA,
 )
 from ramses_rf.protocol.ramses import _31DA_FAN_INFO
-from ramses_rf.strategies import HvacStrategy
+from ramses_rf.strategies import HvacStrategy, VentilationControlStrategy
 from ramses_tx.address import NON_DEV_ADDR
 from ramses_tx.const import DEFAULT_NUM_REPEATS, I_, RQ, W_, Code, Priority
 from ramses_tx.dtos import CommandDTO
@@ -147,35 +147,24 @@ def build_put_co2_level(intent: Command) -> CommandDTO:
 
 
 def build_put_ventilation_demand(intent: Command) -> CommandDTO:
-    """Translate a transient ventilation demand into an Orcon 31E0 DTO.
+    """Translate a transient ventilation demand into a 31E0 DTO.
 
-    Orcon HRC-350 CO2 controllers send two four-byte demand domains in one
-    message.  The first carries a standard RAMSES high-resolution percentage
-    (0-200) and the second is inactive::
-
-        00 00 DD 00 01 00 00 00
-
-    HRC-400 community implementations have been observed using the second
-    domain with a literal 0-100 byte.  Keep this HRC-350 encoding explicitly
-    vendor/model-specific until a capability discriminator is available.
-
-    :param intent: The command intent containing the demand and scheme.
+    :param intent: The command intent containing the demand and strategy.
     :type intent: Command
     :returns: The encoded Orcon demand command.
     :rtype: CommandDTO
-    :raises ValueError: If the demand or scheme is unsupported.
+    :raises TypeError: If no HVAC strategy is provided.
+    :raises ValueError: If the demand or strategy is unsupported.
     """
     demand = float(intent.get("ventilation_demand"))
     if not 0.0 <= demand <= 1.0:
         raise ValueError("ventilation_demand must be between 0.0 and 1.0")
 
-    scheme = intent.get("scheme")
-    if scheme != "orcon":
-        raise ValueError(
-            "put_ventilation_demand is currently supported only for Orcon"
-        )
+    strategy = intent.get("strategy")
+    if not isinstance(strategy, VentilationControlStrategy):
+        raise TypeError("strategy must implement VentilationControlStrategy")
 
-    demand_raw = round(demand * 200)
+    payload = strategy.ventilation_demand_payload(demand)
     addr1, addr2, addr3 = resolve_addrs(intent.src, intent.dst)
     return CommandDTO(
         verb=I_,
@@ -183,7 +172,7 @@ def build_put_ventilation_demand(intent: Command) -> CommandDTO:
         addr2=addr2,
         addr3=addr3,
         code=Code._31E0,
-        payload=f"0000{demand_raw:02X}0001000000",
+        payload=payload,
         priority=Priority.DEFAULT,
         num_repeats=DEFAULT_NUM_REPEATS,
     )

--- a/src/ramses_rf/devices/hvac_sensors.py
+++ b/src/ramses_rf/devices/hvac_sensors.py
@@ -21,6 +21,7 @@ from ramses_rf.messages import Message
 from ramses_rf.models import DeviceTraits, HvacState
 from ramses_tx import Packet, Priority
 from ramses_tx.const import Code
+from ramses_tx.typing import DeviceIdT
 
 from .dev_base import BatteryState, DeviceHvac, Fakeable
 
@@ -266,4 +267,33 @@ class HvacCarbonDioxideSensor(CarbonDioxide, Fakeable):  # CO2: I/1298
             )
         return await super()._initiate_binding_process(
             (Code._31E0, Code._1298, Code._2E10)
+        )
+
+    async def set_ventilation_demand(
+        self, fan_id: DeviceIdT, value: float
+    ) -> Message | None:
+        """Send a transient ventilation demand to a bound Orcon fan.
+
+        :param fan_id: The device ID of the destination fan.
+        :type fan_id: DeviceIdT
+        :param value: The demand as a value from 0.0 to 1.0.
+        :type value: float
+        :returns: The resulting message, if one was generated.
+        :rtype: Message | None
+        :raises exc.DeviceNotFaked: If faking is not enabled.
+        """
+        if not self.is_faked:
+            raise exc.DeviceNotFaked(f"{self}: Faking is not enabled")
+
+        intent = Intent(
+            src=Address(self.id),
+            dst=Address(fan_id),
+            action=Action.PUT_VENTILATION_DEMAND,
+            data={
+                "ventilation_demand": value,
+                "scheme": "orcon",
+            },
+        )
+        return await self._gateway.dispatcher.send(
+            intent, priority=Priority.HIGH
         )

--- a/src/ramses_rf/devices/hvac_sensors.py
+++ b/src/ramses_rf/devices/hvac_sensors.py
@@ -19,6 +19,8 @@ from ramses_rf.const import (
 from ramses_rf.enums import Action
 from ramses_rf.messages import Message
 from ramses_rf.models import DeviceTraits, HvacState
+from ramses_rf.schemas import SZ_BOUND_TO
+from ramses_rf.strategies import VentilationControlStrategy, best_hvac_strategy
 from ramses_tx import Packet, Priority
 from ramses_tx.const import Code
 from ramses_tx.typing import DeviceIdT
@@ -252,6 +254,36 @@ class HvacCarbonDioxideSensor(CarbonDioxide, Fakeable):  # CO2: I/1298
     # .W --- 32:155617 29:181813 --:------ 1FC9 012 00-31D9-825FE1 00-31DA-825FE1  # The HRU
     # .I --- 29:181813 32:155617 --:------ 1FC9 001 00
 
+    async def _resolve_fan_strategy(
+        self, fan_id: DeviceIdT
+    ) -> VentilationControlStrategy:
+        """Resolve capability from the destination fan and its model."""
+        fan = self._gateway.device_registry.get_device(fan_id)
+        explicit_strategy: object = fan._strategy
+        if isinstance(explicit_strategy, VentilationControlStrategy):
+            return explicit_strategy
+
+        info = await fan.entity_state.get_value(Code._10E0)
+        model = info.get("description") if isinstance(info, dict) else None
+        strategy = best_hvac_strategy(fan.id, fan._scheme, model=model)
+        if not isinstance(strategy, VentilationControlStrategy):
+            raise ValueError(f"{fan}: ventilation demand is not supported")
+        return strategy
+
+    def _bound_fan_id(self) -> DeviceIdT | None:
+        """Return the configured bound fan ID, if present."""
+        traits = self._gateway.config.known_list.get(self.id, {})
+        bound = traits.get(SZ_BOUND_TO)
+        device_ids = bound if isinstance(bound, list) else [bound]
+        return next(
+            (
+                DeviceIdT(fan_id)
+                for fan_id in device_ids
+                if isinstance(fan_id, str) and fan_id.startswith("32:")
+            ),
+            None,
+        )
+
     async def initiate_binding_process(
         self,
     ) -> tuple[Message, Message, Message, Packet | None]:
@@ -261,18 +293,25 @@ class HvacCarbonDioxideSensor(CarbonDioxide, Fakeable):  # CO2: I/1298
         :rtype: tuple[Message, Message, Message, Packet | None]
         :raises exc.BindingError: If binding fails
         """
-        if self._scheme == "orcon":
-            return await super()._initiate_binding_process(
-                (("00", Code._31E0), ("01", Code._31E0), ("00", Code._1298))
-            )
-        return await super()._initiate_binding_process(
-            (Code._31E0, Code._1298, Code._2E10)
+        configured_strategy: object = self._get_configured_strategy()
+        strategy = (
+            configured_strategy
+            if isinstance(configured_strategy, VentilationControlStrategy)
+            else None
         )
+        if not strategy and (fan_id := self._bound_fan_id()):
+            strategy = await self._resolve_fan_strategy(fan_id)
+        offer_codes = (
+            strategy.co2_binding_codes()
+            if strategy
+            else (Code._31E0, Code._1298, Code._2E10)
+        )
+        return await super()._initiate_binding_process(offer_codes)
 
     async def set_ventilation_demand(
         self, fan_id: DeviceIdT, value: float
     ) -> Message | None:
-        """Send a transient ventilation demand to a bound Orcon fan.
+        """Send a transient ventilation demand to a bound fan.
 
         :param fan_id: The device ID of the destination fan.
         :type fan_id: DeviceIdT
@@ -285,13 +324,14 @@ class HvacCarbonDioxideSensor(CarbonDioxide, Fakeable):  # CO2: I/1298
         if not self.is_faked:
             raise exc.DeviceNotFaked(f"{self}: Faking is not enabled")
 
+        strategy = await self._resolve_fan_strategy(fan_id)
         intent = Intent(
             src=Address(self.id),
             dst=Address(fan_id),
             action=Action.PUT_VENTILATION_DEMAND,
             data={
                 "ventilation_demand": value,
-                "scheme": "orcon",
+                "strategy": strategy,
             },
         )
         return await self._gateway.dispatcher.send(

--- a/src/ramses_rf/enums.py
+++ b/src/ramses_rf/enums.py
@@ -110,6 +110,7 @@ class Action(StrEnum):
     SET_DHW_MODE = "set_dhw_mode"
 
     PUT_CO2_LEVEL = "put_co2_level"
+    PUT_VENTILATION_DEMAND = "put_ventilation_demand"
     PUT_INDOOR_HUMIDITY = "put_indoor_humidity"
     PUT_OUTDOOR_TEMP = "put_outdoor_temp"
     PUT_SENSOR_TEMP = "put_sensor_temp"

--- a/src/ramses_rf/strategies/__init__.py
+++ b/src/ramses_rf/strategies/__init__.py
@@ -9,11 +9,15 @@ See :doc:`roadmap item 5 <https://github.com/ramses-rf/ramses_rf/issues/1093>`.
 
 from __future__ import annotations
 
-from ramses_rf.strategies.base import HvacStrategy, HvacStrategyBase
+from ramses_rf.strategies.base import (
+    HvacStrategy,
+    HvacStrategyBase,
+    VentilationControlStrategy,
+)
 from ramses_rf.strategies.climarad import ClimaRadStrategy
 from ramses_rf.strategies.itho import IthoStrategy
 from ramses_rf.strategies.nuaire import NuaireStrategy
-from ramses_rf.strategies.orcon import OrconStrategy
+from ramses_rf.strategies.orcon import OrconHrc350Strategy, OrconStrategy
 from ramses_rf.strategies.vasco import VascoStrategy
 
 __all__ = [
@@ -22,8 +26,10 @@ __all__ = [
     "HvacStrategyBase",
     "IthoStrategy",
     "NuaireStrategy",
+    "OrconHrc350Strategy",
     "OrconStrategy",
     "VascoStrategy",
+    "VentilationControlStrategy",
     "best_hvac_strategy",
 ]
 
@@ -41,6 +47,7 @@ def best_hvac_strategy(
     device_id: str,
     scheme: str | None = None,
     codes_seen: list[str] | None = None,
+    model: str | None = None,
 ) -> HvacStrategy:
     """Select the best HVAC strategy for a device.
 
@@ -54,8 +61,13 @@ def best_hvac_strategy(
     :type scheme: str | None
     :param codes_seen: Protocol codes observed for the device.
     :type codes_seen: list[str] | None
+    :param model: Device model reported by 10E0, if available.
+    :type model: str | None
     :returns: The selected HVAC strategy.
     :rtype: HvacStrategy
     """
+    if scheme == "orcon" and model and model.upper().startswith("VMD-15RMS64"):
+        return OrconHrc350Strategy()
+
     strategy_cls = _STRATEGY_BY_SCHEME.get(scheme or "", OrconStrategy)
     return strategy_cls()

--- a/src/ramses_rf/strategies/base.py
+++ b/src/ramses_rf/strategies/base.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 from typing import Any, Protocol, runtime_checkable
 
 from ramses_rf.models import HvacState
-from ramses_tx.const import Code
+from ramses_tx.const import Code, IndexT
 
 
 @runtime_checkable
@@ -102,6 +102,32 @@ class HvacStrategy(Protocol):
 
         :returns: Dict of command name → template.
         :rtype: dict[str, dict[str, str]]
+        """
+        ...
+
+
+@runtime_checkable
+class VentilationControlStrategy(Protocol):
+    """Capability interface for CO2 binding and demand control."""
+
+    def co2_binding_codes(
+        self,
+    ) -> tuple[Code | tuple[IndexT, Code], ...]:
+        """Codes and domains offered by a CO2 sensor.
+
+        :returns: Ordered CO2 binding codes, optionally with domain indices.
+        :rtype: tuple[Code | tuple[IndexT, Code], ...]
+        """
+        ...
+
+    def ventilation_demand_payload(self, value: float) -> str:
+        """Encode a ventilation demand for this device capability.
+
+        :param value: Demand as a value from 0.0 to 1.0.
+        :type value: float
+        :returns: Encoded 31E0 payload.
+        :rtype: str
+        :raises ValueError: If this strategy does not support demand control.
         """
         ...
 
@@ -296,6 +322,18 @@ class HvacStrategyBase:
         :rtype: tuple[Code, ...]
         """
         return self._binding_codes
+
+    def co2_binding_codes(
+        self,
+    ) -> tuple[Code | tuple[IndexT, Code], ...]:
+        """Return the generic CO2 sensor binding offer."""
+        return (Code._31E0, Code._1298, Code._2E10)
+
+    def ventilation_demand_payload(self, value: float) -> str:
+        """Reject ventilation demand when the capability is unknown."""
+        raise ValueError(
+            f"ventilation demand is not supported for scheme '{self.scheme}'"
+        )
 
     #: Vendor-specific commands hardcoded in the strategy.
     #: Subclasses override with vendor-specific commands (bypass, filter

--- a/src/ramses_rf/strategies/orcon.py
+++ b/src/ramses_rf/strategies/orcon.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from ramses_rf.models.hvac_schemas import _22F1_MODE_MAX, _22F1_MODE_ORCON
 from ramses_rf.strategies.base import HvacStrategyBase
-from ramses_tx.const import Code
+from ramses_tx.const import Code, IndexT
 
 
 class OrconStrategy(HvacStrategyBase):
@@ -20,3 +20,27 @@ class OrconStrategy(HvacStrategyBase):
         for k, v in HvacStrategyBase._DUTCH_ALIASES.items()
         if v in _22F1_MODE_ORCON.values()
     }
+
+    def co2_binding_codes(
+        self,
+    ) -> tuple[Code | tuple[IndexT, Code], ...]:
+        """Return the indexed binding offer used by Orcon CO2 sensors."""
+        return (
+            ("00", Code._31E0),
+            ("01", Code._31E0),
+            ("00", Code._1298),
+        )
+
+    def ventilation_demand_payload(self, value: float) -> str:
+        """Encode the second-domain demand used by Orcon VMD units."""
+        demand_raw = round(value * 100)
+        return f"000000000100{demand_raw:02X}00"
+
+
+class OrconHrc350Strategy(OrconStrategy):
+    """Orcon capability profile for VMD-15RMS64/HRC-350 units."""
+
+    def ventilation_demand_payload(self, value: float) -> str:
+        """Encode the first-domain high-resolution HRC-350 demand."""
+        demand_raw = round(value * 200)
+        return f"0000{demand_raw:02X}0001000000"

--- a/tests/tests_rf/commands/test_command_builders.py
+++ b/tests/tests_rf/commands/test_command_builders.py
@@ -414,6 +414,43 @@ def test_build_put_co2_level(snapshot: Any) -> None:
     assert dto.payload == "000190"
 
 
+@pytest.mark.parametrize(
+    ("demand", "payload"),
+    [
+        (0.0, "0000000001000000"),
+        (0.5, "0000640001000000"),
+        (1.0, "0000C80001000000"),
+    ],
+)
+def test_build_put_orcon_ventilation_demand(
+    demand: float, payload: str
+) -> None:
+    intent = Intent(
+        src=Address("29:111111"),
+        dst=Address("32:222222"),
+        action=Action.PUT_VENTILATION_DEMAND,
+        data={"ventilation_demand": demand, "scheme": "orcon"},
+    )
+    dto = build_dto(intent)
+    assert str(dto.verb) == Verb.I_
+    assert str(dto.code) == Code._31E0
+    assert dto.payload == payload
+
+
+@pytest.mark.parametrize("demand", [-0.01, 1.01])
+def test_build_put_orcon_ventilation_demand_rejects_range(
+    demand: float,
+) -> None:
+    intent = Intent(
+        src=Address("29:111111"),
+        dst=Address("32:222222"),
+        action=Action.PUT_VENTILATION_DEMAND,
+        data={"ventilation_demand": demand, "scheme": "orcon"},
+    )
+    with pytest.raises(ValueError, match="between 0.0 and 1.0"):
+        build_dto(intent)
+
+
 def test_build_put_indoor_humidity(snapshot: Any) -> None:
     intent = Intent(
         src=Address("32:111111"),

--- a/tests/tests_rf/commands/test_command_builders.py
+++ b/tests/tests_rf/commands/test_command_builders.py
@@ -9,7 +9,7 @@ from ramses_rf.commands.builders import build_dto
 from ramses_rf.commands.core import Command as Intent
 from ramses_rf.const import ZON_MODE_MAP, Code, Verb
 from ramses_rf.enums import Action
-from ramses_rf.strategies import OrconStrategy
+from ramses_rf.strategies import OrconHrc350Strategy, OrconStrategy
 from ramses_tx.const import FaultDeviceClass, FaultState, FaultType
 from ramses_tx.packet import Packet
 
@@ -429,12 +429,33 @@ def test_build_put_orcon_ventilation_demand(
         src=Address("29:111111"),
         dst=Address("32:222222"),
         action=Action.PUT_VENTILATION_DEMAND,
-        data={"ventilation_demand": demand, "scheme": "orcon"},
+        data={
+            "ventilation_demand": demand,
+            "strategy": OrconHrc350Strategy(),
+        },
     )
     dto = build_dto(intent)
     assert str(dto.verb) == Verb.I_
     assert str(dto.code) == Code._31E0
     assert dto.payload == payload
+
+
+def test_build_put_orcon_second_domain_ventilation_demand() -> None:
+    """Regress the real VMD-15RMS86-2 packet reported in PR 1187."""
+    intent = Intent(
+        src=Address("37:126776"),
+        dst=Address("32:153289"),
+        action=Action.PUT_VENTILATION_DEMAND,
+        data={
+            "ventilation_demand": 0.3,
+            "strategy": OrconStrategy(),
+        },
+    )
+    dto = build_dto(intent)
+    assert dto.payload == "0000000001001E00"
+    assert str(Packet._from_cmd(dto)._frame) == (
+        " I --- 37:126776 32:153289 --:------ 31E0 008 0000000001001E00"
+    )
 
 
 @pytest.mark.parametrize("demand", [-0.01, 1.01])
@@ -445,7 +466,10 @@ def test_build_put_orcon_ventilation_demand_rejects_range(
         src=Address("29:111111"),
         dst=Address("32:222222"),
         action=Action.PUT_VENTILATION_DEMAND,
-        data={"ventilation_demand": demand, "scheme": "orcon"},
+        data={
+            "ventilation_demand": demand,
+            "strategy": OrconHrc350Strategy(),
+        },
     )
     with pytest.raises(ValueError, match="between 0.0 and 1.0"):
         build_dto(intent)

--- a/tests/tests_rf/data_driven/test_apis_binding.py
+++ b/tests/tests_rf/data_driven/test_apis_binding.py
@@ -52,8 +52,8 @@ class GatewayStub:
         """Initialize the GatewayStub."""
         self.config = SimpleNamespace(disable_discovery=True, known_list={})
 
-        self.device_by_id: dict[str, Fakeable] = {}
-        self.devices: list[Fakeable] = []
+        self.device_by_id: dict[str, Any] = {}
+        self.devices: list[Any] = []
 
         # Explicitly type as Any to prevent strict mode from complaining about missing mock attributes
         self._engine: Any = unittest.mock.MagicMock()
@@ -66,9 +66,13 @@ class GatewayStub:
         """Act as our own DeviceRegistry for testing purposes."""
         return self
 
-    def _add_device(self, dev: Fakeable) -> None:
+    def _add_device(self, dev: Any) -> None:
         self.device_by_id[dev.id] = dev
         self.devices.append(dev)
+
+    def get_device(self, device_id: str) -> Any:
+        """Return a previously registered test device."""
+        return self.device_by_id[device_id]
 
 
 # ### FIXTURES ########################################################################
@@ -128,11 +132,20 @@ async def test_initiate_binding_process(dev_class: type[Fakeable]) -> None:
 
         if isinstance(dev, HvacCarbonDioxideSensor):
             mocked_method.reset_mock()
+            fan_id = "32:123459"
+            gwy.device_by_id[fan_id] = SimpleNamespace(
+                id=fan_id,
+                _scheme="orcon",
+                _strategy=None,
+                entity_state=SimpleNamespace(
+                    get_value=unittest.mock.AsyncMock(return_value=None)
+                ),
+            )
             configured_sensor = HvacCarbonDioxideSensor(
                 gwy,
                 Address("29:123458"),
-                traits=DeviceTraits(scheme="orcon"),
             )
+            gwy.config.known_list[configured_sensor.id] = {"bound": fan_id}
             await configured_sensor.initiate_binding_process()
             mocked_method.assert_called_once_with(
                 (("00", Code._31E0), ("01", Code._31E0), ("00", Code._1298))

--- a/tests/tests_rf/test_strategies/test_strategies.py
+++ b/tests/tests_rf/test_strategies/test_strategies.py
@@ -21,6 +21,7 @@ from ramses_rf.strategies import (
     HvacStrategy,
     IthoStrategy,
     NuaireStrategy,
+    OrconHrc350Strategy,
     OrconStrategy,
     VascoStrategy,
     best_hvac_strategy,
@@ -439,6 +440,20 @@ class TestBestHvacStrategy:
         strategy = best_hvac_strategy("32:123456", scheme="unknown")
 
         assert isinstance(strategy, OrconStrategy)
+
+    def test_orcon_hrc350_model_selects_first_domain_capability(self) -> None:
+        strategy = best_hvac_strategy(
+            "32:134044", scheme="orcon", model="VMD-15RMS64"
+        )
+
+        assert isinstance(strategy, OrconHrc350Strategy)
+
+    def test_other_orcon_model_keeps_second_domain_capability(self) -> None:
+        strategy = best_hvac_strategy(
+            "32:153289", scheme="orcon", model="VMD-15RMS86-2"
+        )
+
+        assert type(strategy) is OrconStrategy
 
 
 class TestQuirkDispatch:


### PR DESCRIPTION
- [x] I have reviewed and tested these code changes myself, successfully ran pre-commit hooks and am available to address review comments.
- [x] AI Coding Assistance disclosure: used for 75%

These changes make it possible to drive the Orcon HRC-350 ventilation system using a faked CO2 sensor. The HRC-350 uses the RAMSES `31E0` payload to encode ventilation demand as a percentage, and this change allows the system to respond to simulated CO2 levels.

- Preserve binding-domain indices when a device offers the same RAMSES code more than once, and use the indexed offer advertised by Orcon CO2 controllers: `00/31E0`, `01/31E0`, and `00/1298`.

- Add an Orcon-specific ventilation-demand action for faked CO2 sensors. The HRC-350 uses the first domain of its eight-byte `31E0` payload with the standard RAMSES 0-200 percentage encoding. The command is restricted to the Orcon scheme until another device capability can select between this encoding and the second-domain form seen on other models.

Verified on my Orcon HRC-350 unit.
