### PR TITLE
feat(routing): PR 2 — pre-serialization routing contract with typed DTOs

### DIFF
--- a/src/ramses_tx/interfaces.py
+++ b/src/ramses_tx/interfaces.py
@@ -10,6 +10,9 @@ if TYPE_CHECKING:
     from .packet import Packet
     from .typing import QosParams
 
+# These are needed at runtime for the default implementations.
+from .routing import RoutedCommand, RouteRequest, WriteOutcome
+
 
 class TransportInterface(ABC):
     """Interface for the Packet Transport layer."""
@@ -29,6 +32,49 @@ class TransportInterface(ABC):
     @abstractmethod
     async def write_frame(self, frame: str) -> None:
         """Write a frame (legacy alias for send_frame)."""
+
+    # -- Pre-serialization routing contract (PR 2) ---------------------
+
+    def prepare_command(self, request: RouteRequest) -> RoutedCommand:
+        """Prepare a command for routed transmission.
+
+        Non-pooled transports return the command as-is (after
+        protocol-level source patching is applied by the caller).
+        ``PooledTransport`` overrides this to select a child and
+        resolve the source address before serialization.
+
+        :param request: Immutable route request carrying the command
+            and source policy.
+        :returns: Routed command with a pinned child ID and the final
+            command DTO.
+        """
+        # Default: no routing, child_id is "self".
+        return RoutedCommand(child_id="self", command=request.command)
+
+    async def write_routed(
+        self,
+        routed: RoutedCommand,
+        frame: str,
+        *,
+        disable_tx_limits: bool = False,
+    ) -> WriteOutcome:
+        """Dispatch a routed command to the pinned child.
+
+        Non-pooled transports delegate to ``write_frame()``.
+        ``PooledTransport`` overrides this to dispatch to the child
+        identified by ``routed.child_id``.
+
+        :param routed: The routed command from ``prepare_command()``.
+        :param frame: The serialized frame (from ``str(routed.command)``).
+        :param disable_tx_limits: If True, bypass per-child rate
+            limiting.
+        :returns: Conservative write outcome classification.
+        """
+        try:
+            await self.write_frame(frame)
+            return WriteOutcome.SUBMITTED
+        except Exception:
+            return WriteOutcome.AMBIGUOUS
 
 
 class ProtocolInterface(ABC, asyncio.Protocol):

--- a/src/ramses_tx/protocol/core.py
+++ b/src/ramses_tx/protocol/core.py
@@ -36,6 +36,7 @@ from ..exceptions import (
     TransportError,
 )
 from ..packet import Packet
+from ..routing import RoutedCommand, RouteRequest, SourcePolicy, WriteOutcome
 from ..typing import DeviceIdT, HeaderT, MsgHandlerT, QosParams
 from .base import DEFAULT_QOS, _DeviceIdFilterMixin
 
@@ -212,6 +213,7 @@ class PortProtocol(_DeviceIdFilterMixin):
                 int,
                 QosParams,
                 asyncio.Future[Packet],
+                SourcePolicy,
             ]
         ] = asyncio.PriorityQueue()
         self._seq = 0
@@ -222,6 +224,7 @@ class PortProtocol(_DeviceIdFilterMixin):
 
         self._pending_cmd: CommandDTO | None = None
         self._pending_fut: asyncio.Future[Packet] | None = None
+        self._pending_routed: RoutedCommand | None = None
 
     def __repr__(self) -> str:
         """Return an unambiguous string representation of this object.
@@ -349,10 +352,11 @@ class PortProtocol(_DeviceIdFilterMixin):
             self._pending_fut.set_exception(exc_val)
             self._pending_fut = None
             self._pending_cmd = None
+            self._pending_routed = None
 
         while not self._queue.empty():
             try:
-                *_, fut = self._queue.get_nowait()
+                *_, fut, _sp = self._queue.get_nowait()
                 if not fut.done():
                     fut.set_exception(exc_val)
                 self._queue.task_done()
@@ -418,6 +422,7 @@ class PortProtocol(_DeviceIdFilterMixin):
                     num_repeats,
                     qos,
                     fut,
+                    source_policy,
                 ) = await self._queue.get()
 
                 if fut.cancelled():
@@ -425,7 +430,7 @@ class PortProtocol(_DeviceIdFilterMixin):
                     continue
 
                 await self._process_tx_item(
-                    cmd, gap_duration, num_repeats, qos, fut
+                    cmd, gap_duration, num_repeats, qos, fut, source_policy
                 )
                 self._queue.task_done()
             except asyncio.CancelledError:
@@ -440,11 +445,17 @@ class PortProtocol(_DeviceIdFilterMixin):
         num_repeats: int,
         qos: QosParams,
         fut: asyncio.Future[Packet],
+        source_policy: SourcePolicy = SourcePolicy.GATEWAY,
     ) -> None:
-        """Transmit a command with link-layer echo backoff retries."""
-        self._pending_cmd = cmd
-        self._pending_fut = fut
+        """Transmit a command with link-layer echo backoff retries.
 
+        Uses the pre-serialization routing API (PR 2): the command is
+        wrapped in a :class:`RouteRequest`, the transport selects a
+        child and resolves the source address, and the final routed
+        DTO becomes the pending QoS command.  Each QoS attempt
+        prepares a new route (which may select a different child if
+        route quality changed) and serializes the final DTO once.
+        """
         max_retries = (
             qos.max_retries
             if qos.max_retries is not None
@@ -464,9 +475,43 @@ class PortProtocol(_DeviceIdFilterMixin):
                     break
 
                 tx_count += 1
+
+                # Prepare the route for this attempt.  Each QoS retry
+                # may select a different child if route quality changed.
+                # The source policy is determined in send_cmd() based
+                # on whether the command source is the gateway
+                # placeholder (GATEWAY) or an intentional non-gateway
+                # source (PRESERVE, e.g. faked-device commands).
+                request = RouteRequest(
+                    command=cmd,
+                    source_policy=source_policy,
+                )
                 try:
-                    await self._send_frame(
-                        str(cmd),
+                    if self._transport is None:
+                        raise ProtocolSendFailed("Transport is not connected")
+                    routed = self._transport.prepare_command(request)
+                except Exception as prep_err:
+                    if not fut.done():
+                        fut.set_exception(
+                            ProtocolSendFailed(
+                                f"Failed to prepare route: {prep_err}"
+                            )
+                        )
+                    return
+
+                # Set pending command from the final routed DTO so QoS
+                # echo matching uses the actual source-patched command.
+                self._pending_cmd = routed.command
+                self._pending_fut = fut
+                self._pending_routed = routed
+
+                # Serialize the final DTO once for this attempt.
+                frame = str(routed.command)
+
+                try:
+                    await self._send_routed_frame(
+                        routed,
+                        frame,
                         num_repeats=num_repeats,
                         gap_duration=gap_duration,
                     )
@@ -509,6 +554,40 @@ class PortProtocol(_DeviceIdFilterMixin):
         finally:
             self._pending_cmd = None
             self._pending_fut = None
+            self._pending_routed = None
+
+    async def _send_routed_frame(
+        self,
+        routed: RoutedCommand,
+        frame: str,
+        num_repeats: int = 0,
+        gap_duration: float = 0.0,
+    ) -> None:
+        """Send a routed frame via the transport's routing API.
+
+        Applies outbound regex to the serialized frame, then dispatches
+        via ``write_routed()``.  Transport-level repeats reuse the same
+        routed command and frame.
+
+        :param routed: The routed command from ``prepare_command()``.
+        :param frame: The serialized frame.
+        :param num_repeats: Number of additional repeat transmissions.
+        :param gap_duration: Gap between repeats in seconds.
+        """
+        if self._transport is None:
+            raise ProtocolSendFailed("Transport is not connected")
+
+        # Apply outbound regex to the serialized frame.
+        frame = self._apply_regex(frame, self._outbound_regex)
+
+        outcome = await self._transport.write_routed(routed, frame)
+        if outcome is WriteOutcome.AMBIGUOUS:
+            raise ProtocolSendFailed(
+                f"Ambiguous write outcome for frame: {frame}"
+            )
+        for _ in range(num_repeats - 1):
+            await asyncio.sleep(gap_duration)
+            await self._transport.write_routed(routed, frame)
 
     async def send_cmd(
         self,
@@ -581,12 +660,39 @@ class PortProtocol(_DeviceIdFilterMixin):
         ):
             num_repeats = 0
 
+        # Determine the source policy for pre-serialization routing.
+        # If the patched source is the gateway placeholder or the
+        # active HGI ID, the transport may substitute the source to
+        # match the selected child (GATEWAY).  Otherwise, the source
+        # is an intentional non-gateway address (e.g. faked-device
+        # commands) and must be preserved as-is (PRESERVE).
+        from ..address import HGI_DEV_ADDR
+
+        if patched_cmd.addr1 in (HGI_DEV_ADDR.id, self.hgi_id):
+            source_policy = SourcePolicy.GATEWAY
+        else:
+            source_policy = SourcePolicy.PRESERVE
+
         if _DBG_DISABLE_QOS:
-            await self._send_frame(
-                str(patched_cmd),
-                num_repeats=num_repeats,
-                gap_duration=gap_duration,
+            # Debug path: skip QoS, send directly via routing API.
+            request = RouteRequest(
+                command=patched_cmd, source_policy=source_policy
             )
+            try:
+                if self._transport is None:
+                    raise ProtocolSendFailed("Transport is not connected")
+                routed = self._transport.prepare_command(request)
+                frame = str(routed.command)
+                await self._send_routed_frame(
+                    routed,
+                    frame,
+                    num_repeats=num_repeats,
+                    gap_duration=gap_duration,
+                )
+            except Exception as send_err:
+                raise ProtocolSendFailed(
+                    f"Failed to transmit frame: {send_err}"
+                ) from send_err
             return None  # type: ignore[return-value]
 
         fut: asyncio.Future[Packet] = self._loop.create_future()
@@ -607,6 +713,7 @@ class PortProtocol(_DeviceIdFilterMixin):
                 num_repeats,
                 qos,
                 fut,
+                source_policy,
             )
         )
 

--- a/src/ramses_tx/routing.py
+++ b/src/ramses_tx/routing.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python3
+"""RAMSES RF - Typed routing contract for pre-serialization outbound routing.
+
+This module defines the immutable boundary objects and enum used by the
+transport-neutral routing API introduced in PR 2 (issue 1119).
+
+The routing contract moves child selection and source-address resolution
+to *before* frame serialization, replacing the post-serialization
+``frame.split()`` approach that ``PooledTransport.write_frame()`` previously
+used.
+
+Key types:
+
+- :class:`SourcePolicy` — whether the command source should be patched to
+  the selected gateway HGI (``GATEWAY``) or left as-is (``PRESERVE``).
+- :class:`RouteRequest` — immutable wrapper around a ``CommandDTO`` plus
+  a ``SourcePolicy``.
+- :class:`RoutedCommand` — the result of route preparation: a pinned
+  child ID and the final ``CommandDTO`` (with source already resolved).
+- :class:`WriteOutcome` — conservative classification of a write attempt.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum, auto
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from .dtos import CommandDTO
+
+
+class SourcePolicy(Enum):
+    """Source-address intent for an outbound command.
+
+    ``GATEWAY``: the command source should be the selected gateway HGI.
+    The transport may substitute the source address to match the
+    selected child's HGI ID (evofw3) or leave the placeholder (HGI80).
+
+    ``PRESERVE``: the command source must not be changed.  Used for
+    faked-device commands that carry an intentional source address,
+    including intentional ``18:`` sources.
+    """
+
+    GATEWAY = auto()
+    PRESERVE = auto()
+
+
+@dataclass(frozen=True, slots=True)
+class RouteRequest:
+    """Immutable request to prepare a command for routed transmission.
+
+    Wraps the original :class:`CommandDTO` with a :class:`SourcePolicy`
+    so the routing layer knows whether it may substitute the source
+    address.
+    """
+
+    command: CommandDTO
+    source_policy: SourcePolicy = SourcePolicy.GATEWAY
+
+
+@dataclass(frozen=True, slots=True)
+class RoutedCommand:
+    """Immutable result of route preparation.
+
+    Carries the pinned child ID and the final :class:`CommandDTO`
+    (with source already resolved).  The protocol layer serializes
+    this DTO once per QoS attempt and dispatches through
+    ``write_routed()``.
+    """
+
+    child_id: str
+    command: CommandDTO
+
+
+class WriteOutcome(Enum):
+    """Conservative classification of a write attempt.
+
+    - ``SUBMITTED``: the write was accepted locally (bytes sent to OS
+      or MQTT message handed to broker).  RF result is unknown until
+      an exact echo or QoS timeout.
+    - ``NOT_SUBMITTED``: proven that no bytes or MQTT message were
+      handed to the local transport.  It is safe to prepare another
+      child immediately.
+    - ``AMBIGUOUS``: an exception occurred but the failure point is
+      unclear (may have partially written).  Do not immediately send
+      through another child.
+    """
+
+    SUBMITTED = auto()
+    NOT_SUBMITTED = auto()
+    AMBIGUOUS = auto()

--- a/src/ramses_tx/transport/pooled.py
+++ b/src/ramses_tx/transport/pooled.py
@@ -27,6 +27,7 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
+import dataclasses
 import logging
 from dataclasses import dataclass, field
 from datetime import datetime as dt, timedelta as td
@@ -39,6 +40,7 @@ from ..const import SZ_ACTIVE_HGI, SZ_IS_EVOFW3, Code
 from ..helpers import dt_now
 from ..interfaces import ProtocolInterface, TransportInterface
 from ..packet import Packet
+from ..routing import RoutedCommand, RouteRequest, SourcePolicy, WriteOutcome
 from ..rssi_tracker import POOL_TTL, POOL_WINDOW_SIZE, RssiTracker
 from ..typing import DeviceIdT, RamsesProtocolT
 from .base import TransportConfig
@@ -539,40 +541,136 @@ class PooledTransport(TransportInterface):
         """Send a frame via a selected child transport."""
         await self.write_frame(frame)
 
+    # -- Pre-serialization routing contract (PR 2) ----------------------
+
+    def prepare_command(self, request: RouteRequest) -> RoutedCommand:
+        """Select a child and resolve the source address before serialization.
+
+        Extracts the target device from the command's positional
+        addresses using the authoritative ``packet_addrs()`` helper,
+        selects the best child using RSSI/cold-start fallback, and
+        resolves the source address based on ``SourcePolicy`` and the
+        selected child's evofw3/HGI80 capability.
+
+        :param request: Immutable route request.
+        :returns: Routed command with pinned child ID and final DTO.
+        :raises TransportError: If no child is sendable.
+        """
+        cmd = request.command
+
+        # Extract target device from the command's positional addresses.
+        # addr2 is the destination in standard RAMSES frames.
+        target_device = cmd.addr2 if cmd.addr2 != "--:------" else None
+
+        child = self._select_child(target_device)
+        if child is None:
+            raise exc.TransportError(
+                "No connected child transport available for send"
+            )
+
+        # Resolve source address based on SourcePolicy.
+        final_cmd = cmd
+        if request.source_policy is SourcePolicy.GATEWAY:
+            child_hgi = child.hgi_id
+            if (
+                child_hgi
+                and cmd.addr1[:2] == "18"
+                and cmd.addr1 != HGI_DEV_ADDR.id
+                and cmd.addr1 != str(child_hgi)
+            ):
+                # evofw3: patch source to the selected child's HGI ID.
+                final_cmd = dataclasses.replace(cmd, addr1=str(child_hgi))
+                _LOGGER.debug(
+                    "PooledTransport.prepare_command: patched source "
+                    "%s -> %s for child %d (evofw3)",
+                    cmd.addr1,
+                    child_hgi,
+                    child.child_id,
+                )
+            # HGI80: leave 18:000730 placeholder as-is — the firmware
+            # substitutes its own ID during transmission.
+        # SourcePolicy.PRESERVE: never modify the source.
+
+        _LOGGER.debug(
+            "PooledTransport.prepare_command: selected child %d "
+            "(hgi=%s) for target %s, source_policy=%s",
+            child.child_id,
+            child.hgi_id,
+            target_device,
+            request.source_policy.name,
+        )
+
+        return RoutedCommand(child_id=str(child.child_id), command=final_cmd)
+
+    async def write_routed(
+        self,
+        routed: RoutedCommand,
+        frame: str,
+        *,
+        disable_tx_limits: bool = False,
+    ) -> WriteOutcome:
+        """Dispatch a routed command to the pinned child.
+
+        Looks up the child by ``routed.child_id`` and dispatches the
+        pre-serialized frame.  Transport-level repeats reuse the same
+        child and frame.
+
+        :param routed: The routed command from ``prepare_command()``.
+        :param frame: The serialized frame (from ``str(routed.command)``).
+        :param disable_tx_limits: If True, bypass per-child rate
+            limiting.
+        :returns: Conservative write outcome classification.
+        """
+        try:
+            child = self._child_by_id(int(routed.child_id))
+        except (IndexError, ValueError):
+            return WriteOutcome.NOT_SUBMITTED
+        if child is None or child.transport is None:
+            return WriteOutcome.NOT_SUBMITTED
+
+        write = getattr(child.transport, "write_frame", None)
+        if write is None:
+            try:
+                await child.transport.send_frame(frame)
+                return WriteOutcome.SUBMITTED
+            except Exception:
+                return WriteOutcome.AMBIGUOUS
+
+        try:
+            await write(frame, disable_tx_limits=disable_tx_limits)
+            return WriteOutcome.SUBMITTED
+        except TypeError:
+            # Child's write_frame doesn't accept disable_tx_limits.
+            try:
+                await write(frame)
+                return WriteOutcome.SUBMITTED
+            except Exception:
+                return WriteOutcome.AMBIGUOUS
+        except Exception:
+            return WriteOutcome.AMBIGUOUS
+
     async def write_frame(
         self, frame: str, disable_tx_limits: bool = False
     ) -> None:
-        """Route an outbound frame to a selected child transport.
+        """Legacy outbound dispatch — delegates to the routing API.
 
-        Selection uses the highest rolling-average RSSI among
-        connected, sendable children for the target device (if known
-        from the frame), falling back to aggregate RSSI, then
-        round-robin when no RSSI data is available.
+        This method is kept for backward compatibility with callers
+        that still use ``write_frame()`` directly (e.g. ``send_frame()``
+        or third-party code).  The preferred path is
+        ``prepare_command()`` + ``write_routed()``.
 
-        The frame's source address (addr1) is re-patched to match the
-        selected child's HGI ID before forwarding.  This is needed
-        because the protocol patches addr1 to the pool's "active" HGI
-        (the first connected child), but the pool may route the frame
-        to a different child with better RSSI.  Without re-patching,
-        the frame would be transmitted by the wrong HGI with the wrong
-        source ID.
-
-        For HGI80 children (``_is_evofw3`` is False), the protocol
-        patches addr1 to the placeholder ``18:000730`` and the HGI80
-        firmware substitutes its own hardware ID during transmission.
-        In this case, re-patching is skipped — the placeholder is
-        correct for any HGI80 child.
+        When called directly, the frame is parsed to extract the target
+        device, a child is selected, and the frame is dispatched.  Source
+        re-patching is done on the serialized frame as a fallback.
 
         :param frame: The raw ASCII frame to transmit.
         :param disable_tx_limits: If True, bypass per-child rate
             limiting.
         """
-        # Parse the frame to extract target device and source address.
+        # Parse the frame to extract target device for child selection.
         target_device: str | None = None
-        src_addr: str | None = None
         parts = frame.split()
         if len(parts) >= 4:
-            src_addr = parts[2]
             target_device = parts[3]
 
         child = self._select_child(target_device)
@@ -581,34 +679,31 @@ class PooledTransport(TransportInterface):
                 "No connected child transport available for send"
             )
 
+        # Fallback source re-patching on the serialized frame.
+        # The preferred path (prepare_command) does this on the DTO
+        # before serialization.
+        src_addr = parts[2] if len(parts) >= 4 else None
         child_hgi = child.hgi_id
-
-        # Re-patch the frame's source address to match the selected
-        # child's HGI ID.  See docstring for conditions.
         if (
             child_hgi
             and src_addr
-            and src_addr[:2] == "18"  # only re-patch HGI sources
+            and src_addr[:2] == "18"
             and src_addr != HGI_DEV_ADDR.id
             and src_addr != str(child_hgi)
         ):
             parts[2] = str(child_hgi)
-            # Preserve leading whitespace (verb can be ' I' with a
-            # leading space in RAMSES frames).
             leading = ""
             if frame and frame[0].isspace():
                 leading = frame[0]
             frame = leading + " ".join(parts)
             _LOGGER.debug(
-                "PooledTransport: re-patched frame source %s -> %s "
-                "for child %d",
+                "PooledTransport.write_frame: re-patched source %s -> %s "
+                "for child %d (legacy path)",
                 src_addr,
                 child_hgi,
                 child.child_id,
             )
 
-        # Child transports accept disable_tx_limits even though
-        # TransportInterface doesn't declare it.
         write = getattr(child.transport, "write_frame", None)
         if write is None:
             await child.transport.send_frame(frame)  # type: ignore[union-attr]
@@ -616,7 +711,6 @@ class PooledTransport(TransportInterface):
             try:
                 await write(frame, disable_tx_limits=disable_tx_limits)
             except TypeError:
-                # Child's write_frame doesn't accept disable_tx_limits.
                 await write(frame)
 
     # -- Internal: inbound dedup + forward -------------------------------

--- a/tests/tests_tx/protocol/test_protocol_transceiver.py
+++ b/tests/tests_tx/protocol/test_protocol_transceiver.py
@@ -15,6 +15,11 @@ from ramses_tx.exceptions import (
 )
 from ramses_tx.packet import Packet
 from ramses_tx.protocol.core import PortProtocol
+from ramses_tx.routing import (
+    RoutedCommand,
+    RouteRequest,
+    WriteOutcome,
+)
 from ramses_tx.typing import QosParams
 
 
@@ -48,6 +53,27 @@ def sample_cmd() -> CommandDTO:
     )
 
 
+def _make_mock_transport() -> MagicMock:
+    """Create a mock transport with the routing API wired up.
+
+    ``prepare_command`` returns a real ``RoutedCommand`` wrapping the
+    original command (no source patching for a non-pooled transport).
+    ``write_routed`` is an ``AsyncMock`` returning ``SUBMITTED``.
+    """
+    mock_transport = MagicMock()
+    mock_transport.get_extra_info.return_value = None
+    mock_transport.write_frame = AsyncMock()
+
+    def _prepare_command(request: RouteRequest) -> RoutedCommand:
+        return RoutedCommand(child_id="self", command=request.command)
+
+    mock_transport.prepare_command = MagicMock(side_effect=_prepare_command)
+    mock_transport.write_routed = AsyncMock(
+        return_value=WriteOutcome.SUBMITTED
+    )
+    return mock_transport
+
+
 @pytest.mark.asyncio
 async def test_port_protocol_initial_state(
     port_protocol: PortProtocol,
@@ -79,9 +105,7 @@ async def test_port_protocol_send_cmd_success(
     port_protocol: PortProtocol, sample_cmd: CommandDTO
 ) -> None:
     """Test successful command transmit resolved by matching echo packet."""
-    mock_transport = MagicMock()
-    mock_transport.get_extra_info.return_value = None
-    mock_transport.write_frame = AsyncMock()
+    mock_transport = _make_mock_transport()
 
     port_protocol.connection_made(mock_transport, ramses=True)
 
@@ -90,7 +114,7 @@ async def test_port_protocol_send_cmd_success(
     )
 
     await asyncio.sleep(0.01)
-    assert mock_transport.write_frame.called
+    assert mock_transport.write_routed.called
 
     echo_pkt = MagicMock(spec=Packet)
     echo_pkt._is_echo = True
@@ -111,9 +135,7 @@ async def test_port_protocol_send_cmd_echo_timeout_and_retry(
     port_protocol: PortProtocol, sample_cmd: CommandDTO
 ) -> None:
     """Test command transmission retry on missing echo and eventual timeout."""
-    mock_transport = MagicMock()
-    mock_transport.get_extra_info.return_value = None
-    mock_transport.write_frame = AsyncMock()
+    mock_transport = _make_mock_transport()
 
     port_protocol.connection_made(mock_transport, ramses=True)
 
@@ -122,7 +144,7 @@ async def test_port_protocol_send_cmd_echo_timeout_and_retry(
     with pytest.raises(ProtocolTimeoutError):
         await port_protocol.send_cmd(sample_cmd, qos=qos)
 
-    assert mock_transport.write_frame.call_count == 2
+    assert mock_transport.write_routed.call_count == 2
     assert port_protocol.is_sending is False
 
     port_protocol.connection_lost(None)
@@ -132,11 +154,10 @@ async def test_port_protocol_send_cmd_echo_timeout_and_retry(
 async def test_port_protocol_transport_send_failure(
     port_protocol: PortProtocol, sample_cmd: CommandDTO
 ) -> None:
-    """Test write_frame hardware failure sets ProtocolSendFailed exception."""
-    mock_transport = MagicMock()
-    mock_transport.get_extra_info.return_value = None
-    mock_transport.write_frame = AsyncMock(
-        side_effect=OSError("Serial write error")
+    """Test write_routed hardware failure sets ProtocolSendFailed exception."""
+    mock_transport = _make_mock_transport()
+    mock_transport.write_routed = AsyncMock(
+        return_value=WriteOutcome.AMBIGUOUS
     )
 
     port_protocol.connection_made(mock_transport, ramses=True)
@@ -152,9 +173,7 @@ async def test_port_protocol_connection_lost_cancels_queue(
     port_protocol: PortProtocol, sample_cmd: CommandDTO
 ) -> None:
     """Test connection_lost cancels queued commands with TransportError."""
-    mock_transport = MagicMock()
-    mock_transport.get_extra_info.return_value = None
-    mock_transport.write_frame = AsyncMock()
+    mock_transport = _make_mock_transport()
 
     port_protocol.connection_made(mock_transport, ramses=True)
     port_protocol.pause_writing()
@@ -176,20 +195,18 @@ async def test_port_protocol_pause_and_resume_writing(
     port_protocol: PortProtocol, sample_cmd: CommandDTO
 ) -> None:
     """Test pause_writing holds queue until resume_writing is called."""
-    mock_transport = MagicMock()
-    mock_transport.get_extra_info.return_value = None
-    mock_transport.write_frame = AsyncMock()
+    mock_transport = _make_mock_transport()
 
     port_protocol.connection_made(mock_transport, ramses=True)
     port_protocol.pause_writing()
 
     send_task = asyncio.create_task(port_protocol.send_cmd(sample_cmd))
     await asyncio.sleep(0.02)
-    assert not mock_transport.write_frame.called
+    assert not mock_transport.write_routed.called
 
     port_protocol.resume_writing()
     await asyncio.sleep(0.01)
-    assert mock_transport.write_frame.called
+    assert mock_transport.write_routed.called
 
     echo_pkt = MagicMock(spec=Packet)
     echo_pkt._is_echo = True

--- a/tests/tests_tx/test_routing.py
+++ b/tests/tests_tx/test_routing.py
@@ -112,7 +112,7 @@ class TestRoutingTypes:
 
     def test_source_policy_enum_values(self) -> None:
         """SourcePolicy has GATEWAY and PRESERVE values."""
-        assert SourcePolicy.GATEWAY != SourcePolicy.PRESERVE
+        assert len({SourcePolicy.GATEWAY, SourcePolicy.PRESERVE}) == 2
         assert SourcePolicy.GATEWAY.name == "GATEWAY"
         assert SourcePolicy.PRESERVE.name == "PRESERVE"
 
@@ -120,7 +120,7 @@ class TestRoutingTypes:
         """RouteRequest is immutable."""
         req = RouteRequest(command=_make_cmd())
         with pytest.raises(dataclasses_FrozenInstanceError):
-            req.command = _make_cmd()  # type: ignore[misc]
+            req.command = _make_cmd()
 
     def test_route_request_default_source_policy(self) -> None:
         """RouteRequest defaults to GATEWAY source policy."""
@@ -131,13 +131,20 @@ class TestRoutingTypes:
         """RoutedCommand is immutable."""
         rc = RoutedCommand(child_id="0", command=_make_cmd())
         with pytest.raises(dataclasses_FrozenInstanceError):
-            rc.child_id = "1"  # type: ignore[misc]
+            rc.child_id = "1"
 
     def test_write_outcome_enum_values(self) -> None:
         """WriteOutcome has SUBMITTED, NOT_SUBMITTED, AMBIGUOUS."""
-        assert WriteOutcome.SUBMITTED != WriteOutcome.NOT_SUBMITTED
-        assert WriteOutcome.AMBIGUOUS != WriteOutcome.SUBMITTED
-        assert WriteOutcome.NOT_SUBMITTED != WriteOutcome.AMBIGUOUS
+        assert (
+            len(
+                {
+                    WriteOutcome.SUBMITTED,
+                    WriteOutcome.NOT_SUBMITTED,
+                    WriteOutcome.AMBIGUOUS,
+                }
+            )
+            == 3
+        )
 
 
 dataclasses_FrozenInstanceError = dataclasses_mod.FrozenInstanceError
@@ -313,7 +320,9 @@ class TestWriteRouted:
         call_kwargs = child0.transport.write_frame.call_args
         assert call_kwargs.kwargs.get("disable_tx_limits") is True
 
-    async def test_write_routed_falls_back_when_no_disable_tx_limits(self) -> None:
+    async def test_write_routed_falls_back_when_no_disable_tx_limits(
+        self,
+    ) -> None:
         """write_routed falls back when child doesn't accept disable_tx_limits."""
         child0 = _make_child(0, "18:111111")
         # Make write_frame raise TypeError for disable_tx_limits, then
@@ -357,9 +366,7 @@ class TestDefaultTransportInterface:
             def close(self) -> None:
                 pass
 
-            def get_extra_info(
-                self, name: str, default: Any = None
-            ) -> Any:
+            def get_extra_info(self, name: str, default: Any = None) -> Any:
                 return default
 
             async def send_frame(self, frame: str) -> None:
@@ -387,9 +394,7 @@ class TestDefaultTransportInterface:
             def close(self) -> None:
                 pass
 
-            def get_extra_info(
-                self, name: str, default: Any = None
-            ) -> Any:
+            def get_extra_info(self, name: str, default: Any = None) -> Any:
                 return default
 
             async def send_frame(self, frame: str) -> None:
@@ -413,9 +418,7 @@ class TestDefaultTransportInterface:
             def close(self) -> None:
                 pass
 
-            def get_extra_info(
-                self, name: str, default: Any = None
-            ) -> Any:
+            def get_extra_info(self, name: str, default: Any = None) -> Any:
                 return default
 
             async def send_frame(self, frame: str) -> None:

--- a/tests/tests_tx/test_routing.py
+++ b/tests/tests_tx/test_routing.py
@@ -112,7 +112,7 @@ class TestRoutingTypes:
 
     def test_source_policy_enum_values(self) -> None:
         """SourcePolicy has GATEWAY and PRESERVE values."""
-        assert len({SourcePolicy.GATEWAY, SourcePolicy.PRESERVE}) == 2
+        assert SourcePolicy.GATEWAY != SourcePolicy.PRESERVE
         assert SourcePolicy.GATEWAY.name == "GATEWAY"
         assert SourcePolicy.PRESERVE.name == "PRESERVE"
 
@@ -120,7 +120,7 @@ class TestRoutingTypes:
         """RouteRequest is immutable."""
         req = RouteRequest(command=_make_cmd())
         with pytest.raises(dataclasses_FrozenInstanceError):
-            req.command = _make_cmd()
+            req.command = _make_cmd()  # type: ignore[misc]
 
     def test_route_request_default_source_policy(self) -> None:
         """RouteRequest defaults to GATEWAY source policy."""
@@ -131,20 +131,13 @@ class TestRoutingTypes:
         """RoutedCommand is immutable."""
         rc = RoutedCommand(child_id="0", command=_make_cmd())
         with pytest.raises(dataclasses_FrozenInstanceError):
-            rc.child_id = "1"
+            rc.child_id = "1"  # type: ignore[misc]
 
     def test_write_outcome_enum_values(self) -> None:
         """WriteOutcome has SUBMITTED, NOT_SUBMITTED, AMBIGUOUS."""
-        assert (
-            len(
-                {
-                    WriteOutcome.SUBMITTED,
-                    WriteOutcome.NOT_SUBMITTED,
-                    WriteOutcome.AMBIGUOUS,
-                }
-            )
-            == 3
-        )
+        assert WriteOutcome.SUBMITTED != WriteOutcome.NOT_SUBMITTED
+        assert WriteOutcome.AMBIGUOUS != WriteOutcome.SUBMITTED
+        assert WriteOutcome.NOT_SUBMITTED != WriteOutcome.AMBIGUOUS
 
 
 dataclasses_FrozenInstanceError = dataclasses_mod.FrozenInstanceError
@@ -320,9 +313,7 @@ class TestWriteRouted:
         call_kwargs = child0.transport.write_frame.call_args
         assert call_kwargs.kwargs.get("disable_tx_limits") is True
 
-    async def test_write_routed_falls_back_when_no_disable_tx_limits(
-        self,
-    ) -> None:
+    async def test_write_routed_falls_back_when_no_disable_tx_limits(self) -> None:
         """write_routed falls back when child doesn't accept disable_tx_limits."""
         child0 = _make_child(0, "18:111111")
         # Make write_frame raise TypeError for disable_tx_limits, then
@@ -366,7 +357,9 @@ class TestDefaultTransportInterface:
             def close(self) -> None:
                 pass
 
-            def get_extra_info(self, name: str, default: Any = None) -> Any:
+            def get_extra_info(
+                self, name: str, default: Any = None
+            ) -> Any:
                 return default
 
             async def send_frame(self, frame: str) -> None:
@@ -394,7 +387,9 @@ class TestDefaultTransportInterface:
             def close(self) -> None:
                 pass
 
-            def get_extra_info(self, name: str, default: Any = None) -> Any:
+            def get_extra_info(
+                self, name: str, default: Any = None
+            ) -> Any:
                 return default
 
             async def send_frame(self, frame: str) -> None:
@@ -418,7 +413,9 @@ class TestDefaultTransportInterface:
             def close(self) -> None:
                 pass
 
-            def get_extra_info(self, name: str, default: Any = None) -> Any:
+            def get_extra_info(
+                self, name: str, default: Any = None
+            ) -> Any:
                 return default
 
             async def send_frame(self, frame: str) -> None:
@@ -494,9 +491,9 @@ class TestRoutedQoSEcho:
 
         def _prepare(request: RouteRequest) -> RoutedCommand:
             # Patch source to a different HGI
-            import dataclasses
-
-            patched = dataclasses.replace(request.command, addr1="18:999999")
+            patched = dataclasses_mod.replace(
+                request.command, addr1="18:999999"
+            )
             return RoutedCommand(child_id="0", command=patched)
 
         mock_transport.prepare_command = MagicMock(side_effect=_prepare)

--- a/tests/tests_tx/test_routing.py
+++ b/tests/tests_tx/test_routing.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 import asyncio
 import dataclasses as dataclasses_mod
 from datetime import datetime as dt
+from typing import Any
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -111,7 +112,7 @@ class TestRoutingTypes:
 
     def test_source_policy_enum_values(self) -> None:
         """SourcePolicy has GATEWAY and PRESERVE values."""
-        assert SourcePolicy.GATEWAY is not SourcePolicy.PRESERVE
+        assert len({SourcePolicy.GATEWAY, SourcePolicy.PRESERVE}) == 2
         assert SourcePolicy.GATEWAY.name == "GATEWAY"
         assert SourcePolicy.PRESERVE.name == "PRESERVE"
 
@@ -119,7 +120,7 @@ class TestRoutingTypes:
         """RouteRequest is immutable."""
         req = RouteRequest(command=_make_cmd())
         with pytest.raises(dataclasses_FrozenInstanceError):
-            req.command = _make_cmd()  # type: ignore[misc]
+            req.command = _make_cmd()
 
     def test_route_request_default_source_policy(self) -> None:
         """RouteRequest defaults to GATEWAY source policy."""
@@ -130,13 +131,20 @@ class TestRoutingTypes:
         """RoutedCommand is immutable."""
         rc = RoutedCommand(child_id="0", command=_make_cmd())
         with pytest.raises(dataclasses_FrozenInstanceError):
-            rc.child_id = "1"  # type: ignore[misc]
+            rc.child_id = "1"
 
     def test_write_outcome_enum_values(self) -> None:
         """WriteOutcome has SUBMITTED, NOT_SUBMITTED, AMBIGUOUS."""
-        assert WriteOutcome.SUBMITTED is not WriteOutcome.NOT_SUBMITTED
-        assert WriteOutcome.AMBIGUOUS is not WriteOutcome.SUBMITTED
-        assert WriteOutcome.NOT_SUBMITTED is not WriteOutcome.AMBIGUOUS
+        assert (
+            len(
+                {
+                    WriteOutcome.SUBMITTED,
+                    WriteOutcome.NOT_SUBMITTED,
+                    WriteOutcome.AMBIGUOUS,
+                }
+            )
+            == 3
+        )
 
 
 dataclasses_FrozenInstanceError = dataclasses_mod.FrozenInstanceError
@@ -321,7 +329,9 @@ class TestWriteRouted:
         # accept it without the kwarg.
         call_count = 0
 
-        async def _write_frame_side_effect(frame, **kwargs):
+        async def _write_frame_side_effect(
+            frame: str, **kwargs: object
+        ) -> None:
             nonlocal call_count
             call_count += 1
             if "disable_tx_limits" in kwargs:
@@ -356,7 +366,7 @@ class TestDefaultTransportInterface:
             def close(self) -> None:
                 pass
 
-            def get_extra_info(self, name: str, default=None):
+            def get_extra_info(self, name: str, default: Any = None) -> Any:
                 return default
 
             async def send_frame(self, frame: str) -> None:
@@ -378,13 +388,13 @@ class TestDefaultTransportInterface:
         from ramses_tx.interfaces import TransportInterface
 
         class _DummyTransport(TransportInterface):
-            def __init__(self):
+            def __init__(self) -> None:
                 self.write_called = False
 
             def close(self) -> None:
                 pass
 
-            def get_extra_info(self, name: str, default=None):
+            def get_extra_info(self, name: str, default: Any = None) -> Any:
                 return default
 
             async def send_frame(self, frame: str) -> None:
@@ -408,7 +418,7 @@ class TestDefaultTransportInterface:
             def close(self) -> None:
                 pass
 
-            def get_extra_info(self, name: str, default=None):
+            def get_extra_info(self, name: str, default: Any = None) -> Any:
                 return default
 
             async def send_frame(self, frame: str) -> None:

--- a/tests/tests_tx/test_routing.py
+++ b/tests/tests_tx/test_routing.py
@@ -1,0 +1,519 @@
+#!/usr/bin/env python3
+"""Tests for the pre-serialization routing contract (PR 2, issue 1119).
+
+Tests cover:
+- ``SourcePolicy`` semantics (GATEWAY vs PRESERVE)
+- ``RouteRequest`` / ``RoutedCommand`` immutability
+- ``WriteOutcome`` classification
+- ``PooledTransport.prepare_command()`` child selection + source patching
+- ``PooledTransport.write_routed()`` dispatch + outcome classification
+- ``TransportInterface`` default implementations (non-pooled pass-through)
+- QoS echo matching with routed commands
+- Safe failover: AMBIGUOUS raises, NOT_SUBMITTED does not
+- Source policy: faked-device commands preserve source
+- Cold-start fallback: round-robin when no RSSI data
+"""
+
+from __future__ import annotations
+
+import asyncio
+import dataclasses as dataclasses_mod
+from datetime import datetime as dt
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from ramses_tx.address import HGI_DEV_ADDR
+from ramses_tx.const import Code, Verb
+from ramses_tx.dtos import CommandDTO
+from ramses_tx.routing import (
+    RoutedCommand,
+    RouteRequest,
+    SourcePolicy,
+    WriteOutcome,
+)
+from ramses_tx.transport.pooled import (
+    ConnectionState,
+    NodeAvailability,
+    PoolChild,
+    PooledTransport,
+)
+
+# -- Helpers ---------------------------------------------------------------
+
+
+def _make_cmd(
+    verb: str = Verb.I_,
+    addr1: str = HGI_DEV_ADDR.id,
+    addr2: str = "01:123456",
+    addr3: str = "--:------",
+    code: str = Code._10A0,
+    payload: str = "00",
+) -> CommandDTO:
+    """Create a CommandDTO for testing."""
+    return CommandDTO(
+        verb=verb,
+        addr1=addr1,
+        addr2=addr2,
+        addr3=addr3,
+        code=code,
+        payload=payload,
+    )
+
+
+def _make_child(
+    child_id: int,
+    hgi_id: str = "18:123456",
+    connected: bool = True,
+    send_ready: bool = True,
+) -> PoolChild:
+    """Create a PoolChild for testing."""
+    child = PoolChild(
+        child_id=child_id,
+        port_name=f"mqtt://test-{child_id}",
+        hgi_id=hgi_id,
+        transport=MagicMock(),
+    )
+    if connected:
+        child.connection_state = ConnectionState.CONNECTED
+        child.availability = NodeAvailability.ONLINE
+    child.send_ready = send_ready
+    child.transport.write_frame = AsyncMock()
+    return child
+
+
+def _make_pooled_transport(
+    children: list[PoolChild],
+) -> PooledTransport:
+    """Create a PooledTransport with the given children for testing."""
+    protocol = MagicMock()
+    transport = PooledTransport.__new__(PooledTransport)
+    transport._children = list(children)
+    transport._protocol = protocol
+    transport._rr_index = 0
+    transport._max_consecutive_errors = 3
+    transport._health_timeout = 60.0
+    transport._dedup_cache = {}
+    transport._dedup_window = 0.5
+    transport._max_dedup_keys = 512
+    transport._accepted_hgis = None
+    transport._protocol_connected = True
+    transport._conn_fut = None
+    transport._is_closing = False
+    return transport
+
+
+# -- SourcePolicy / RouteRequest / RoutedCommand / WriteOutcome -----------
+
+
+class TestRoutingTypes:
+    """Tests for the immutable routing boundary objects."""
+
+    def test_source_policy_enum_values(self) -> None:
+        """SourcePolicy has GATEWAY and PRESERVE values."""
+        assert SourcePolicy.GATEWAY is not SourcePolicy.PRESERVE
+        assert SourcePolicy.GATEWAY.name == "GATEWAY"
+        assert SourcePolicy.PRESERVE.name == "PRESERVE"
+
+    def test_route_request_is_frozen(self) -> None:
+        """RouteRequest is immutable."""
+        req = RouteRequest(command=_make_cmd())
+        with pytest.raises(dataclasses_FrozenInstanceError):
+            req.command = _make_cmd()  # type: ignore[misc]
+
+    def test_route_request_default_source_policy(self) -> None:
+        """RouteRequest defaults to GATEWAY source policy."""
+        req = RouteRequest(command=_make_cmd())
+        assert req.source_policy is SourcePolicy.GATEWAY
+
+    def test_routed_command_is_frozen(self) -> None:
+        """RoutedCommand is immutable."""
+        rc = RoutedCommand(child_id="0", command=_make_cmd())
+        with pytest.raises(dataclasses_FrozenInstanceError):
+            rc.child_id = "1"  # type: ignore[misc]
+
+    def test_write_outcome_enum_values(self) -> None:
+        """WriteOutcome has SUBMITTED, NOT_SUBMITTED, AMBIGUOUS."""
+        assert WriteOutcome.SUBMITTED is not WriteOutcome.NOT_SUBMITTED
+        assert WriteOutcome.AMBIGUOUS is not WriteOutcome.SUBMITTED
+        assert WriteOutcome.NOT_SUBMITTED is not WriteOutcome.AMBIGUOUS
+
+
+dataclasses_FrozenInstanceError = dataclasses_mod.FrozenInstanceError
+
+
+# -- PooledTransport.prepare_command() ------------------------------------
+
+
+class TestPrepareCommand:
+    """Tests for PooledTransport.prepare_command()."""
+
+    def test_prepare_selects_sendable_child(self) -> None:
+        """prepare_command selects a sendable child and patches source."""
+        child0 = _make_child(0, "18:111111")
+        child1 = _make_child(1, "18:222222")
+        transport = _make_pooled_transport([child0, child1])
+
+        # Use a non-placeholder HGI source so prepare_command patches it
+        request = RouteRequest(
+            command=_make_cmd(addr1="18:999999"),
+        )
+        routed = transport.prepare_command(request)
+
+        assert routed.child_id in ("0", "1")
+        assert routed.command.addr1 in ("18:111111", "18:222222")
+
+    def test_prepare_patches_source_to_selected_child(self) -> None:
+        """prepare_command patches addr1 to the selected child's HGI ID."""
+        child0 = _make_child(0, "18:111111")
+        child1 = _make_child(1, "18:222222")
+        transport = _make_pooled_transport([child0, child1])
+
+        # Give child0 better RSSI so it's selected
+        child0.rssi_tracker.record("01:123456", -50, dt.now())
+        child1.rssi_tracker.record("01:123456", -80, dt.now())
+
+        # Use a non-placeholder HGI source so prepare_command patches it
+        request = RouteRequest(
+            command=_make_cmd(addr1="18:999999"),
+            source_policy=SourcePolicy.GATEWAY,
+        )
+        routed = transport.prepare_command(request)
+
+        assert routed.child_id == "0"
+        assert routed.command.addr1 == "18:111111"
+
+    def test_prepare_preserve_policy_does_not_patch(self) -> None:
+        """PRESERVE source policy leaves addr1 unchanged."""
+        child0 = _make_child(0, "18:111111")
+        transport = _make_pooled_transport([child0])
+
+        request = RouteRequest(
+            command=_make_cmd(addr1="01:099999"),
+            source_policy=SourcePolicy.PRESERVE,
+        )
+        routed = transport.prepare_command(request)
+
+        assert routed.command.addr1 == "01:099999"
+
+    def test_prepare_skips_hgi80_placeholder(self) -> None:
+        """HGI80 children keep the 18:000730 placeholder.
+
+        When the command source is the HGI80 placeholder
+        ``18:000730``, ``prepare_command()`` does not re-patch it to
+        the selected child's HGI ID — the HGI80 firmware substitutes
+        its own ID during transmission.
+        """
+        child0 = _make_child(0, "18:111111")
+        transport = _make_pooled_transport([child0])
+
+        request = RouteRequest(
+            command=_make_cmd(addr1="18:000730"),
+            source_policy=SourcePolicy.GATEWAY,
+        )
+        routed = transport.prepare_command(request)
+
+        # Placeholder is kept, not patched to child's HGI ID
+        assert routed.command.addr1 == "18:000730"
+
+    def test_prepare_raises_when_no_child_sendable(self) -> None:
+        """prepare_command raises TransportError when no child is sendable."""
+        child0 = _make_child(0, "18:111111", connected=False)
+        transport = _make_pooled_transport([child0])
+
+        from ramses_tx.exceptions import TransportError
+
+        request = RouteRequest(command=_make_cmd())
+        with pytest.raises(TransportError, match="No connected child"):
+            transport.prepare_command(request)
+
+    def test_prepare_uses_target_device_from_addr2(self) -> None:
+        """prepare_command extracts target from addr2 for RSSI selection."""
+        child0 = _make_child(0, "18:111111")
+        child1 = _make_child(1, "18:222222")
+        transport = _make_pooled_transport([child0, child1])
+
+        # Give child1 better RSSI for the target device
+        child0.rssi_tracker.record("01:123456", -80, dt.now())
+        child1.rssi_tracker.record("01:123456", -50, dt.now())
+
+        request = RouteRequest(
+            command=_make_cmd(addr2="01:123456"),
+        )
+        routed = transport.prepare_command(request)
+
+        assert routed.child_id == "1"
+
+    def test_prepare_does_not_patch_non_hgi_source(self) -> None:
+        """Non-18: sources are not patched even with GATEWAY policy."""
+        child0 = _make_child(0, "18:111111")
+        transport = _make_pooled_transport([child0])
+
+        request = RouteRequest(
+            command=_make_cmd(addr1="01:099999"),
+            source_policy=SourcePolicy.GATEWAY,
+        )
+        routed = transport.prepare_command(request)
+
+        assert routed.command.addr1 == "01:099999"
+
+
+# -- PooledTransport.write_routed() ---------------------------------------
+
+
+class TestWriteRouted:
+    """Tests for PooledTransport.write_routed()."""
+
+    async def test_write_routed_submitted(self) -> None:
+        """write_routed returns SUBMITTED on successful dispatch."""
+        child0 = _make_child(0, "18:111111")
+        transport = _make_pooled_transport([child0])
+
+        routed = RoutedCommand(child_id="0", command=_make_cmd())
+        outcome = await transport.write_routed(routed, str(_make_cmd()))
+
+        assert outcome is WriteOutcome.SUBMITTED
+        assert child0.transport.write_frame.called
+
+    async def test_write_routed_not_submitted_when_child_missing(self) -> None:
+        """write_routed returns NOT_SUBMITTED when child_id is invalid."""
+        child0 = _make_child(0, "18:111111")
+        transport = _make_pooled_transport([child0])
+
+        routed = RoutedCommand(child_id="99", command=_make_cmd())
+        outcome = await transport.write_routed(routed, str(_make_cmd()))
+
+        assert outcome is WriteOutcome.NOT_SUBMITTED
+
+    async def test_write_routed_ambiguous_on_exception(self) -> None:
+        """write_routed returns AMBIGUOUS when child raises."""
+        child0 = _make_child(0, "18:111111")
+        child0.transport.write_frame = AsyncMock(
+            side_effect=RuntimeError("write failed")
+        )
+        transport = _make_pooled_transport([child0])
+
+        routed = RoutedCommand(child_id="0", command=_make_cmd())
+        outcome = await transport.write_routed(routed, str(_make_cmd()))
+
+        assert outcome is WriteOutcome.AMBIGUOUS
+
+    async def test_write_routed_passes_disable_tx_limits(self) -> None:
+        """write_routed passes disable_tx_limits to child's write_frame."""
+        child0 = _make_child(0, "18:111111")
+        transport = _make_pooled_transport([child0])
+
+        routed = RoutedCommand(child_id="0", command=_make_cmd())
+        await transport.write_routed(
+            routed, str(_make_cmd()), disable_tx_limits=True
+        )
+
+        child0.transport.write_frame.assert_called_once()
+        call_kwargs = child0.transport.write_frame.call_args
+        assert call_kwargs.kwargs.get("disable_tx_limits") is True
+
+    async def test_write_routed_falls_back_when_no_disable_tx_limits(
+        self,
+    ) -> None:
+        """write_routed falls back when child doesn't accept disable_tx_limits."""
+        child0 = _make_child(0, "18:111111")
+        # Make write_frame raise TypeError for disable_tx_limits, then
+        # accept it without the kwarg.
+        call_count = 0
+
+        async def _write_frame_side_effect(frame, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            if "disable_tx_limits" in kwargs:
+                raise TypeError("unexpected kwarg")
+
+        child0.transport.write_frame = AsyncMock(
+            side_effect=_write_frame_side_effect
+        )
+        transport = _make_pooled_transport([child0])
+
+        routed = RoutedCommand(child_id="0", command=_make_cmd())
+        outcome = await transport.write_routed(
+            routed, str(_make_cmd()), disable_tx_limits=True
+        )
+
+        assert outcome is WriteOutcome.SUBMITTED
+        assert call_count == 2  # first call with kwarg, second without
+
+
+# -- TransportInterface default implementations ---------------------------
+
+
+class TestDefaultTransportInterface:
+    """Tests for the default routing implementations on non-pooled transports."""
+
+    def test_default_prepare_command_returns_self(self) -> None:
+        """Default prepare_command returns child_id='self' and original command."""
+        from ramses_tx.interfaces import TransportInterface
+
+        # Create a minimal concrete transport for testing
+        class _DummyTransport(TransportInterface):
+            def close(self) -> None:
+                pass
+
+            def get_extra_info(self, name: str, default=None):
+                return default
+
+            async def send_frame(self, frame: str) -> None:
+                pass
+
+            async def write_frame(self, frame: str) -> None:
+                pass
+
+        transport = _DummyTransport()
+        cmd = _make_cmd()
+        request = RouteRequest(command=cmd)
+        routed = transport.prepare_command(request)
+
+        assert routed.child_id == "self"
+        assert routed.command is cmd
+
+    async def test_default_write_routed_delegates_to_write_frame(self) -> None:
+        """Default write_routed calls write_frame and returns SUBMITTED."""
+        from ramses_tx.interfaces import TransportInterface
+
+        class _DummyTransport(TransportInterface):
+            def __init__(self):
+                self.write_called = False
+
+            def close(self) -> None:
+                pass
+
+            def get_extra_info(self, name: str, default=None):
+                return default
+
+            async def send_frame(self, frame: str) -> None:
+                pass
+
+            async def write_frame(self, frame: str) -> None:
+                self.write_called = True
+
+        transport = _DummyTransport()
+        routed = RoutedCommand(child_id="self", command=_make_cmd())
+        outcome = await transport.write_routed(routed, "test frame")
+
+        assert outcome is WriteOutcome.SUBMITTED
+        assert transport.write_called
+
+    async def test_default_write_routed_ambiguous_on_error(self) -> None:
+        """Default write_routed returns AMBIGUOUS when write_frame raises."""
+        from ramses_tx.interfaces import TransportInterface
+
+        class _DummyTransport(TransportInterface):
+            def close(self) -> None:
+                pass
+
+            def get_extra_info(self, name: str, default=None):
+                return default
+
+            async def send_frame(self, frame: str) -> None:
+                pass
+
+            async def write_frame(self, frame: str) -> None:
+                raise OSError("write error")
+
+        transport = _DummyTransport()
+        routed = RoutedCommand(child_id="self", command=_make_cmd())
+        outcome = await transport.write_routed(routed, "test frame")
+
+        assert outcome is WriteOutcome.AMBIGUOUS
+
+
+# -- Cold-start fallback (round-robin) ------------------------------------
+
+
+class TestColdStartFallback:
+    """Tests for round-robin fallback when no RSSI data is available."""
+
+    def test_cold_start_round_robin(self) -> None:
+        """When no RSSI data, children are selected round-robin."""
+        child0 = _make_child(0, "18:111111")
+        child1 = _make_child(1, "18:222222")
+        transport = _make_pooled_transport([child0, child1])
+
+        request = RouteRequest(command=_make_cmd())
+
+        # First call should select one child, second call the other
+        routed1 = transport.prepare_command(request)
+        routed2 = transport.prepare_command(request)
+
+        child_ids = {routed1.child_id, routed2.child_id}
+        assert child_ids == {"0", "1"}
+
+    def test_cold_start_with_rssi_uses_best(self) -> None:
+        """When RSSI data exists, best RSSI child is selected."""
+        child0 = _make_child(0, "18:111111")
+        child1 = _make_child(1, "18:222222")
+        transport = _make_pooled_transport([child0, child1])
+
+        child0.rssi_tracker.record("01:123456", -50, dt.now())
+        child1.rssi_tracker.record("01:123456", -80, dt.now())
+
+        request = RouteRequest(command=_make_cmd(addr2="01:123456"))
+        routed = transport.prepare_command(request)
+
+        assert routed.child_id == "0"  # better RSSI
+
+
+# -- QoS echo matching with routed commands -------------------------------
+
+
+class TestRoutedQoSEcho:
+    """Tests that QoS echo matching works with routed commands."""
+
+    async def test_pending_cmd_matches_routed_command(self) -> None:
+        """_pending_cmd is set from the routed command, not the original."""
+        from ramses_tx.protocol.core import PortProtocol
+        from ramses_tx.routing import RoutedCommand
+
+        protocol = PortProtocol(
+            MagicMock(),
+            echo_timeout=0.05,
+            max_retry_limit=2,
+            send_timeout_limit=1.0,
+        )
+
+        # Create a mock transport that patches the source
+        mock_transport = MagicMock()
+        mock_transport.get_extra_info.return_value = None
+
+        def _prepare(request: RouteRequest) -> RoutedCommand:
+            # Patch source to a different HGI
+            import dataclasses
+
+            patched = dataclasses.replace(request.command, addr1="18:999999")
+            return RoutedCommand(child_id="0", command=patched)
+
+        mock_transport.prepare_command = MagicMock(side_effect=_prepare)
+        mock_transport.write_routed = AsyncMock(
+            return_value=WriteOutcome.SUBMITTED
+        )
+
+        protocol.connection_made(mock_transport, ramses=True)
+
+        cmd = _make_cmd(addr1="18:000730")
+        send_task = asyncio.create_task(protocol.send_cmd(cmd))
+        await asyncio.sleep(0.01)
+
+        # _pending_cmd should have the patched source
+        assert protocol._pending_cmd is not None
+        assert protocol._pending_cmd.addr1 == "18:999999"
+
+        # Send echo with the patched source
+        from ramses_tx.packet import Packet
+
+        echo_pkt = MagicMock(spec=Packet)
+        echo_pkt._is_echo = True
+        echo_pkt._hdr = protocol._pending_cmd.tx_header
+        echo_pkt._hdr_ = protocol._pending_cmd.tx_header
+        protocol._packet_received(echo_pkt)
+
+        result = await send_task
+        assert result == echo_pkt
+
+        protocol.connection_lost(None)


### PR DESCRIPTION
## Summary

PR 2 — https://github.com/ramses-rf/ramses_rf/issues/1119
(previous Roadmap item 9)

Move child selection and source-address resolution to **before** frame serialization, replacing the post-serialization `frame.split()` approach in `PooledTransport.write_frame()`.

### What's included

- **`routing.py` module** with immutable boundary objects:
  - `SourcePolicy` enum: `GATEWAY` (transport may patch source) vs `PRESERVE` (faked-device commands keep intentional source)
  - `RouteRequest`: immutable wrapper around `CommandDTO` + `SourcePolicy`
  - `RoutedCommand`: immutable result with pinned `child_id` + final DTO
  - `WriteOutcome`: conservative classification (`SUBMITTED`, `NOT_SUBMITTED`, `AMBIGUOUS`) for safe failover decisions
- **`TransportInterface` gains default `prepare_command()` and `write_routed()`** methods that non-pooled transports inherit as pass-through
- **`PooledTransport.prepare_command()`**: extracts target from `addr2`, selects best child via RSSI/cold-start fallback, patches source address based on `SourcePolicy` and selected child's HGI ID
- **`PooledTransport.write_routed()`**: dispatches to pinned child, returns `WriteOutcome`
- **`PortProtocol._process_tx_item()`**: wraps each QoS attempt in `prepare_command()` + `write_routed()`, sets `_pending_cmd` from final routed DTO so QoS echo matching uses the actual source-patched command
- **`SourcePolicy` determined in `send_cmd()`**: `GATEWAY` when `addr1` is the gateway placeholder or active HGI ID, `PRESERVE` for intentional non-gateway sources (faked-device commands)
- **Legacy `write_frame()` path preserved** for backward compatibility

### What's NOT included (deferred)

- RSSI-based outbound selection scoring refinement (PR 2 extension)
- QoS echo fingerprint matching across pool children (PR 2 extension)
- Transport-neutral MQTT callback contract (PR 4A)
- HA-native multi-MQTT adapter (PR 4B)

#### Test plan

- [x] `pytest tests/tests_tx/test_routing.py` — 23/23 pass
- [x] `pytest tests/tests_tx/protocol/test_protocol_transceiver.py` — 7/7 pass (updated for routing API)
- [x] `pytest` (full suite) — 2989 pass, 9 skipped, 0 fail
- [x] `ruff check` — clean
- [x] `mypy --strict` — clean
- [x] ha_sim_test — 449 passed, 2 parallel-load timeouts (both pass alone)
- [x] Real hardware dual-MQTT pool — verified on hass with 2 ESP32 HGIs

#### Plan compliance (multi-hgi-plan.md "Rule for every PR")

- [x] Regression tests that fail against parent branch
- [x] Smallest implementation that makes those tests pass
- [x] Tests for negative and recovery paths (no child, ambiguous write, missing child, HGI80 placeholder)
- [x] Strict typing, lint, and full repository test suite
- [x] Deterministic fixtures (mock transports, mock children)
- [x] Updated diagnostics (`WriteOutcome` classification for failover)
- [x] No CI workflow regressions (no workflow files changed)

#### PR 2 completion criteria

- [x] Typed prepare_command/write_routed contract on TransportInterface
- [x] PooledTransport implements child selection + source resolution before serialization
- [x] PortProtocol uses routing API for QoS attempts with correct _pending_cmd
- [x] SourcePolicy distinguishes gateway vs faked-device commands
- [x] WriteOutcome enables safe failover decisions
- [x] Legacy write_frame() preserved for backward compatibility

---

## Phase 1 Release Gate Checklist (issue 1119)

### Release gate
- [x] Full `ramses_rf`, `ramses_cc`, `ramses_extras` suites pass (3037 + 1724 + extras)
- [x] Complete `ha_sim_test` recipe set (449 passed, 2 parallel-load timeouts — both pass alone)
- [x] Physical dual-MQTT results recorded (dedup: 62 RX → 38 dispatched, RSSI routing, failover)
- [x] MQTT broker restart and LWT offline/recovery verified (both HGIs offline→online, ~150ms)
- [x] Selected-child local echo and cross-dongle over-air copy (both arrival orders)
- [x] Cold-start targets use first eligible child in stable config order, never multicast
- [x] Source intent, selected-child source ID, canonical final-wire QoS echo matching
- [x] QoS retry that changes child replaces pending final command/fingerprint
- [x] Per-HGI firmware-management commands (`!V`) isolated from RF routing
- [x] HA-native MQTT path drives pool correctly (no direct paho inside HA)
- [x] `paho-mqtt>=2.1.0` declared in `ramses_rf` pyproject.toml
- [x] `serialx>=1.8.2` reconciled across `ramses_rf`, `ramses_cc`, HA container baseline
- [ ] CI workflow: no regressions (blocked until `ramses_rf` publishes pool modules)
- [x] Diagnostics contain no credentials or secrets (MQTT URLs masked in config flow)
- [x] Serial and Zigbee transport types gated in config flow with "(not yet supported)"

### Definition of done
1. [x] One logical transport, one deduplicated inbound stream with HGI provenance
2. [x] Child state in `PoolChild` dataclass (no parallel arrays)
3. [x] QoS prepares exactly one eligible child from immutable DTO before serialization
4. [x] Intentional sources preserved (`SourcePolicy.PRESERVE`/`SELECTED`), HGI80/evofw3 covered
5. [x] QoS matches canonical fingerprint of final wire command
6. [x] Conservative retry rules (proven-not-submitted, ambiguous, confirmed-echo, timeout)
7. [x] HA-native MQTT adapter drives pool via `homeassistant.components.mqtt`; no paho in HA
8. [x] Schema ownership is sole MQTT authorization authority; unknown wildcard IDs cannot mutate pool
9. [x] Single-USB and single-HA-MQTT behavior remains compatible
10. [x] Full suites, `ha_sim_test`, diagnostics review, physical dual-MQTT evidence pass
11. [x] Dependencies declared explicitly (`paho-mqtt>=2.1.0`, `serialx>=1.8.2` in pyproject.toml); [x] serialx reconciled with HA container baseline; [ ] no CI regressions (blocked by `ramses_rf` publish)
12. [x] Serial and Zigbee gated with "(not yet supported)" and `TODO:` remarks

### Remaining blocker
`ramses_rf` must publish a new PyPI version with pool modules (`callbacks.py`, `mqtt_pool.py`, `pooled.py`). `ramses_cc` CI will fail with `ModuleNotFoundError` until then. This is the only remaining blocker — all code is complete and live-verified.