### PR TITLE
fix: reconcile dependency declarations for pool PRs (issue 1119)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,7 @@
     "colorlog>=6.9.0",              # latest
     "orjson>=3.9.0",                # added for Phase 2.1 Fat SQLite Backend
     "paho-mqtt>=2.1.0",             # latest
-    "serialx>=1.9.0",               # latest (Roadmap Item 9 / Issue #606)
+    "serialx>=1.8.2",               # Roadmap Item 9 / Issue #606 (HA container baseline; 1.8.1 fixed fd leak, Win32 race, USB string descriptors)
     "probatio >= 0.11.2"            # latest
   ]
 

--- a/src/ramses_tx/transport/zigbee/transport.py
+++ b/src/ramses_tx/transport/zigbee/transport.py
@@ -744,6 +744,19 @@ class ZigbeeTransport(_FullTransport, _ZigbeeTransportAbstractor):
             )
         except asyncio.CancelledError:
             raise
+        except ImportError as err:
+            _LOGGER.error(
+                "zigpy is required for Zigbee transport but is not "
+                "installed: %s. Install zigpy (e.g. via the ZHA "
+                "integration) or use a different transport.",
+                err,
+            )
+            self._close(
+                exc.TransportZigbeeError(
+                    f"zigpy is required for Zigbee transport: {err}. "
+                    "Install it or use a different transport."
+                )
+            )
         except Exception as err:
             _LOGGER.exception("Failed to initialize Zigbee transport: %s", err)
             self._close(exc.TransportZigbeeError(str(err)))


### PR DESCRIPTION
## Summary

- **serialx**: lower pin from `>=1.9.0` to `>=1.8.2` — all APIs used by `ramses_tx` (`BaseSerialTransport`, `SerialException`, `serial_for_url`, `create_serial_connection`) are available in 1.8.2 (the HA container baseline). The `>=1.9.0` pin was opportunistic (set to "latest" in PR 1122), not feature-driven, and would block the next `ramses_rf` release on current HA containers. Pinning to `>=1.8.2` (not `>=1.8.0`) because 1.8.1 fixed a POSIX fd leak, a Win32 close/connection_lost race, and missing USB string descriptors on Linux — 1.8.0 has known bugs that 1.8.2 does not.
- **zigpy**: catch `ImportError` in `ZigbeeTransport._async_init` and raise a clear `TransportZigbeeError` with installation guidance, instead of letting a bare `ImportError` propagate from a method body. zigpy is not declared as a hard requirement because Zigbee transport is niche and most users do not need it installed.

These are preconditions for the multi-HGI pool PRs (issue 1119). They are independent of the pool architecture and can merge independently.

#### Test plan
- [x] `pytest tests/ -x` passes (2906 passed, 9 skipped)
- [x] Pre-commit hooks pass (ruff, codespell, etc.)