### PR TITLE
fix: await _tx_worker task on engine stop (issue 1171)

### DIFF
--- a/src/ramses_tx/engine.py
+++ b/src/ramses_tx/engine.py
@@ -5,6 +5,7 @@
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import logging
 import threading
 from collections.abc import Awaitable, Callable
@@ -265,6 +266,16 @@ class Engine:
         if self._transport:
             self._transport.close()
             await self._protocol.wait_for_connection_lost()
+
+        # Await the _tx_worker task if it was cancelled but not yet
+        # awaited.  connection_lost() cancels it synchronously, but
+        # the cancellation needs to be awaited to avoid "Task was
+        # destroyed but it is pending" warnings (issue 1171).
+        tx_task = getattr(self._protocol, "_tx_worker_task", None)
+        if tx_task is not None and not tx_task.done():
+            tx_task.cancel()
+            with contextlib.suppress(asyncio.CancelledError, Exception):
+                await tx_task
 
         return None
 

--- a/src/ramses_tx/protocol/core.py
+++ b/src/ramses_tx/protocol/core.py
@@ -347,7 +347,9 @@ class PortProtocol(_DeviceIdFilterMixin):
 
         if self._tx_worker_task and not self._tx_worker_task.done():
             self._tx_worker_task.cancel()
-            self._tx_worker_task = None
+            # NOTE: do NOT null out _tx_worker_task here — engine.stop()
+            # needs to await the cancelled task to avoid
+            # "Task was destroyed but it is pending" warnings (issue 1171).
 
         exc_val = TransportError("Connection lost") if error is None else error
 


### PR DESCRIPTION
## Summary

Fixes the `Task was destroyed but it is pending` warning reported in https://github.com/ramses-rf/ramses_cc/issues/1171.

`PortProtocol.connection_lost()` cancelled the `_tx_worker` task but nulled the reference, so `engine.stop()` couldn't await it. The cancelled task was left pending, causing HA to log:

```
Task was destroyed but it is pending! (task: <Task pending name='PortProtocol._tx_worker()' ...>)
```

Now:
- `connection_lost()` cancels the task but preserves the reference
- `engine.stop()` awaits the cancelled task after `wait_for_connection_lost()`

Companion PR: https://github.com/ramses-rf/ramses_cc/pull/1178

#### Test plan
- [x] Full ramses_rf suite — 3053 passed, 9 skipped