### PR TITLE
fix: _classify VC pair must only classify the sender, not the receiver

### DIFF
--- a/src/ramses_rf/discovery_scan.py
+++ b/src/ramses_rf/discovery_scan.py
@@ -1381,12 +1381,20 @@ def _classify(
     #    For ambiguous HVAC prefixes (e.g. 37:), only accept VC pairs that
     #    map to a type valid for that prefix (e.g. 31D9 I→FAN is rejected
     #    for 37: because FAN is 32: only).
-    vc_key = (verb, code)
-    if vc_key in _VC_TO_TYPE:
-        vc_type = _VC_TO_TYPE[vc_key]
-        valid_types = _AMBIGUOUS_HVAC_PREFIX_TYPES.get(prefix)
-        if valid_types is None or vc_type in valid_types:
-            return vc_type
+    #
+    #    IMPORTANT: the VC pair classifies the SENDER, not the receiver.
+    #    When a FAN (32:) sends I 31D9 to a REM/DIS (37:), the (I, 31D9)
+    #    pair tells us the sender is a FAN — it says nothing about the
+    #    receiver.  Without this is_source guard, the destination 37:
+    #    device would be incorrectly classified as FAN just because it
+    #    received a packet from a FAN.
+    if is_source:
+        vc_key = (verb, code)
+        if vc_key in _VC_TO_TYPE:
+            vc_type = _VC_TO_TYPE[vc_key]
+            valid_types = _AMBIGUOUS_HVAC_PREFIX_TYPES.get(prefix)
+            if valid_types is None or vc_type in valid_types:
+                return vc_type
 
     # 4. Check accumulated codes if we have a device
     if device and is_source:

--- a/tests/tests_rf/test_discovery_scan.py
+++ b/tests/tests_rf/test_discovery_scan.py
@@ -563,14 +563,31 @@ class TestClassify:
         result = _classify("37:154519", Code._313F, Verb.RQ, is_source=True)
         assert result == DevType.REM
 
-    def test_37_31d9_is_fan(self) -> None:
-        """37: sending 31D9 I should be FAN — some FANs use 37: prefix.
+    def test_37_31d9_is_fan_as_source(self) -> None:
+        """37: sending 31D9 I as source should be FAN — some FANs use 37: prefix.
 
         31D9 I maps to FAN in HVAC_KLASS_BY_VC_PAIR, and 37: is ambiguous
         (FAN/REM/CO2/HUM/DIS) so FAN is a valid type for 37:.
         """
         result = _classify("37:154519", Code._31D9, Verb.I_, is_source=True)
         assert result == DevType.FAN
+
+    def test_37_31d9_as_destination_is_not_fan(self) -> None:
+        """37: receiving 31D9 I should NOT be FAN — VC pair classifies sender.
+
+        When a FAN (32:) sends I 31D9 to a REM/DIS (37:), the (I, 31D9)
+        pair tells us the sender is a FAN.  The receiver should fall back
+        to the prefix default (REM), not inherit the sender's classification.
+        """
+        result = _classify("37:169161", Code._31D9, Verb.I_, is_source=False)
+        assert result == DevType.REM
+
+    def test_37_31da_as_destination_is_not_fan(self) -> None:
+        """37: receiving 31DA I/RP should NOT be FAN — same direction logic."""
+        result = _classify("37:169161", Code._31DA, Verb.I_, is_source=False)
+        assert result == DevType.REM
+        result = _classify("37:169161", Code._31DA, Verb.RP, is_source=False)
+        assert result == DevType.REM
 
     def test_32_31d9_is_fan(self) -> None:
         """32: sending 31D9 I should be FAN (unambiguous prefix)."""


### PR DESCRIPTION
## Summary

When a FAN (32:) sends `I 31D9` to a DIS/REM (37:), the `(I, 31D9)` VC pair
tells us the **sender** is a FAN. The receiver should not inherit that
classification — but `_classify`'s step 3 checked the VC pair regardless of
`is_source`, so the destination 37: device was incorrectly classified as FAN.

This caused Orcon RF15 Display devices (37:) to be discovered as FAN instead
of DIS/REM when they received `I 31D9`/`I 31DA` packets from the FAN.

Fix: guard step 3 with `is_source=True`. When the device is the destination,
skip the VC pair check and fall to the prefix default (REM for 37:).

## Verification

- All 3053 tests pass.
- Pre-commit hooks pass (ruff, codespell, etc.).

#### Test plan

- [x] `pytest tests/` passes (3053 passed, 9 skipped)
- [x] ruff check + format pass
- [x] Manual: 37:169161 discovered as REM/DIS, not FAN