### PR TITLE
feat(transport): PR 4A — transport-neutral MQTT callback contract

### DIFF
--- a/src/ramses_rf/devices/dev_base.py
+++ b/src/ramses_rf/devices/dev_base.py
@@ -171,6 +171,10 @@ class DeviceBase(Entity):
         ``None`` if the gateway has no RSSI tracker (e.g. during
         tests without a real gateway).
 
+        For pooled transports, gathers RSSI trackers from all connected
+        pool children so that ``best_rssi`` reflects the strongest signal
+        across all HGIs, not just the primary.
+
         :return: Communication quality snapshot, or ``None``.
         :rtype: CommunicationQuality | None
         """
@@ -180,7 +184,18 @@ class DeviceBase(Entity):
         tracker = getattr(gwy, "_rssi_tracker", None)
         if tracker is None:
             return None
-        return compute_quality(str(self.id), [tracker])
+        # Gather trackers from all pool children if the transport is pooled.
+        # The pooled transport exposes ``pool_rssi_trackers`` via
+        # get_extra_info, returning a list of RssiTracker objects for each
+        # connected child HGI.
+        trackers = [tracker]
+        engine = getattr(gwy, "_engine", None)
+        transport = getattr(engine, "_transport", None) if engine else None
+        if transport is not None:
+            pool_trackers = transport.get_extra_info("pool_rssi_trackers")
+            if pool_trackers:
+                trackers = pool_trackers
+        return compute_quality(str(self.id), trackers)
 
     def set_strategy(self, strategy: HvacStrategy) -> None:
         """Set the HVAC strategy for this device.

--- a/src/ramses_tx/protocol/base.py
+++ b/src/ramses_tx/protocol/base.py
@@ -258,6 +258,11 @@ class _BaseProtocol(ProtocolInterface, asyncio.Protocol):
                 task.cancel()
         self._handler_tasks.clear()
 
+        # Reset connection-scoped state so connection_made() can run
+        # cleanly on reconnect (e.g. MQTT broker reconnect, issue 1119)
+        self._active_hgi = None
+        self._is_evofw3 = None
+
         self._wait_connection_made = self._loop.create_future()
         if error:
             self._wait_connection_lost.set_exception(error)
@@ -583,7 +588,13 @@ class _DeviceIdFilterMixin(_BaseProtocol):
         when the real ID arrives, and the hgi_id property reads it from
         there.  See issue 1002.
         """
-        assert self._active_hgi is None  # should only be called once
+        if self._active_hgi is not None and self._active_hgi != device_id:
+            _LOGGER.warning(
+                "Active gateway already set to %s, overwriting with %s "
+                "(connection_made called twice without connection_lost)",
+                self._active_hgi,
+                device_id,
+            )
 
         # MQTT bridges: HGI ID not known yet (ramses_esp hasn't sent
         # its "online" LWT message).  Defer the check — the transport

--- a/src/ramses_tx/transport/callbacks.py
+++ b/src/ramses_tx/transport/callbacks.py
@@ -1,0 +1,162 @@
+#!/usr/bin/env python3
+"""RAMSES RF - Transport-neutral callback contracts for pool children.
+
+Defines the inbound/outbound callback interfaces that bridge an
+external MQTT client (e.g. Home Assistant's shared MQTT connection)
+to :class:`~ramses_tx.transport.pooled.PooledTransport` without
+creating a per-child transport or TCP connection.
+
+These protocols are HA-import-free.  PR 4B implements them in
+``ramses_cc`` using ``homeassistant.components.mqtt``.
+
+Inbound events (``MqttPoolInbound``):
+
+- ``on_child_online`` — LWT online or first packet from a configured
+  child.
+- ``on_child_offline`` — LWT offline (definitive) or transient broker
+  issue (non-definitive).
+- ``on_child_recovering`` — child is coming back after a transient
+  outage.
+- ``on_child_identity`` — HGI identity confirmed (e.g. from puzzle
+  response or topic inference).
+- ``on_child_packet`` — a parsed packet from the child, carrying
+  topic-derived ``ingress_hgi_id``.
+- ``on_broker_connected`` / ``on_broker_disconnected`` — broker-level
+  state affecting all MQTT children.
+
+Outbound (``MqttPoolOutbound``):
+
+- ``publish_frame`` — publish a serialized frame to a specific
+  child's TX topic through the shared MQTT connection.
+
+Discovery (``MqttDiscoveryCallback``):
+
+- ``on_unknown_hgi`` — an unknown HGI was observed on the wildcard
+  topic.  Does not create a ``PoolChild``.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Protocol, runtime_checkable
+
+if TYPE_CHECKING:
+    from ..packet import Packet
+    from ..typing import DeviceIdT
+
+
+@runtime_checkable
+class MqttPoolOutbound(Protocol):
+    """Outbound callback for publishing frames to specific children.
+
+    Implemented by the HA-native MQTT bridge (PR 4B).  The pool
+    calls this to publish a frame to a specific child's TX topic
+    through the shared MQTT connection — no per-child transport
+    or TCP connection is created.
+    """
+
+    async def publish_frame(self, child_id: str, frame: str) -> None:
+        """Publish ``frame`` to the child's TX topic.
+
+        :param child_id: The configured logical child ID (HGI ID).
+        :param frame: The serialized RAMSES frame string.
+        """
+
+
+@runtime_checkable
+class MqttDiscoveryCallback(Protocol):
+    """Discovery callback for unknown HGI IDs.
+
+    Implemented by the coordinator or discovery layer to receive
+    notifications about unknown HGIs observed on the wildcard
+    topic.  Does **not** create a ``PoolChild``.
+    """
+
+    def on_unknown_hgi(
+        self,
+        hgi_id: DeviceIdT,
+        *,
+        topic: str | None = None,
+    ) -> None:
+        """Report an unknown HGI observed on the wildcard topic.
+
+        :param hgi_id: The unknown HGI device ID.
+        :param topic: The MQTT topic where it was observed.
+        """
+
+
+@runtime_checkable
+class MqttPoolInbound(Protocol):
+    """Inbound callback contract for MQTT-driven pool children.
+
+    Implemented by the pool adapter (see
+    :class:`~ramses_tx.transport.mqtt_pool.MqttCallbackPoolAdapter`).
+    The HA-native MQTT bridge (PR 4B) calls these methods to
+    deliver events from a shared MQTT connection.
+    """
+
+    def on_child_online(
+        self,
+        child_id: str,
+        *,
+        hgi_id: DeviceIdT | None = None,
+    ) -> None:
+        """Mark a configured child as online.
+
+        Called when an LWT ``online`` message or the first packet
+        from the child is received.
+
+        :param child_id: The configured logical child ID (HGI ID).
+        :param hgi_id: Optional confirmed HGI identity.
+        """
+
+    def on_child_offline(
+        self,
+        child_id: str,
+        *,
+        definitive: bool = True,
+    ) -> None:
+        """Mark a child as offline.
+
+        :param child_id: The configured logical child ID.
+        :param definitive: ``True`` for LWT offline (node is down),
+            ``False`` for transient broker issues.
+        """
+
+    def on_child_recovering(self, child_id: str) -> None:
+        """Signal that a child is recovering after a transient outage.
+
+        :param child_id: The configured logical child ID.
+        """
+
+    def on_child_identity(
+        self,
+        child_id: str,
+        hgi_id: DeviceIdT,
+    ) -> None:
+        """Confirm the child's HGI identity.
+
+        :param child_id: The configured logical child ID.
+        :param hgi_id: The confirmed HGI device ID.
+        """
+
+    def on_child_packet(
+        self,
+        child_id: str,
+        packet: Packet,
+        *,
+        ingress_hgi_id: DeviceIdT | None = None,
+    ) -> None:
+        """Process a packet received from the child.
+
+        :param child_id: The configured logical child ID.
+        :param packet: The parsed packet.
+        :param ingress_hgi_id: Optional HGI identity extracted
+            from the MQTT topic.  When provided, overrides the
+            child record's HGI for ingress provenance.
+        """
+
+    def on_broker_connected(self) -> None:
+        """Signal that the MQTT broker connection is established."""
+
+    def on_broker_disconnected(self) -> None:
+        """Signal that the MQTT broker connection is lost."""

--- a/src/ramses_tx/transport/mqtt_pool.py
+++ b/src/ramses_tx/transport/mqtt_pool.py
@@ -1,0 +1,299 @@
+#!/usr/bin/env python3
+"""RAMSES RF - MQTT callback pool adapter.
+
+Bridges the transport-neutral MQTT callback contract
+(:mod:`ramses_tx.transport.callbacks`) to a
+:class:`~ramses_tx.transport.pooled.PooledTransport`.
+
+The adapter pre-creates logical children from configured HGI IDs
+and maps callback availability events into the pool's child
+registry without creating a per-child transport or TCP connection.
+Outbound frames for callback-driven children are published through
+an :class:`~ramses_tx.transport.callbacks.MqttPoolOutbound`
+publisher.
+
+This module is HA-import-free.  PR 4B implements the
+:class:`~ramses_tx.transport.callbacks.MqttPoolOutbound` and
+:class:`~ramses_tx.transport.callbacks.MqttPoolInbound` interfaces
+in ``ramses_cc`` using ``homeassistant.components.mqtt``.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import logging
+
+from ..helpers import dt_now
+from ..packet import Packet
+from ..typing import DeviceIdT
+from .callbacks import MqttDiscoveryCallback, MqttPoolOutbound
+from .pooled import (
+    ConnectionState,
+    NodeAvailability,
+    PoolChild,
+    PooledTransport,
+)
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class MqttCallbackPoolAdapter:
+    """Bridge MQTT callbacks to a :class:`PooledTransport`.
+
+    Pre-creates logical children from configured HGI IDs and maps
+    callback availability events into the pool's child registry.
+    Uses an :class:`MqttPoolOutbound` publisher for outbound frames
+    so no per-child transport or TCP connection is created.
+
+    This adapter implements the inbound side of the callback
+    contract.  The HA-native MQTT bridge (PR 4B) calls these
+    methods to deliver events from a shared MQTT connection.
+
+    :param pool: The pooled transport to bridge callbacks into.
+    :param configured_hgi_ids: List of configured HGI IDs for
+        pre-created logical children.
+    :param outbound: The outbound publisher for frame delivery.
+    :param discovery_callback: Optional callback for unknown HGIs
+        observed on the wildcard topic.
+    """
+
+    def __init__(
+        self,
+        pool: PooledTransport,
+        configured_hgi_ids: list[str],
+        outbound: MqttPoolOutbound,
+        *,
+        discovery_callback: MqttDiscoveryCallback | None = None,
+    ) -> None:
+        """Initialise the callback pool adapter."""
+        self._pool = pool
+        self._outbound = outbound
+        self._discovery_callback = discovery_callback
+        self._hgi_to_child: dict[str, int] = {}
+
+        # Wire the outbound publisher into the pool.
+        pool.set_outbound_publisher(outbound)
+
+        # Pre-create children in the pool for each configured HGI.
+        # The pool must have enough slots (transports list entries).
+        for i, hgi_id in enumerate(configured_hgi_ids):
+            if i >= len(pool._children):
+                break
+            self._hgi_to_child[hgi_id] = i
+            child = pool._child_by_id(i)
+            child.hgi_id = DeviceIdT(hgi_id)
+            child.callback_driven = True
+            _LOGGER.debug(
+                "MqttCallbackPool: pre-created child %d for HGI %s",
+                i,
+                hgi_id,
+            )
+
+    def _lookup(self, child_id: str) -> PoolChild | None:
+        """Look up a child by configured HGI ID.
+
+        :param child_id: The configured logical child ID (HGI ID).
+        :returns: The matching PoolChild, or ``None`` if not found.
+        """
+        idx = self._hgi_to_child.get(child_id)
+        if idx is None:
+            return None
+        return self._pool._child_by_id(idx)
+
+    # -- Inbound callback contract ---------------------------------------
+
+    def on_child_online(
+        self,
+        child_id: str,
+        *,
+        hgi_id: DeviceIdT | None = None,
+    ) -> None:
+        """Mark a configured child as online.
+
+        Marks the child as connected and online.  If this is the
+        first connected child, notifies the real protocol.
+
+        :param child_id: The configured logical child ID (HGI ID).
+        :param hgi_id: Optional confirmed HGI identity.
+        """
+        child = self._lookup(child_id)
+        if child is None:
+            _LOGGER.warning(
+                "MqttCallbackPool: online event for unknown child %s",
+                child_id,
+            )
+            return
+
+        child.connection_state = ConnectionState.CONNECTED
+        child.availability = NodeAvailability.ONLINE
+        child.send_ready = True
+        child.last_pkt_time = dt_now()
+        if hgi_id is not None and child.hgi_id is None:
+            child.hgi_id = hgi_id
+
+        # Notify the real protocol if this is the first connection.
+        if not self._pool._protocol_connected:
+            self._pool._protocol_connected = True
+            self._pool._protocol.connection_made(self._pool, ramses=True)
+        # Resolve the connection future if waiting.
+        if (
+            self._pool._conn_fut is not None
+            and not self._pool._conn_fut.done()
+        ):
+            self._pool._conn_fut.set_result(self._pool)
+
+        _LOGGER.info(
+            "MqttCallbackPool: child %s online (HGI=%s), %d/%d connected",
+            child_id,
+            child.hgi_id,
+            len(self._pool._connected_children),
+            len(self._pool._children),
+        )
+
+    def on_child_offline(
+        self,
+        child_id: str,
+        *,
+        definitive: bool = True,
+    ) -> None:
+        """Mark a child as offline.
+
+        For definitive offline (LWT), marks the child as
+        disconnected and quarantines RSSI evidence.  For transient
+        broker issues, marks the child as stale.
+
+        :param child_id: The configured logical child ID.
+        :param definitive: ``True`` for LWT offline (node is down),
+            ``False`` for transient broker issues.
+        """
+        child = self._lookup(child_id)
+        if child is None:
+            _LOGGER.warning(
+                "MqttCallbackPool: offline event for unknown child %s",
+                child_id,
+            )
+            return
+
+        if definitive:
+            # LWT offline is definitive — clear RSSI and mark offline.
+            child.mark_disconnected()
+        else:
+            # Transient broker issue — mark stale but keep connected.
+            child.availability = NodeAvailability.STALE
+
+        _LOGGER.info(
+            "MqttCallbackPool: child %s offline (definitive=%s)",
+            child_id,
+            definitive,
+        )
+
+        # If no children are connected, notify the real protocol.
+        if not self._pool._connected_children and not self._pool._closing:
+            self._pool._protocol_connected = False
+            with contextlib.suppress(RuntimeError):
+                self._pool._loop.call_soon_threadsafe(
+                    self._pool._protocol.connection_lost, None
+                )
+
+    def on_child_recovering(self, child_id: str) -> None:
+        """Signal that a child is recovering after a transient outage.
+
+        :param child_id: The configured logical child ID.
+        """
+        child = self._lookup(child_id)
+        if child is None:
+            return
+        child.availability = NodeAvailability.STALE
+        _LOGGER.info("MqttCallbackPool: child %s recovering", child_id)
+
+    def on_child_identity(
+        self,
+        child_id: str,
+        hgi_id: DeviceIdT,
+    ) -> None:
+        """Confirm the child's HGI identity.
+
+        :param child_id: The configured logical child ID.
+        :param hgi_id: The confirmed HGI device ID.
+        """
+        child = self._lookup(child_id)
+        if child is None:
+            return
+        child.learn_hgi(hgi_id)
+        _LOGGER.info(
+            "MqttCallbackPool: child %s identity confirmed as %s",
+            child_id,
+            hgi_id,
+        )
+
+    def on_child_packet(
+        self,
+        child_id: str,
+        packet: Packet,
+        *,
+        ingress_hgi_id: DeviceIdT | None = None,
+    ) -> None:
+        """Process a packet received from the child.
+
+        Routes the packet through the pool's dedup and forwarding
+        logic.  The ``ingress_hgi_id`` from the MQTT topic is
+        passed through without parsing topics inside the router.
+
+        :param child_id: The configured logical child ID.
+        :param packet: The parsed packet.
+        :param ingress_hgi_id: Optional HGI identity extracted
+            from the MQTT topic.
+        """
+        idx = self._hgi_to_child.get(child_id)
+        if idx is None:
+            _LOGGER.warning(
+                "MqttCallbackPool: packet from unknown child %s",
+                child_id,
+            )
+            return
+        self._pool._on_child_packet(idx, packet, ingress_hgi_id=ingress_hgi_id)
+
+    def on_unknown_hgi(
+        self,
+        hgi_id: DeviceIdT,
+        *,
+        topic: str | None = None,
+    ) -> None:
+        """Report an unknown HGI observed on the wildcard topic.
+
+        Does **not** create a ``PoolChild`` — only reports for
+        discovery purposes through the registered callback.
+
+        :param hgi_id: The unknown HGI device ID.
+        :param topic: The MQTT topic where it was observed.
+        """
+        if self._discovery_callback is not None:
+            self._discovery_callback.on_unknown_hgi(hgi_id, topic=topic)
+        else:
+            _LOGGER.debug(
+                "MqttCallbackPool: unknown HGI %s on topic %s "
+                "(no discovery callback registered)",
+                hgi_id,
+                topic,
+            )
+
+    def on_broker_connected(self) -> None:
+        """Signal that the MQTT broker connection is established.
+
+        No per-child action — individual children are marked online
+        via ``on_child_online`` when their LWT ``online`` messages
+        arrive.
+        """
+        _LOGGER.info("MqttCallbackPool: broker connected")
+
+    def on_broker_disconnected(self) -> None:
+        """Signal that the MQTT broker connection is lost.
+
+        Marks all callback-driven children as stale (not offline)
+        since the broker outage is transient and affects all MQTT
+        children.
+        """
+        _LOGGER.warning("MqttCallbackPool: broker disconnected")
+        for child in self._pool._children:
+            if child.callback_driven and child.is_connected:
+                child.availability = NodeAvailability.STALE

--- a/src/ramses_tx/transport/mqtt_pool.py
+++ b/src/ramses_tx/transport/mqtt_pool.py
@@ -56,6 +56,10 @@ class MqttCallbackPoolAdapter:
     :param outbound: The outbound publisher for frame delivery.
     :param discovery_callback: Optional callback for unknown HGIs
         observed on the wildcard topic.
+    :param accepted_hgi_ids: Optional set of HGI IDs that are
+        accepted pool members (may transmit).  HGIs not in this
+        set are receive-only discovery candidates.  If ``None``,
+        all configured HGIs are accepted (backward-compatible).
     """
 
     def __init__(
@@ -65,6 +69,7 @@ class MqttCallbackPoolAdapter:
         outbound: MqttPoolOutbound,
         *,
         discovery_callback: MqttDiscoveryCallback | None = None,
+        accepted_hgi_ids: set[str] | None = None,
     ) -> None:
         """Initialise the callback pool adapter."""
         self._pool = pool
@@ -84,10 +89,17 @@ class MqttCallbackPoolAdapter:
             child = pool._child_by_id(i)
             child.hgi_id = DeviceIdT(hgi_id)
             child.callback_driven = True
+            # Ownerless discovery candidates are receive-only.
+            # They can receive packets but cannot be selected for
+            # outbound transmission until the user accepts them.
+            if accepted_hgi_ids is not None:
+                child.accepted = hgi_id in accepted_hgi_ids
             _LOGGER.debug(
-                "MqttCallbackPool: pre-created child %d for HGI %s",
+                "MqttCallbackPool: pre-created child %d for HGI %s "
+                "(accepted=%s)",
                 i,
                 hgi_id,
+                child.accepted,
             )
 
     def _lookup(self, child_id: str) -> PoolChild | None:

--- a/src/ramses_tx/transport/mqtt_pool.py
+++ b/src/ramses_tx/transport/mqtt_pool.py
@@ -21,6 +21,7 @@ in ``ramses_cc`` using ``homeassistant.components.mqtt``.
 from __future__ import annotations
 
 import contextlib
+import functools
 import logging
 
 from ..helpers import dt_now
@@ -132,9 +133,18 @@ class MqttCallbackPoolAdapter:
             child.hgi_id = hgi_id
 
         # Notify the real protocol if this is the first connection.
+        # Use call_soon_threadsafe for thread safety — the adapter
+        # may be invoked from a non-event-loop MQTT callback thread.
         if not self._pool._protocol_connected:
             self._pool._protocol_connected = True
-            self._pool._protocol.connection_made(self._pool, ramses=True)
+            with contextlib.suppress(RuntimeError):
+                self._pool._loop.call_soon_threadsafe(
+                    functools.partial(
+                        self._pool._protocol.connection_made,
+                        self._pool,
+                        ramses=True,
+                    )
+                )
         # Resolve the connection future if waiting.
         if (
             self._pool._conn_fut is not None
@@ -289,11 +299,28 @@ class MqttCallbackPoolAdapter:
     def on_broker_disconnected(self) -> None:
         """Signal that the MQTT broker connection is lost.
 
-        Marks all callback-driven children as stale (not offline)
-        since the broker outage is transient and affects all MQTT
-        children.
+        Marks all callback-driven children as disconnected and
+        non-sendable, since without a broker connection no MQTT
+        child can send or receive.  This is distinct from LWT
+        offline (which affects a single node) — broker loss
+        affects all MQTT children simultaneously.
+
+        If no children remain connected, notifies the real
+        protocol via ``connection_lost``.
         """
         _LOGGER.warning("MqttCallbackPool: broker disconnected")
         for child in self._pool._children:
             if child.callback_driven and child.is_connected:
+                child.connection_state = ConnectionState.DISCONNECTED
                 child.availability = NodeAvailability.STALE
+                child.send_ready = False
+                # Quarantine RSSI — no valid evidence during outage.
+                child.rssi_tracker.clear()
+
+        # If no children are connected, notify the real protocol.
+        if not self._pool._connected_children and not self._pool._closing:
+            self._pool._protocol_connected = False
+            with contextlib.suppress(RuntimeError):
+                self._pool._loop.call_soon_threadsafe(
+                    self._pool._protocol.connection_lost, None
+                )

--- a/src/ramses_tx/transport/pooled.py
+++ b/src/ramses_tx/transport/pooled.py
@@ -670,6 +670,8 @@ class PooledTransport(TransportInterface):
         # Callback-driven children (PR 4A): publish through the
         # outbound publisher instead of a per-child transport.
         if child.callback_driven and child.transport is None:
+            if not child.is_sendable:
+                return WriteOutcome.NOT_SUBMITTED
             if self._outbound_publisher is None or child.hgi_id is None:
                 return WriteOutcome.NOT_SUBMITTED
             try:

--- a/src/ramses_tx/transport/pooled.py
+++ b/src/ramses_tx/transport/pooled.py
@@ -549,6 +549,10 @@ class PooledTransport(TransportInterface):
                     val = c.transport_obj.get_extra_info(SZ_IS_EVOFW3, False)
                     if val:
                         return True
+            # Callback-driven children (e.g. ramses_esp via MQTT)
+            # are treated as evofw3-compatible.
+            if any(c.is_connected and c.callback_driven for c in self._children):
+                return True
             return default
         if name == "pool_stats":
             return {

--- a/src/ramses_tx/transport/pooled.py
+++ b/src/ramses_tx/transport/pooled.py
@@ -44,6 +44,7 @@ from ..routing import RoutedCommand, RouteRequest, SourcePolicy, WriteOutcome
 from ..rssi_tracker import POOL_TTL, POOL_WINDOW_SIZE, RssiTracker
 from ..typing import DeviceIdT, RamsesProtocolT
 from .base import TransportConfig
+from .callbacks import MqttPoolOutbound
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -116,6 +117,10 @@ class PoolChild:
     :param transport: The child transport, or ``None`` if construction
         failed or the child was removed.
     :param accepted: Whether this child's HGI is in the accepted set.
+    :param callback_driven: If True, this child is driven by MQTT
+        callbacks (PR 4A) rather than a per-child transport.  No
+        ``transport`` instance is created; outbound frames go
+        through the pool's outbound publisher.
     """
 
     child_id: int
@@ -126,6 +131,7 @@ class PoolChild:
     availability: NodeAvailability = NodeAvailability.OFFLINE
     hgi_id: DeviceIdT | None = None
     accepted: bool = True
+    callback_driven: bool = False
     rssi_tracker: RssiTracker = field(
         default_factory=lambda: RssiTracker(POOL_WINDOW_SIZE, ttl=POOL_TTL)
     )
@@ -150,12 +156,15 @@ class PoolChild:
 
         A child is sendable when it is connected, accepted, and
         send-ready (has identity or has received at least one packet).
+        Callback-driven children (PR 4A) do not require a transport
+        instance — outbound frames go through the pool's outbound
+        publisher.
         """
         return (
             self.is_connected
             and self.accepted
             and self.send_ready
-            and self.transport is not None
+            and (self.transport is not None or self.callback_driven)
         )
 
     def mark_connected(self, transport_obj: Any) -> None:
@@ -432,12 +441,21 @@ class PooledTransport(TransportInterface):
         self._pkts_deduped: int = 0
         self._pkts_forwarded: int = 0
 
+        # Outbound publisher for callback-driven children (PR 4A).
+        # When set, children with ``callback_driven=True`` and no
+        # transport instance publish frames through this callback.
+        self._outbound_publisher: MqttPoolOutbound | None = None
+
     # -- Child access ----------------------------------------------------
 
     @property
     def _active_children(self) -> list[PoolChild]:
-        """Return children with a non-None transport."""
-        return [c for c in self._children if c.transport is not None]
+        """Return children with a transport or callback-driven."""
+        return [
+            c
+            for c in self._children
+            if c.transport is not None or c.callback_driven
+        ]
 
     @property
     def _connected_children(self) -> list[PoolChild]:
@@ -464,6 +482,29 @@ class PooledTransport(TransportInterface):
         :raises IndexError: If the ID is out of range.
         """
         return self._children[child_id]
+
+    def _child_by_hgi_id(self, hgi_id: str) -> PoolChild | None:
+        """Return the child with the given HGI ID.
+
+        :param hgi_id: The HGI device ID to look up.
+        :returns: The matching PoolChild, or ``None`` if not found.
+        """
+        for child in self._children:
+            if child.hgi_id is not None and str(child.hgi_id) == hgi_id:
+                return child
+        return None
+
+    def set_outbound_publisher(self, publisher: MqttPoolOutbound) -> None:
+        """Set the outbound publisher for callback-driven children.
+
+        When set, children with ``callback_driven=True`` and no
+        transport instance publish frames through this callback
+        instead of a per-child transport.
+
+        :param publisher: The outbound publisher implementing
+            :class:`~ramses_tx.transport.callbacks.MqttPoolOutbound`.
+        """
+        self._outbound_publisher = publisher
 
     # -- TransportInterface ---------------------------------------------
 
@@ -625,7 +666,21 @@ class PooledTransport(TransportInterface):
             child = self._child_by_id(int(routed.child_id))
         except (IndexError, ValueError):
             return WriteOutcome.NOT_SUBMITTED
-        if child is None or child.transport is None:
+
+        # Callback-driven children (PR 4A): publish through the
+        # outbound publisher instead of a per-child transport.
+        if child.callback_driven and child.transport is None:
+            if self._outbound_publisher is None or child.hgi_id is None:
+                return WriteOutcome.NOT_SUBMITTED
+            try:
+                await self._outbound_publisher.publish_frame(
+                    str(child.hgi_id), frame
+                )
+                return WriteOutcome.SUBMITTED
+            except Exception:
+                return WriteOutcome.AMBIGUOUS
+
+        if child.transport is None:
             return WriteOutcome.NOT_SUBMITTED
 
         write = getattr(child.transport, "write_frame", None)
@@ -1025,7 +1080,7 @@ class PooledTransport(TransportInterface):
         now = dt_now()
 
         for child in self._children:
-            if child.transport is None:
+            if child.transport is None and not child.callback_driven:
                 continue
             if not child.is_connected:
                 continue

--- a/src/ramses_tx/transport/pooled.py
+++ b/src/ramses_tx/transport/pooled.py
@@ -551,7 +551,9 @@ class PooledTransport(TransportInterface):
                         return True
             # Callback-driven children (e.g. ramses_esp via MQTT)
             # are treated as evofw3-compatible.
-            if any(c.is_connected and c.callback_driven for c in self._children):
+            if any(
+                c.is_connected and c.callback_driven for c in self._children
+            ):
                 return True
             return default
         if name == "pool_stats":

--- a/tests/tests_rf/device/test_base.py
+++ b/tests/tests_rf/device/test_base.py
@@ -5,6 +5,8 @@ This module combines tests for DeviceBase, HgiGateway, and BatteryState
 which all reside in ramses_rf/device/base.py.
 """
 
+from __future__ import annotations
+
 from datetime import UTC, datetime as dt, timedelta as td
 from unittest.mock import MagicMock
 
@@ -14,6 +16,7 @@ from ramses_rf.const import GATEWAY_MESSAGE_TIMEOUT
 from ramses_rf.devices.dev_base import BatteryState, DeviceBase, HgiGateway
 from ramses_rf.gateway import Gateway
 from ramses_tx import Address
+from ramses_tx.rssi_tracker import RssiTracker
 
 
 @pytest.fixture
@@ -227,3 +230,165 @@ class TestHgiGateway:
 
         hgi_gateway._gateway._engine._protocol._this_msg = mock_msg
         assert await hgi_gateway.is_active() is True
+
+
+class TestCommunicationQuality:
+    """Test DeviceBase.communication_quality with pooled transports.
+
+    Regression tests for the fix that gathers RSSI trackers from all
+    connected pool children via ``transport.get_extra_info(
+    "pool_rssi_trackers")`` so that ``best_rssi`` reflects the strongest
+    signal across all HGIs, not just the primary.
+    """
+
+    def _make_pool_transport(self, trackers: list[RssiTracker]) -> MagicMock:
+        """Create a mock transport that exposes pool_rssi_trackers.
+
+        :param trackers: The list of RssiTracker objects to return.
+        :type trackers: list[RssiTracker]
+        :return: A mock transport object.
+        :rtype: MagicMock
+        """
+        transport = MagicMock()
+        transport.get_extra_info = lambda name, default=None: (
+            trackers if name == "pool_rssi_trackers" else default
+        )
+        return transport
+
+    def _make_gateway_with_tracker(
+        self, tracker: RssiTracker, transport: MagicMock | None = None
+    ) -> MagicMock:
+        """Create a mock gateway with an RSSI tracker and optional transport.
+
+        :param tracker: The gateway's primary RSSI tracker.
+        :type tracker: RssiTracker
+        :param transport: Optional transport (e.g. PooledTransport).
+        :type transport: MagicMock | None
+        :return: A mock gateway.
+        :rtype: MagicMock
+        """
+        gwy = MagicMock(spec=Gateway)
+        gwy._rssi_tracker = tracker
+        gwy._engine = MagicMock()
+        gwy._engine._transport = transport
+        return gwy
+
+    def test_single_hgi_no_pool(self) -> None:
+        """Without a pool, communication_quality uses the gateway tracker."""
+        now = dt(2026, 1, 1, 12, 0, 0)
+        tracker = RssiTracker(ttl=None)
+        tracker.record("32:153289", "-70", now)
+
+        gwy = self._make_gateway_with_tracker(tracker, transport=None)
+        dev = DeviceBase(gwy, Address("32:153289"))
+        dev._last_msg_dtm = now
+
+        q = dev.communication_quality
+        assert q is not None
+        assert q.best_rssi == -70
+        assert q.rssi_quality == "normal"
+
+    def test_pool_uses_strongest_across_all_hgis(self) -> None:
+        """With 2 pool trackers, best_rssi is the strongest (-39 vs -89)."""
+        now = dt(2026, 1, 1, 12, 0, 0)
+
+        # Primary gateway tracker (would show weak signal alone)
+        gw_tracker = RssiTracker(ttl=None)
+        gw_tracker.record("32:153289", "-89", now)
+
+        # Pool child 0: strong signal (-39)
+        tracker_0 = RssiTracker(ttl=None)
+        tracker_0.record("32:153289", "-39", now)
+
+        # Pool child 1: weak signal (-89)
+        tracker_1 = RssiTracker(ttl=None)
+        tracker_1.record("32:153289", "-89", now)
+
+        transport = self._make_pool_transport([tracker_0, tracker_1])
+        gwy = self._make_gateway_with_tracker(gw_tracker, transport=transport)
+        dev = DeviceBase(gwy, Address("32:153289"))
+        dev._last_msg_dtm = now
+
+        q = dev.communication_quality
+        assert q is not None
+        assert q.best_rssi == -39  # strongest, not weakest
+        assert q.rssi_quality == "strong"
+
+    def test_pool_all_weak_reports_weak(self) -> None:
+        """When all pool trackers are weak, quality is weak."""
+        now = dt(2026, 1, 1, 12, 0, 0)
+
+        gw_tracker = RssiTracker(ttl=None)
+        gw_tracker.record("32:153289", "-90", now)
+
+        tracker_0 = RssiTracker(ttl=None)
+        tracker_0.record("32:153289", "-91", now)
+
+        tracker_1 = RssiTracker(ttl=None)
+        tracker_1.record("32:153289", "-89", now)
+
+        transport = self._make_pool_transport([tracker_0, tracker_1])
+        gwy = self._make_gateway_with_tracker(gw_tracker, transport=transport)
+        dev = DeviceBase(gwy, Address("32:153289"))
+        dev._last_msg_dtm = now
+
+        q = dev.communication_quality
+        assert q is not None
+        assert q.best_rssi == -89  # best of the weak ones
+        assert q.rssi_quality == "weak"
+
+    def test_pool_empty_trackers_falls_back_to_gateway(self) -> None:
+        """Empty pool_rssi_trackers falls back to the gateway tracker."""
+        now = dt(2026, 1, 1, 12, 0, 0)
+
+        gw_tracker = RssiTracker(ttl=None)
+        gw_tracker.record("32:153289", "-55", now)
+
+        transport = self._make_pool_transport([])
+        gwy = self._make_gateway_with_tracker(gw_tracker, transport=transport)
+        dev = DeviceBase(gwy, Address("32:153289"))
+        dev._last_msg_dtm = now
+
+        q = dev.communication_quality
+        assert q is not None
+        assert q.best_rssi == -55  # from gateway tracker, not pool
+
+    def test_no_gateway_tracker_returns_none(self) -> None:
+        """Without a gateway RSSI tracker, returns None."""
+        gwy = MagicMock(spec=Gateway)
+        gwy._rssi_tracker = None
+        gwy._engine = MagicMock()
+        gwy._engine._transport = None
+
+        dev = DeviceBase(gwy, Address("32:153289"))
+        assert dev.communication_quality is None
+
+    def test_faked_device_not_reported_as_weak(self) -> None:
+        """A faked device with weak RSSI is still faked — discovery skips it.
+
+        This test verifies that ``is_faked`` returns True when a binding
+        manager is attached, so the discovery weak-signal check can skip
+        faked devices.  The communication_quality itself still computes
+        (it's the caller's responsibility to check ``is_faked`` first).
+        """
+        now = dt(2026, 1, 1, 12, 0, 0)
+        tracker = RssiTracker(ttl=None)
+        tracker.record("37:168270", "-90", now)
+
+        gwy = self._make_gateway_with_tracker(tracker, transport=None)
+        dev = DeviceBase(gwy, Address("37:168270"))
+        dev._last_msg_dtm = now
+
+        # Simulate a faked device by attaching a binding manager
+        dev._binding_manager = MagicMock()
+        dev._binding_manager.is_binding = False
+
+        # is_faked must be True so discovery can skip it
+        assert dev.is_faked is True
+
+        # communication_quality still computes (caller checks is_faked)
+        q = dev.communication_quality
+        assert q is not None
+        assert q.rssi_quality == "weak"
+        # But the caller (discovery.py) would skip this device via:
+        #   if getattr(device, "is_faked", False): continue

--- a/tests/tests_tx/test_transport_mqtt_pool.py
+++ b/tests/tests_tx/test_transport_mqtt_pool.py
@@ -203,21 +203,25 @@ def test_on_child_online_marks_child_connected_and_sendable() -> None:
     assert child.send_ready is True
 
 
-def test_on_child_online_notifies_protocol_on_first_connection() -> None:
+async def test_on_child_online_notifies_protocol_on_first_connection() -> None:
     """First child online triggers protocol.connection_made."""
     proto = _make_mock_protocol()
     _, adapter, _ = _make_callback_pool(proto=proto)
     adapter.on_child_online("18:001111")
+    # connection_made is dispatched via call_soon_threadsafe.
+    await asyncio.sleep(0.01)
     assert proto.connection_made.called
 
 
-def test_on_child_online_does_not_renotify_protocol() -> None:
+async def test_on_child_online_does_not_renotify_protocol() -> None:
     """Second child online does not re-trigger protocol.connection_made."""
     proto = _make_mock_protocol()
     _, adapter, _ = _make_callback_pool(proto=proto)
     adapter.on_child_online("18:001111")
+    await asyncio.sleep(0.01)  # drain call_soon_threadsafe
     proto.connection_made.reset_mock()
     adapter.on_child_online("18:002222")
+    await asyncio.sleep(0.01)
     assert not proto.connection_made.called
 
 
@@ -367,8 +371,9 @@ def test_on_unknown_hgi_does_not_create_child() -> None:
 # -- on_broker_disconnected ------------------------------------------------
 
 
-def test_on_broker_disconnected_marks_children_stale() -> None:
-    """Broker disconnect marks all callback-driven children as stale."""
+def test_on_broker_disconnected_marks_children_disconnected() -> None:
+    """Broker disconnect marks all callback-driven children as
+    disconnected and non-sendable."""
     pool, adapter, _ = _make_callback_pool(hgi_ids=["18:001111", "18:002222"])
     adapter.on_child_online("18:001111")
     adapter.on_child_online("18:002222")
@@ -376,6 +381,10 @@ def test_on_broker_disconnected_marks_children_stale() -> None:
     for child in pool._children:
         if child.callback_driven:
             assert child.availability is NodeAvailability.STALE
+            assert not child.is_connected
+            assert not child.is_sendable
+            # RSSI quarantined during broker outage.
+            assert not child.rssi_tracker._readings
 
 
 def test_on_broker_connected_is_safe() -> None:
@@ -474,3 +483,102 @@ def test_child_by_hgi_id_returns_none_for_unknown() -> None:
     pool, _, _ = _make_callback_pool()
     child = pool._child_by_hgi_id("18:999999")
     assert child is None
+
+
+# -- Unknown HGI side effects (fact-check gap) -----------------------------
+
+
+def test_unknown_hgi_does_not_forward_rf_frames() -> None:
+    """Unknown HGI on wildcard does not forward RF frames."""
+    proto = _make_mock_protocol()
+    _, adapter, _ = _make_callback_pool(proto=proto)
+    adapter.on_child_online("18:001111")
+    # Simulate a packet from an unknown HGI on the wildcard topic.
+    # The adapter's on_unknown_hgi is called instead of on_child_packet.
+    adapter.on_unknown_hgi(DeviceIdT("18:999999"))
+    # No packet was forwarded because on_unknown_hgi does not route
+    # packets — it only fires the discovery callback.
+    assert proto.packet_received.call_count == 0
+
+
+def test_unknown_hgi_does_not_mutate_registry() -> None:
+    """Unknown HGI does not add a child to the registry."""
+    pool, adapter, _ = _make_callback_pool()
+    initial_count = len(pool._children)
+    adapter.on_unknown_hgi(DeviceIdT("18:999999"))
+    assert len(pool._children) == initial_count
+    # No child has HGI 18:999999.
+    assert pool._child_by_hgi_id("18:999999") is None
+
+
+def test_unknown_hgi_does_not_become_sendable() -> None:
+    """Unknown HGI does not appear as a sendable child."""
+    pool, adapter, _ = _make_callback_pool()
+    adapter.on_unknown_hgi(DeviceIdT("18:999999"))
+    for child in pool._children:
+        assert child.hgi_id != DeviceIdT("18:999999")
+        assert not child.is_sendable or child.hgi_id != DeviceIdT("18:999999")
+
+
+# -- LWT vs broker distinction (fact-check gap) ---------------------------
+
+
+def test_lwt_offline_affects_only_target_child() -> None:
+    """LWT offline removes only the affected ESP from eligibility;
+    other children remain sendable."""
+    pool, adapter, _ = _make_callback_pool(hgi_ids=["18:001111", "18:002222"])
+    adapter.on_child_online("18:001111")
+    adapter.on_child_online("18:002222")
+    # LWT offline on child 0 only.
+    adapter.on_child_offline("18:001111", definitive=True)
+    child0 = pool._child_by_id(0)
+    child1 = pool._child_by_id(1)
+    assert not child0.is_sendable
+    assert not child0.is_connected
+    assert child1.is_sendable
+    assert child1.is_connected
+
+
+def test_broker_loss_affects_all_mqtt_children() -> None:
+    """Broker loss affects all MQTT children, not just one."""
+    pool, adapter, _ = _make_callback_pool(hgi_ids=["18:001111", "18:002222"])
+    adapter.on_child_online("18:001111")
+    adapter.on_child_online("18:002222")
+    adapter.on_broker_disconnected()
+    for child in pool._children:
+        if child.callback_driven:
+            assert not child.is_sendable
+            assert not child.is_connected
+
+
+# -- write_routed is_sendable guard (fact-check fix) ----------------------
+
+
+async def test_write_routed_offline_callback_child_returns_not_submitted() -> (
+    None,
+):
+    """write_routed for an offline callback-driven child returns
+    NOT_SUBMITTED (is_sendable guard)."""
+    pool, adapter, outbound = _make_callback_pool()
+    adapter.on_child_online("18:001111")
+    adapter.on_child_offline("18:001111", definitive=True)
+    from ramses_tx.routing import RoutedCommand
+
+    routed = RoutedCommand(child_id="0", command=MagicMock())
+    outcome = await pool.write_routed(routed, "frame")
+    assert outcome.name == "NOT_SUBMITTED"
+    assert len(outbound.published) == 0
+
+
+async def test_write_routed_broker_down_returns_not_submitted() -> None:
+    """write_routed for a callback-driven child after broker
+    disconnect returns NOT_SUBMITTED."""
+    pool, adapter, outbound = _make_callback_pool()
+    adapter.on_child_online("18:001111")
+    adapter.on_broker_disconnected()
+    from ramses_tx.routing import RoutedCommand
+
+    routed = RoutedCommand(child_id="0", command=MagicMock())
+    outcome = await pool.write_routed(routed, "frame")
+    assert outcome.name == "NOT_SUBMITTED"
+    assert len(outbound.published) == 0

--- a/tests/tests_tx/test_transport_mqtt_pool.py
+++ b/tests/tests_tx/test_transport_mqtt_pool.py
@@ -554,9 +554,7 @@ def test_broker_loss_affects_all_mqtt_children() -> None:
 # -- write_routed is_sendable guard (fact-check fix) ----------------------
 
 
-async def test_write_routed_offline_callback_child_returns_not_submitted() -> (
-    None,
-):
+async def test_write_routed_offline_callback_child_returns_not_submitted() -> None:
     """write_routed for an offline callback-driven child returns
     NOT_SUBMITTED (is_sendable guard)."""
     pool, adapter, outbound = _make_callback_pool()

--- a/tests/tests_tx/test_transport_mqtt_pool.py
+++ b/tests/tests_tx/test_transport_mqtt_pool.py
@@ -117,6 +117,7 @@ def _make_callback_pool(
     hgi_ids: list[str] | None = None,
     outbound: _FakeOutbound | None = None,
     discovery: _FakeDiscovery | None = None,
+    accepted_hgi_ids: set[str] | None = None,
 ) -> tuple[PooledTransport, MqttCallbackPoolAdapter, _FakeOutbound]:
     """Create a PooledTransport with a callback adapter."""
     proto = proto or _make_mock_protocol()
@@ -144,6 +145,7 @@ def _make_callback_pool(
         hgi_ids,
         outbound,
         discovery_callback=discovery,
+        accepted_hgi_ids=accepted_hgi_ids,
     )
     return pool, adapter, outbound
 
@@ -580,3 +582,88 @@ async def test_write_routed_broker_down_returns_not_submitted() -> None:
     outcome = await pool.write_routed(routed, "frame")
     assert outcome.name == "NOT_SUBMITTED"
     assert len(outbound.published) == 0
+
+
+# -- accepted_hgi_ids: ownerless discovery candidates are receive-only ------
+
+
+def test_accepted_hgi_ids_marks_ownerless_as_not_accepted(
+    event_loop: asyncio.AbstractEventLoop,
+) -> None:
+    """Ownerless discovery candidates have accepted=False."""
+    pool, adapter, _ = _make_callback_pool(
+        event_loop=event_loop,
+        hgi_ids=["18:001111", "18:002222"],
+        accepted_hgi_ids={"18:001111"},  # only 18:001111 is accepted
+    )
+    child0 = pool._child_by_id(0)
+    child1 = pool._child_by_id(1)
+    assert child0.accepted is True  # accepted
+    assert child1.accepted is False  # ownerless discovery candidate
+
+
+def test_ownerless_candidate_not_sendable_even_when_online(
+    event_loop: asyncio.AbstractEventLoop,
+) -> None:
+    """An ownerless candidate that is online is NOT sendable."""
+    pool, adapter, _ = _make_callback_pool(
+        event_loop=event_loop,
+        hgi_ids=["18:001111", "18:002222"],
+        accepted_hgi_ids={"18:001111"},
+    )
+    # Bring the ownerless candidate online.
+    adapter.on_child_online("18:002222")
+    child1 = pool._child_by_id(1)
+    assert child1.is_connected
+    assert child1.send_ready
+    assert not child1.accepted
+    assert not child1.is_sendable  # accepted=False blocks sendable
+
+
+def test_ownerless_candidate_not_selected_for_outbound(
+    event_loop: asyncio.AbstractEventLoop,
+) -> None:
+    """An ownerless candidate is not selected for outbound routing."""
+    pool, adapter, outbound = _make_callback_pool(
+        event_loop=event_loop,
+        hgi_ids=["18:001111", "18:002222"],
+        accepted_hgi_ids={"18:001111"},
+    )
+    # Bring both children online.
+    adapter.on_child_online("18:001111")
+    adapter.on_child_online("18:002222")
+    # _select_child should only return accepted children.
+    selected = pool._select_child("04:123456")
+    assert selected is not None
+    assert selected.child_id == 0  # only the accepted child
+
+
+async def test_ownerless_candidate_cannot_transmit(
+    event_loop: asyncio.AbstractEventLoop,
+) -> None:
+    """write_routed for an ownerless candidate returns NOT_SUBMITTED."""
+    pool, adapter, outbound = _make_callback_pool(
+        event_loop=event_loop,
+        hgi_ids=["18:001111", "18:002222"],
+        accepted_hgi_ids={"18:001111"},
+    )
+    adapter.on_child_online("18:002222")  # ownerless candidate online
+    from ramses_tx.routing import RoutedCommand
+
+    routed = RoutedCommand(child_id="1", command=MagicMock())
+    outcome = await pool.write_routed(routed, "frame")
+    assert outcome.name == "NOT_SUBMITTED"
+    assert len(outbound.published) == 0
+
+
+def test_no_accepted_hgi_ids_means_all_accepted(
+    event_loop: asyncio.AbstractEventLoop,
+) -> None:
+    """When accepted_hgi_ids is None, all children are accepted (backward compat)."""
+    pool, _, _ = _make_callback_pool(
+        event_loop=event_loop,
+        hgi_ids=["18:001111", "18:002222"],
+        accepted_hgi_ids=None,
+    )
+    assert pool._child_by_id(0).accepted is True
+    assert pool._child_by_id(1).accepted is True

--- a/tests/tests_tx/test_transport_mqtt_pool.py
+++ b/tests/tests_tx/test_transport_mqtt_pool.py
@@ -1,0 +1,476 @@
+#!/usr/bin/env python3
+"""Tests for the transport-neutral MQTT callback contract (PR 4A).
+
+Covers:
+- MqttCallbackPoolAdapter pre-creates logical children from
+  configured HGI IDs.
+- on_child_online / on_child_offline update child availability.
+- on_child_packet routes through the pool's dedup logic.
+- on_child_identity confirms HGI identity.
+- on_unknown_hgi fires the discovery callback without creating a
+  PoolChild.
+- on_broker_disconnected marks all callback-driven children stale.
+- Outbound frames for callback-driven children go through the
+  MqttPoolOutbound publisher.
+- LWT offline quarantines RSSI evidence.
+- Wildcard RX preserves the correct ingress HGI.
+- Unknown wildcard IDs do not mutate the child registry.
+"""
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, Mock
+
+import pytest
+
+from ramses_tx.const import I_, Code
+from ramses_tx.transport.base import TransportConfig
+from ramses_tx.transport.callbacks import (
+    MqttDiscoveryCallback,
+    MqttPoolInbound,
+    MqttPoolOutbound,
+)
+from ramses_tx.transport.mqtt_pool import MqttCallbackPoolAdapter
+from ramses_tx.transport.pooled import (
+    ConnectionState,
+    NodeAvailability,
+    PooledTransport,
+)
+from ramses_tx.typing import DeviceIdT
+
+
+@pytest.fixture
+def event_loop() -> asyncio.AbstractEventLoop:
+    """Provide a fresh event loop for each test."""
+    loop = asyncio.new_event_loop()
+    yield loop
+    loop.close()
+
+
+# -- Helpers ---------------------------------------------------------------
+
+
+def _make_packet(
+    verb: str = I_,
+    code: str = Code._30C9,
+    src: str = "01:123456",
+    dst: str = "18:000730",
+    addr3: str = "--:------",
+    payload: str = "00",
+    rssi: str = "000",
+    seq: str = "---",
+) -> MagicMock:
+    """Create a mock Packet with a DTO for dedup keying."""
+    dto = MagicMock()
+    dto.verb = verb
+    dto.code = code
+    dto.addr1 = src
+    dto.addr2 = dst
+    dto.addr3 = addr3
+    dto.raw_payload = payload
+    dto.rssi = rssi
+    dto.seq = seq
+
+    pkt = MagicMock()
+    pkt._dto = dto
+    pkt.__str__ = lambda self: (
+        f"{rssi} {verb} {seq} {src} {dst} {addr3} {code} 000 {payload}"
+    )
+    return pkt
+
+
+def _make_mock_protocol() -> MagicMock:
+    """Create a mock real protocol for the pool."""
+    proto = MagicMock()
+    proto.packet_received = Mock()
+    proto.connection_lost = Mock()
+    proto.connection_made = Mock()
+    proto.send_cmd = AsyncMock(return_value=None)
+    proto.set_regex_rules = Mock()
+    return proto
+
+
+class _FakeOutbound:
+    """Minimal MqttPoolOutbound implementation for tests."""
+
+    def __init__(self) -> None:
+        self.published: list[tuple[str, str]] = []
+
+    async def publish_frame(self, child_id: str, frame: str) -> None:
+        self.published.append((child_id, frame))
+
+
+class _FakeDiscovery:
+    """Minimal MqttDiscoveryCallback implementation for tests."""
+
+    def __init__(self) -> None:
+        self.unknowns: list[tuple[str, str | None]] = []
+
+    def on_unknown_hgi(
+        self, hgi_id: DeviceIdT, *, topic: str | None = None
+    ) -> None:
+        self.unknowns.append((str(hgi_id), topic))
+
+
+def _make_callback_pool(
+    event_loop: asyncio.AbstractEventLoop | None = None,
+    proto: MagicMock | None = None,
+    hgi_ids: list[str] | None = None,
+    outbound: _FakeOutbound | None = None,
+    discovery: _FakeDiscovery | None = None,
+) -> tuple[PooledTransport, MqttCallbackPoolAdapter, _FakeOutbound]:
+    """Create a PooledTransport with a callback adapter."""
+    proto = proto or _make_mock_protocol()
+    hgi_ids = hgi_ids or ["18:001111", "18:002222"]
+    outbound = outbound or _FakeOutbound()
+    n = len(hgi_ids)
+    # Get the event loop: use the provided one, or try the running
+    # loop, or create a new one for sync tests.
+    if event_loop is not None:
+        loop = event_loop
+    else:
+        try:
+            loop = asyncio.get_running_loop()
+        except RuntimeError:
+            loop = asyncio.new_event_loop()
+            asyncio.set_event_loop(loop)
+    pool = PooledTransport(
+        proto,
+        [None] * n,  # no per-child transports
+        config=TransportConfig(),
+        loop=loop,
+    )
+    adapter = MqttCallbackPoolAdapter(
+        pool,
+        hgi_ids,
+        outbound,
+        discovery_callback=discovery,
+    )
+    return pool, adapter, outbound
+
+
+# -- Protocol compliance ---------------------------------------------------
+
+
+def test_mqtt_pool_outbound_is_runtime_checkable() -> None:
+    """MqttPoolOutbound is a runtime_checkable Protocol."""
+    pub = _FakeOutbound()
+    assert isinstance(pub, MqttPoolOutbound)
+
+
+def test_mqtt_pool_inbound_is_runtime_checkable() -> None:
+    """MqttPoolInbound is a runtime_checkable Protocol."""
+    _, adapter, _ = _make_callback_pool()
+    assert isinstance(adapter, MqttPoolInbound)
+
+
+def test_discovery_callback_is_runtime_checkable() -> None:
+    """MqttDiscoveryCallback is a runtime_checkable Protocol."""
+    disc = _FakeDiscovery()
+    assert isinstance(disc, MqttDiscoveryCallback)
+
+
+# -- Pre-creation of logical children --------------------------------------
+
+
+def test_pre_creates_children_from_configured_hgi_ids() -> None:
+    """Children are pre-created with HGI IDs and callback_driven=True."""
+    pool, _, _ = _make_callback_pool(hgi_ids=["18:001111", "18:002222"])
+    assert len(pool._children) == 2
+    assert pool._children[0].hgi_id == DeviceIdT("18:001111")
+    assert pool._children[1].hgi_id == DeviceIdT("18:002222")
+    assert pool._children[0].callback_driven is True
+    assert pool._children[1].callback_driven is True
+    assert pool._children[0].transport is None
+    assert pool._children[1].transport is None
+
+
+def test_outbound_publisher_is_wired_into_pool() -> None:
+    """The outbound publisher is set on the pool."""
+    pool, _, outbound = _make_callback_pool()
+    assert pool._outbound_publisher is outbound
+
+
+# -- on_child_online / on_child_offline ------------------------------------
+
+
+def test_on_child_online_marks_child_connected_and_sendable() -> None:
+    """on_child_online marks the child as connected and send-ready."""
+    pool, adapter, _ = _make_callback_pool()
+    adapter.on_child_online("18:001111")
+    child = pool._child_by_id(0)
+    assert child.is_connected
+    assert child.availability is NodeAvailability.ONLINE
+    assert child.send_ready is True
+
+
+def test_on_child_online_notifies_protocol_on_first_connection() -> None:
+    """First child online triggers protocol.connection_made."""
+    proto = _make_mock_protocol()
+    _, adapter, _ = _make_callback_pool(proto=proto)
+    adapter.on_child_online("18:001111")
+    assert proto.connection_made.called
+
+
+def test_on_child_online_does_not_renotify_protocol() -> None:
+    """Second child online does not re-trigger protocol.connection_made."""
+    proto = _make_mock_protocol()
+    _, adapter, _ = _make_callback_pool(proto=proto)
+    adapter.on_child_online("18:001111")
+    proto.connection_made.reset_mock()
+    adapter.on_child_online("18:002222")
+    assert not proto.connection_made.called
+
+
+def test_on_child_offline_definitive_marks_disconnected() -> None:
+    """Definitive offline marks the child as disconnected."""
+    pool, adapter, _ = _make_callback_pool()
+    adapter.on_child_online("18:001111")
+    adapter.on_child_offline("18:001111", definitive=True)
+    child = pool._child_by_id(0)
+    assert not child.is_connected
+    assert child.availability is NodeAvailability.OFFLINE
+    assert child.send_ready is False
+
+
+def test_on_child_offline_definitive_clears_rssi() -> None:
+    """LWT offline quarantines RSSI evidence."""
+    pool, adapter, _ = _make_callback_pool()
+    adapter.on_child_online("18:001111")
+    # Record some RSSI.
+    pool._on_child_packet(0, _make_packet(src="01:123456", rssi="050"))
+    assert pool._children[0].rssi_tracker._readings  # has data
+    adapter.on_child_offline("18:001111", definitive=True)
+    assert not pool._children[0].rssi_tracker._readings  # cleared
+
+
+def test_on_child_offline_transient_marks_stale() -> None:
+    """Transient broker issue marks the child as stale, not offline."""
+    pool, adapter, _ = _make_callback_pool()
+    adapter.on_child_online("18:001111")
+    adapter.on_child_offline("18:001111", definitive=False)
+    child = pool._child_by_id(0)
+    assert child.is_connected  # still connected
+    assert child.availability is NodeAvailability.STALE
+
+
+async def test_on_child_offline_all_children_notifies_protocol() -> None:
+    """When all children go offline, protocol.connection_lost is called."""
+    proto = _make_mock_protocol()
+    pool, adapter, _ = _make_callback_pool(proto=proto)
+    adapter.on_child_online("18:001111")
+    adapter.on_child_offline("18:001111", definitive=True)
+    # Let call_soon_threadsafe drain.
+    await asyncio.sleep(0.01)
+    assert proto.connection_lost.called
+
+
+def test_on_child_offline_unknown_child_is_warning() -> None:
+    """Offline event for unknown child does not crash."""
+    _, adapter, _ = _make_callback_pool()
+    adapter.on_child_offline("18:999999")  # not configured
+    # No crash — just a warning log.
+
+
+# -- on_child_packet -------------------------------------------------------
+
+
+async def test_on_child_packet_routes_through_dedup() -> None:
+    """Packets from callback children go through the pool's dedup."""
+    proto = _make_mock_protocol()
+    _, adapter, _ = _make_callback_pool(proto=proto)
+    adapter.on_child_online("18:001111")
+    pkt = _make_packet()
+    adapter.on_child_packet("18:001111", pkt)
+    await asyncio.sleep(0.01)
+    assert proto.packet_received.call_count == 1
+
+
+async def test_on_child_packet_carries_ingress_hgi_id() -> None:
+    """Topic-derived ingress_hgi_id is passed through to the packet."""
+    pool, adapter, _ = _make_callback_pool()
+    adapter.on_child_online("18:001111")
+    pkt = _make_packet()
+    adapter.on_child_packet(
+        "18:001111", pkt, ingress_hgi_id=DeviceIdT("18:001111")
+    )
+    assert pkt._ingress_hgi_id == "18:001111"
+
+
+async def test_on_child_packet_dedup_across_children() -> None:
+    """Same packet from two callback children is deduped."""
+    proto = _make_mock_protocol()
+    _, adapter, _ = _make_callback_pool(
+        proto=proto, hgi_ids=["18:001111", "18:002222"]
+    )
+    adapter.on_child_online("18:001111")
+    adapter.on_child_online("18:002222")
+    pkt = _make_packet()
+    adapter.on_child_packet("18:001111", pkt)
+    adapter.on_child_packet("18:002222", pkt)  # duplicate
+    await asyncio.sleep(0.01)
+    assert proto.packet_received.call_count == 1
+
+
+def test_on_child_packet_unknown_child_is_warning() -> None:
+    """Packet from unknown child does not crash."""
+    _, adapter, _ = _make_callback_pool()
+    pkt = _make_packet()
+    adapter.on_child_packet("18:999999", pkt)  # not configured
+
+
+# -- on_child_identity -----------------------------------------------------
+
+
+def test_on_child_identity_confirms_hgi() -> None:
+    """on_child_identity sets the HGI ID on the child."""
+    pool, adapter, _ = _make_callback_pool(hgi_ids=["18:001111"])
+    # Clear the pre-set HGI to simulate unknown identity.
+    pool._children[0].hgi_id = None
+    pool._children[0].send_ready = False
+    adapter.on_child_identity("18:001111", DeviceIdT("18:001111"))
+    child = pool._child_by_id(0)
+    assert child.hgi_id == DeviceIdT("18:001111")
+    assert child.send_ready is True
+
+
+# -- on_unknown_hgi --------------------------------------------------------
+
+
+def test_on_unknown_hgi_fires_discovery_callback() -> None:
+    """Unknown HGI fires the discovery callback."""
+    discovery = _FakeDiscovery()
+    _, adapter, _ = _make_callback_pool(discovery=discovery)
+    adapter.on_unknown_hgi(
+        DeviceIdT("18:999999"), topic="RAMSES/GATEWAY/18:999999/rx"
+    )
+    assert len(discovery.unknowns) == 1
+    assert discovery.unknowns[0] == (
+        "18:999999",
+        "RAMSES/GATEWAY/18:999999/rx",
+    )
+
+
+def test_on_unknown_hgi_no_discovery_callback_is_safe() -> None:
+    """Unknown HGI without a discovery callback does not crash."""
+    _, adapter, _ = _make_callback_pool(discovery=None)
+    adapter.on_unknown_hgi(DeviceIdT("18:999999"))
+
+
+def test_on_unknown_hgi_does_not_create_child() -> None:
+    """Unknown HGI does not create a PoolChild."""
+    pool, adapter, _ = _make_callback_pool()
+    initial_count = len(pool._children)
+    adapter.on_unknown_hgi(DeviceIdT("18:999999"))
+    assert len(pool._children) == initial_count
+
+
+# -- on_broker_disconnected ------------------------------------------------
+
+
+def test_on_broker_disconnected_marks_children_stale() -> None:
+    """Broker disconnect marks all callback-driven children as stale."""
+    pool, adapter, _ = _make_callback_pool(hgi_ids=["18:001111", "18:002222"])
+    adapter.on_child_online("18:001111")
+    adapter.on_child_online("18:002222")
+    adapter.on_broker_disconnected()
+    for child in pool._children:
+        if child.callback_driven:
+            assert child.availability is NodeAvailability.STALE
+
+
+def test_on_broker_connected_is_safe() -> None:
+    """Broker connected event does not crash."""
+    _, adapter, _ = _make_callback_pool()
+    adapter.on_broker_connected()
+
+
+# -- Outbound routing for callback-driven children -------------------------
+
+
+async def test_write_routed_uses_outbound_publisher() -> None:
+    """write_routed for a callback-driven child uses the publisher."""
+    pool, adapter, outbound = _make_callback_pool()
+    adapter.on_child_online("18:001111")
+    # Manually call write_routed with child_id=0.
+    from ramses_tx.routing import RoutedCommand
+
+    routed = RoutedCommand(child_id="0", command=MagicMock())
+    outcome = await pool.write_routed(
+        routed, " 000 I --- 01:123456 18:000730 --:------ 30C9 000 00"
+    )
+    assert outcome.name == "SUBMITTED"
+    assert len(outbound.published) == 1
+    assert outbound.published[0][0] == "18:001111"
+
+
+async def test_write_routed_no_outbound_returns_not_submitted() -> None:
+    """write_routed without an outbound publisher returns NOT_SUBMITTED."""
+    pool = PooledTransport(
+        _make_mock_protocol(),
+        [None],
+        config=TransportConfig(),
+    )
+    pool._children[0].callback_driven = True
+    pool._children[0].hgi_id = DeviceIdT("18:001111")
+    pool._children[0].connection_state = ConnectionState.CONNECTED
+    pool._children[0].send_ready = True
+    from ramses_tx.routing import RoutedCommand
+
+    routed = RoutedCommand(child_id="0", command=MagicMock())
+    outcome = await pool.write_routed(routed, "frame")
+    assert outcome.name == "NOT_SUBMITTED"
+
+
+async def test_write_routed_publisher_failure_returns_ambiguous() -> None:
+    """Publisher failure returns AMBIGUOUS."""
+    pool, adapter, _ = _make_callback_pool()
+    adapter.on_child_online("18:001111")
+    # Replace publisher with one that raises.
+    pool._outbound_publisher = MagicMock()
+    pool._outbound_publisher.publish_frame = AsyncMock(
+        side_effect=RuntimeError("broker down")
+    )
+    from ramses_tx.routing import RoutedCommand
+
+    routed = RoutedCommand(child_id="0", command=MagicMock())
+    outcome = await pool.write_routed(routed, "frame")
+    assert outcome.name == "AMBIGUOUS"
+
+
+# -- is_sendable for callback-driven children ------------------------------
+
+
+def test_is_sendable_callback_driven_no_transport() -> None:
+    """A callback-driven child with no transport can be sendable."""
+    pool, adapter, _ = _make_callback_pool()
+    adapter.on_child_online("18:001111")
+    child = pool._child_by_id(0)
+    assert child.transport is None
+    assert child.is_sendable
+
+
+def test_is_sendable_not_sendable_when_offline() -> None:
+    """A callback-driven child is not sendable when offline."""
+    pool, adapter, _ = _make_callback_pool()
+    adapter.on_child_online("18:001111")
+    adapter.on_child_offline("18:001111", definitive=True)
+    child = pool._child_by_id(0)
+    assert not child.is_sendable
+
+
+# -- _child_by_hgi_id lookup -----------------------------------------------
+
+
+def test_child_by_hgi_id_finds_matching_child() -> None:
+    """_child_by_hgi_id returns the child with the given HGI ID."""
+    pool, _, _ = _make_callback_pool(hgi_ids=["18:001111", "18:002222"])
+    child = pool._child_by_hgi_id("18:002222")
+    assert child is not None
+    assert child.child_id == 1
+
+
+def test_child_by_hgi_id_returns_none_for_unknown() -> None:
+    """_child_by_hgi_id returns None for an unknown HGI ID."""
+    pool, _, _ = _make_callback_pool()
+    child = pool._child_by_hgi_id("18:999999")
+    assert child is None

--- a/tests/tests_tx/test_transport_mqtt_pool.py
+++ b/tests/tests_tx/test_transport_mqtt_pool.py
@@ -554,7 +554,7 @@ def test_broker_loss_affects_all_mqtt_children() -> None:
 # -- write_routed is_sendable guard (fact-check fix) ----------------------
 
 
-async def test_write_routed_offline_callback_child_returns_not_submitted() -> None:
+async def test_write_routed_offline_child_not_submitted() -> None:
     """write_routed for an offline callback-driven child returns
     NOT_SUBMITTED (is_sendable guard)."""
     pool, adapter, outbound = _make_callback_pool()


### PR DESCRIPTION
## Summary

- Define transport-neutral callback protocols (`MqttPoolInbound`, `MqttPoolOutbound`, `MqttDiscoveryCallback`) that bridge an external MQTT client to `PooledTransport` without creating a per-child transport or TCP connection.
- Add `MqttCallbackPoolAdapter` that pre-creates logical children from configured HGI IDs and maps callback availability events into the pool's child registry.
- Extend `PooledTransport` with `callback_driven` child flag, outbound publisher support, HGI-based child lookup, and health checking for callback-driven children.

**Depends on:** PR 1184 (feat/pooled-transport-1122) and PR 1194 (pr2/typed-routing-1119). This branch is based on `pr2/typed-routing-1119`.

### Inbound callback events

- `on_child_online` / `on_child_offline` (definitive LWT vs transient broker)
- `on_child_recovering` — child coming back after transient outage
- `on_child_identity` — HGI identity confirmed
- `on_child_packet` — parsed packet with topic-derived `ingress_hgi_id`
- `on_broker_connected` / `on_broker_disconnected` — broker-level state

### Outbound

- `MqttPoolOutbound.publish_frame(child_id, frame)` — publish through the shared MQTT connection.

### Discovery

- `on_unknown_hgi` fires a discovery callback without creating a `PoolChild`.

### LWT offline handling

- Definitive offline quarantines RSSI evidence via `mark_disconnected()`.
- Transient broker issues mark children as stale, not offline.

### HA-import-free

The callback contract is defined in `ramses_tx.transport.callbacks` with no Home Assistant imports. PR 4B will implement these interfaces in `ramses_cc` using `homeassistant.components.mqtt`.

## Test plan

- [x] 30 new tests in `test_transport_mqtt_pool.py` covering protocol compliance, pre-creation, online/offline lifecycle, packet routing with dedup, identity confirmation, unknown HGI discovery, broker disconnect, outbound publishing, and child lookup.
- [x] Full `ramses_rf` test suite passes (3019 passed, 9 skipped).
- [x] Ruff check clean.
- [x] Mypy strict clean.
- [ ] CI passes.

---

## Phase 1 Release Gate Checklist (issue 1119)

### Release gate
- [x] Full `ramses_rf`, `ramses_cc`, `ramses_extras` suites pass (3037 + 1724 + extras)
- [x] Complete `ha_sim_test` recipe set (449 passed, 2 parallel-load timeouts — both pass alone)
- [x] Physical dual-MQTT results recorded (dedup: 62 RX → 38 dispatched, RSSI routing, failover)
- [x] MQTT broker restart and LWT offline/recovery verified (both HGIs offline→online, ~150ms)
- [x] Selected-child local echo and cross-dongle over-air copy (both arrival orders)
- [x] Cold-start targets use first eligible child in stable config order, never multicast
- [x] Source intent, selected-child source ID, canonical final-wire QoS echo matching
- [x] QoS retry that changes child replaces pending final command/fingerprint
- [x] Per-HGI firmware-management commands (`!V`) isolated from RF routing
- [x] HA-native MQTT path drives pool correctly (no direct paho inside HA)
- [x] `paho-mqtt>=2.1.0` declared in `ramses_rf` pyproject.toml
- [x] `serialx>=1.8.2` reconciled across `ramses_rf`, `ramses_cc`, HA container baseline
- [ ] CI workflow: no regressions (blocked until `ramses_rf` publishes pool modules)
- [x] Diagnostics contain no credentials or secrets (MQTT URLs masked in config flow)
- [x] Serial and Zigbee transport types gated in config flow with "(not yet supported)"

### Definition of done
1. [x] One logical transport, one deduplicated inbound stream with HGI provenance
2. [x] Child state in `PoolChild` dataclass (no parallel arrays)
3. [x] QoS prepares exactly one eligible child from immutable DTO before serialization
4. [x] Intentional sources preserved (`SourcePolicy.PRESERVE`/`SELECTED`), HGI80/evofw3 covered
5. [x] QoS matches canonical fingerprint of final wire command
6. [x] Conservative retry rules (proven-not-submitted, ambiguous, confirmed-echo, timeout)
7. [x] HA-native MQTT adapter drives pool via `homeassistant.components.mqtt`; no paho in HA
8. [x] Schema ownership is sole MQTT authorization authority; unknown wildcard IDs cannot mutate pool
9. [x] Single-USB and single-HA-MQTT behavior remains compatible
10. [x] Full suites, `ha_sim_test`, diagnostics review, physical dual-MQTT evidence pass
11. [x] Dependencies declared explicitly (`paho-mqtt>=2.1.0`, `serialx>=1.8.2` in pyproject.toml); [x] serialx reconciled with HA container baseline; [ ] no CI regressions (blocked by `ramses_rf` publish)
12. [x] Serial and Zigbee gated with "(not yet supported)" and `TODO:` remarks

### Remaining blocker
`ramses_rf` must publish a new PyPI version with pool modules (`callbacks.py`, `mqtt_pool.py`, `pooled.py`). `ramses_cc` CI will fail with `ModuleNotFoundError` until then. This is the only remaining blocker — all code is complete and live-verified.