### PR TITLE
fix: DhwZone heat_demand/relay_demand fallback to hotwater_valve BDR (issue 1130)

### DIFF
--- a/src/ramses_rf/systems/zones.py
+++ b/src/ramses_rf/systems/zones.py
@@ -388,12 +388,39 @@ class DhwZone(ZoneSchedule):  # CS92A
         return self.temp_state.temperature
 
     async def heat_demand(self) -> float | None:  # 3150
-        """Return the DHW heat demand percentage (0.0 to 1.0)."""
-        return self.demand_state.heat_demand
+        """Return the DHW heat demand percentage (0.0 to 1.0).
+
+        The controller does not broadcast 3150|FA for DHW, so
+        ``demand_state.heat_demand`` is typically None.  Fall back to
+        the hotwater_valve BDR's relay_demand, which is the closest
+        proxy for DHW heat demand (ramses-rf/ramses_cc issue 1130).
+
+        :returns: Heat demand as a fraction (0.0 to 1.0), or None.
+        :rtype: float | None
+        """
+        if self.demand_state.heat_demand is not None:
+            return self.demand_state.heat_demand
+        if self._dhw_valve is not None:
+            return await self._dhw_valve.relay_demand()
+        return None
 
     async def relay_demand(self) -> float | None:  # 0008
-        """Return the DHW relay demand percentage (0.0 to 1.0)."""
-        return self.demand_state.relay_demand
+        """Return the DHW relay demand percentage (0.0 to 1.0).
+
+        The controller's 0008|FA packet usually carries 0% — the real
+        DHW relay state is tracked by the hotwater_valve BDR via its
+        3EF0 actuator state.  Fall back to the BDR's relay_demand when
+        ``demand_state.relay_demand`` is not populated
+        (ramses-rf/ramses_cc issue 1130).
+
+        :returns: Relay demand as a fraction (0.0 to 1.0), or None.
+        :rtype: float | None
+        """
+        if self.demand_state.relay_demand is not None:
+            return self.demand_state.relay_demand
+        if self._dhw_valve is not None:
+            return await self._dhw_valve.relay_demand()
+        return None
 
     async def relay_failsafe(self) -> float | None:  # 0009
         """Return DHW relay failsafe demand percentage (0.0 to 1.0)."""

--- a/tests/tests_rf/data_driven/test_dhw_zone_temp_issue_843.py
+++ b/tests/tests_rf/data_driven/test_dhw_zone_temp_issue_843.py
@@ -103,10 +103,14 @@ async def test_dhw_zone_relay_demand_and_failsafe_hydrated() -> None:
             f"DHW relay_failsafe expected False: {relay_failsafe!r}"
         )
 
-        # heat_demand must NOT be wrongly set from relay_demand (old bug)
+        # heat_demand falls back to the hotwater_valve BDR's relay_demand
+        # when demand_state.heat_demand is None (no 3150|FA packets for
+        # DHW on real systems).  The BDR 13:109598 has relay_demand=0.0
+        # (relay off), so heat_demand should be 0.0, not None.
+        # See: ramses-rf/ramses_cc issue 1130
         heat_demand = await tcs.dhw.heat_demand()
-        assert heat_demand is None, (
-            f"DHW heat_demand wrongly set from relay_demand: {heat_demand!r}"
+        assert heat_demand == 0.0, (
+            f"DHW heat_demand expected 0.0 (BDR fallback): {heat_demand!r}"
         )
     finally:
         await gwy.stop()


### PR DESCRIPTION
## Summary

- Stored HW (DhwZone) `heat_demand` and `relay_demand` sensors were always Unknown on real systems because the controller does not broadcast 3150|FA for DHW, and 0008|FA packets carry 0% demand
- The real DHW relay state is tracked by the `hotwater_valve` BDR via its 3EF0 actuator state, which already works correctly (BDR's `relay_demand` has a 3EF0 fallback)
- Add a fallback in `DhwZone.heat_demand()` and `DhwZone.relay_demand()` to delegate to the `hotwater_valve` BDR's `relay_demand` when the DhwZone's own `demand_state` is not populated
- Updated the issue 843 test to reflect the new expected behavior (`heat_demand` returns 0.0 from BDR fallback instead of None)

See: https://github.com/ramses-rf/ramses_cc/issues/1130

#### Test plan
- [x] `pytest tests/` — 3053 passed, 9 skipped
- [x] `ruff check` and `mypy --strict` pass
- [x] ha_sim_test recipe R103 passes (5/5 checks): injects 3EF0 with modulation_level=100% on the BDR, verifies DHW `heat_demand` and `relay_demand` sensors show 100.0 via the BDR fallback