### PR TITLE
Decode Orcon `31D9` feedback with the vendor mode map

### DIFF
--- a/src/ramses_rf/payloads/hvac.py
+++ b/src/ramses_rf/payloads/hvac.py
@@ -39,6 +39,7 @@ from ramses_rf.const import (
     Code,
 )
 from ramses_rf.protocol.ramses import (
+    _22F1_MODE_ORCON,
     _31DA_FAN_INFO,
     _2411_PARAMS_SCHEMA,
     SZ_DESCRIPTION,
@@ -2589,6 +2590,11 @@ class HvacBypassStatePayload(PayloadBase):
                 0xC8: "III (boost)",
                 0x50: "I (low)",
                 0x1E: "0 (very low)",
+            }
+        elif is_4b_orcon:
+            fan_mode_map = {
+                int(mode_index, 16): fan_mode
+                for mode_index, fan_mode in _22F1_MODE_ORCON.items()
             }
         else:
             fan_mode_map = {0: "off", 5: "auto"}

--- a/tests/tests_rf/data_driven/parsers/code_31d9.log
+++ b/tests/tests_rf/data_driven/parsers/code_31d9.log
@@ -27,7 +27,7 @@
 
 
 # parse_fan_info:          31D9[4:6] == 31DA[36:38] ?Orcon, ignore speed
-2023-11-15T22:21:04.358292 076  I --- 32:134044 --:------ 32:134044 31D9 004 00000200                                                    # {'hvac_id': '00', 'fan_mode': '02',                                         'passive': False, 'damper_only': False, 'filter_dirty': False, 'frost_cycle': False, 'has_fault': False, '_flags': [0, 0, 0, 0, 0, 0, 0, 0], '_unknown_3': '00'}
+2023-11-15T22:21:04.358292 076  I --- 32:134044 --:------ 32:134044 31D9 004 00000200                                                    # {'hvac_id': '00', 'fan_mode': 'medium',                                     'passive': False, 'damper_only': False, 'filter_dirty': False, 'frost_cycle': False, 'has_fault': False, '_flags': [0, 0, 0, 0, 0, 0, 0, 0], '_unknown_3': '00'}
 2023-11-15T22:21:04.496217 077  I --- 32:134044 --:------ 32:134044 31DA 029 00EF007FFF3E30042406B806D8055FF800000248480000EFEF0F810F9D  # {'hvac_id': '00', 'exhaust_fan_speed': 0.36,  'fan_info': 'speed 2, medium', '_unknown_fan_info_flags': [0, 0, 0], 'air_quality': None, 'co2_level': None, 'indoor_humidity': 0.62, 'outdoor_humidity': 0.48, 'exhaust_temp': 10.6, 'supply_temp': 17.2, 'indoor_temp': 17.52, 'outdoor_temp': 13.75, 'speed_capabilities': ['off', 'low_med_high', 'timer', 'boost', 'auto'], 'bypass_position': 0.0, 'supply_fan_speed': 0.36, 'remaining_mins': 0, 'post_heat': None, 'pre_heat': None, 'supply_flow': 39.69, 'exhaust_flow': 39.97}
 
 # parse_exhaust_fan_speed: 31D9[4:6] == 31DA[38:40] ?Itho = speed %, ignore mode

--- a/tests/tests_rf/data_driven/parsers/code_31d9_orcon.log
+++ b/tests/tests_rf/data_driven/parsers/code_31d9_orcon.log
@@ -1,0 +1,3 @@
+2026-09-04T11:14:01.434787 ...  I --- 32:123456 --:------ 32:123456 31D9 004 00200000 # {'fan_mode': 'away', 'passive': False, 'damper_only': False, 'filter_dirty': True, 'frost_cycle': False, 'has_fault': False}
+2026-09-04T11:14:49.358065 ...  I --- 32:123456 --:------ 32:123456 31D9 004 00200400 # {'fan_mode': 'auto', 'passive': False, 'damper_only': False, 'filter_dirty': True, 'frost_cycle': False, 'has_fault': False}
+2026-09-04T11:14:38.816443 ...  I --- 32:123456 --:------ 32:123456 31D9 004 00200700 # {'fan_mode': 'off', 'passive': False, 'damper_only': False, 'filter_dirty': True, 'frost_cycle': False, 'has_fault': False}

--- a/tests/tests_rf/test_payload_dataclasses.py
+++ b/tests/tests_rf/test_payload_dataclasses.py
@@ -10,6 +10,7 @@ import ramses_rf.payloads.system
 import ramses_tx.const as tx_const
 from ramses_rf.const import (
     SZ_DIAGNOSTIC_CODE,
+    SZ_FAN_MODE,
     SZ_FLAGS,
     SZ_FRAME_CODE,
     SZ_HEAT_DEMAND,
@@ -735,6 +736,31 @@ def test_hvac_bypass_state_payload_31d9_parity() -> None:
     assert payload.mode_flags == 0
     assert reencoded == raw_hex
     assert as_dict == {"bypass_position": 100, "mode_flags": 0}
+
+
+@pytest.mark.parametrize(
+    ("mode_index", "fan_mode"),
+    (
+        (0, "away"),
+        (1, "low"),
+        (2, "medium"),
+        (3, "high"),
+        (4, "auto"),
+        (5, "auto_alt"),
+        (6, "boost"),
+        (7, "off"),
+        (8, "08"),
+    ),
+)
+def test_hvac_bypass_state_payload_31d9_orcon_modes(
+    mode_index: int, fan_mode: str
+) -> None:
+    """Decode 4-byte Orcon 31D9 mode feedback without conflating away/off."""
+    payload = HvacBypassStatePayload.from_bytes(
+        bytes((0x00, 0x20, mode_index, 0x00))
+    )
+
+    assert payload.to_dict()[SZ_FAN_MODE] == fan_mode
 
 
 def test_hvac_air_quality_payload_3110_parity() -> None:


### PR DESCRIPTION
I let Codex go loose on my HRC 350 to see if everything works, and it found this problem:

> Live HRC-350/VMD-15RMS64 probes distinguish away (mode byte 00, fans at the configured 10% minimum) from off (mode byte 07, fans at 0%), but the 4-byte Orcon 31D9 parser labelled byte 00 as off and left most other supported modes as raw hex. This made Home Assistant conflate away and off even though 22F1 already defines the complete Orcon mode table.

This PR fixes that, by using the existing Orcon 22F1 mode map when decoding the semantic mode byte in 4-byte 31D9 packets. Longer Itho/Brofer packets and 3-byte Vasco/ClimaRad packets retain their existing branches; unrecognised Orcon values remain raw hex.

Validated locally.

PR template:

- [x] I have reviewed and tested these code changes myself, successfully ran pre-commit hooks and am available to address review comments.
- [x] AI Coding Assistance disclosure: not used/used for 75%