### PR TITLE
fix: `ReadProtocol.resume_writing()` should not raise

### DIFF
--- a/src/ramses_tx/protocol/core.py
+++ b/src/ramses_tx/protocol/core.py
@@ -105,12 +105,15 @@ class ReadProtocol(_DeviceIdFilterMixin):
         super().connection_made(transport)
 
     def resume_writing(self) -> None:
-        """Raise an exception as the Protocol cannot send Commands.
+        """No-op for read-only protocols.
 
-        :raises NotImplementedError: Always raised as ReadProtocol is
-            read-only.
+        ``asyncio`` calls this when the transport's write buffer drains.
+        Read-only protocols (eavesdrop/listen mode) never write, but the
+        transport may still call this during connection setup. Silently
+        ignore rather than raising — the exception broke CLI listen mode
+        over MQTT.
         """
-        raise NotImplementedError(f"{self}: The chosen Protocol is Read-Only")
+        _LOGGER.debug("%s: resume_writing (read-only, ignoring)", self)
 
     async def send_cmd(
         self,


### PR DESCRIPTION
## Summary

- `ReadProtocol.resume_writing()` raised `NotImplementedError` whenever asyncio called it during transport connection setup.
- This broke CLI listen/eavesdrop mode over MQTT:

  ```
  Exception in callback ReadProtocol.resume_writing()
  NotImplementedError: <ReadProtocol ...>: The chosen Protocol is Read-Only
  ```

- Read-only protocols never write, but the transport may still invoke `resume_writing()` during connection setup (e.g. MQTT broker connect). The method is now a no-op with a debug log instead of raising.

## Verification

- `client -e listen 'mqtt://...'` now connects to the broker and receives packets without exception.
- Full test suite: `2906 passed, 9 skipped`.

#### Test plan

- [x] CLI listen mode over MQTT connects without exception
- [x] CLI listen mode receives packets from the broker
- [x] `pytest tests/` passes (2906 passed, 9 skipped)
- [x] Pre-commit hooks pass (ruff, codespell, etc.)